### PR TITLE
Fix slow Live TV preview after channel changes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         versionCode = (System.getenv("VERSION_CODE") ?: "1").toInt()
         // Keep the fallback at the latest released version, or local debug builds will see the
         // in-app updater offer them the release as an "update".
-        versionName = System.getenv("VERSION_NAME") ?: "2.0.1"
+        versionName = System.getenv("VERSION_NAME") ?: "99.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/tv/own/owntv/features/live/LiveScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/live/LiveScreen.kt
@@ -301,6 +301,9 @@ private fun LivePreviewPane(
     onMatchEpg: () -> Unit,
 ) {
     val colors = OwnTVTheme.colors
+    val videoAspect by player.videoAspect.collectAsStateWithLifecycle()
+    val playerError by player.error.collectAsStateWithLifecycle()
+    val previewLoading = showVideo && videoAspect == null && playerError == null
     if (channel == null) {
         PreviewPane(hint = "Focus a channel to see it here.")
         return
@@ -313,13 +316,17 @@ private fun LivePreviewPane(
             modifier = Modifier.fillMaxWidth().aspectRatio(16f / 9f).clip(RoundedCornerShape(12.dp)).background(colors.surfaceContainerLowest),
             contentAlignment = Alignment.Center,
         ) {
-            // Logo placeholder behind, live video on top once it starts.
             if (!channel.logoUrl.isNullOrBlank()) {
                 AsyncImage(model = channel.logoUrl, contentDescription = null, modifier = Modifier.size(120.dp))
             } else {
                 OwnTVIcon(OwnTVIcon.LIVE_TV, tint = colors.onSurfaceVariant, modifier = Modifier.size(56.dp))
             }
-            if (showVideo) tv.own.owntv.player.MpvVideoSurface(player = player, modifier = Modifier.fillMaxSize())
+            if (showVideo) {
+                tv.own.owntv.player.MpvVideoSurface(player = player, modifier = Modifier.fillMaxSize())
+            }
+            if (previewLoading) {
+                OwnTVSpinner(sizeDp = 28)
+            }
         }
         Spacer(Modifier.height(14.dp))
         Text(channel.name, style = MaterialTheme.typography.titleLarge, color = colors.onSurface)

--- a/app/src/main/java/tv/own/owntv/player/OwnTVPlayer.kt
+++ b/app/src/main/java/tv/own/owntv/player/OwnTVPlayer.kt
@@ -18,6 +18,8 @@ import kotlinx.coroutines.launch
 import tv.own.owntv.core.network.HttpClient
 import tv.own.owntv.features.settings.data.SettingsRepository
 import java.util.Locale
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 
 /** A selectable audio/subtitle track ([mpvId] is the mpv track id used for `aid`/`sid`). */
 data class TrackOption(val label: String, val mpvId: Int, val selected: Boolean)
@@ -173,6 +175,58 @@ class OwnTVPlayer(
         mpvExecutor.execute { runCatching { m.block() } }
     }
 
+    private fun markActiveFile(active: Boolean, reason: String) {
+        mpvHasActiveFile.set(active)
+    }
+
+    private fun MPVLib.incrementPendingStopCounter(reason: String): Boolean {
+        if (!mpvHasActiveFile.get()) return false
+        pendingStopEndFiles.incrementAndGet()
+        return true
+    }
+
+    private fun MPVLib.rollbackPendingStopCounter(reason: String) {
+        while (true) {
+            val current = pendingStopEndFiles.get()
+            if (current <= 0) return
+            if (pendingStopEndFiles.compareAndSet(current, current - 1)) {
+                return
+            }
+        }
+    }
+
+    private fun MPVLib.loadfileWithStopClassification(url: String, reason: String) {
+        val counted = incrementPendingStopCounter(reason)
+        try {
+            command(arrayOf("loadfile", url))
+            markActiveFile(true, reason)
+        } catch (t: Throwable) {
+            if (counted) rollbackPendingStopCounter(reason)
+            throw t
+        }
+    }
+
+    private fun MPVLib.stopWithStopClassification(reason: String) {
+        val counted = incrementPendingStopCounter(reason)
+        try {
+            command(arrayOf("stop"))
+            markActiveFile(false, reason)
+        } catch (t: Throwable) {
+            if (counted) rollbackPendingStopCounter(reason)
+            throw t
+        }
+    }
+
+    private fun consumePendingStopEndFile(): Boolean {
+        while (true) {
+            val current = pendingStopEndFiles.get()
+            if (current <= 0) return false
+            if (pendingStopEndFiles.compareAndSet(current, current - 1)) {
+                return true
+            }
+        }
+    }
+
     init {
         // Track the HDR setting; apply it live and re-apply on each load via ensureInit.
         settings.hdrEnabled.onEach { enabled ->
@@ -211,6 +265,10 @@ class OwnTVPlayer(
     // may run, or a slow provider makes the worker grind through dead loads). Volatile: written on
     // the main thread, read on the mpv-cmd worker.
     @Volatile private var loadGeneration = 0
+    // App-issued loadfile/stop commands can leave a cleanup END_FILE behind. Track those separately
+    // so mpv's event thread can classify them as STOP instead of startup failure or reconnect.
+    private val pendingStopEndFiles = AtomicInteger(0)
+    private val mpvHasActiveFile = AtomicBoolean(false)
     private var errorCheckJob: Job? = null
 
     private val _nav = MutableStateFlow(NavState(false, false))
@@ -442,7 +500,7 @@ class OwnTVPlayer(
             // Superseded by a newer load or a stop while waiting in the queue? Skip the dead load —
             // this keeps fast preview-scrolling from grinding through every channel it passed.
             if (gen != loadGeneration) return@mpvAsync
-            command(arrayOf("loadfile", url))
+            loadfileWithStopClassification(url, "replacement loadfile")
             setPropertyBoolean("pause", false)
         }
         // mpv only fires the "pause" observer on a *change*; at startup pause is already false, so seed
@@ -511,7 +569,9 @@ class OwnTVPlayer(
 
     fun stop() {
         loadGeneration++ // cancels any queued-but-not-yet-executed load
-        if (initialized) mpvAsync { command(arrayOf("stop")) }
+        expectingPlayback = false
+        errorCheckJob?.cancel()
+        if (initialized) mpvAsync { stopWithStopClassification("stop") }
         currentUrl = null
         pendingUrl = null
         _isPlaying.value = false
@@ -687,7 +747,7 @@ class OwnTVPlayer(
         expectingPlayback = false
         errorCheckJob?.cancel()
         pendingUrl = null
-        mpvAsync { command(arrayOf("stop")) }
+        mpvAsync { stopWithStopClassification("decodeGuard") }
         scope.launch {
             _isPlaying.value = false
             _buffering.value = false
@@ -733,6 +793,15 @@ class OwnTVPlayer(
     override fun event(eventId: Int) {
         when (eventId) {
             MPVLib.MpvEvent.MPV_EVENT_FILE_LOADED -> {
+                val pendingStops = pendingStopEndFiles.getAndSet(0)
+                if (pendingStops > 0) {
+                    android.util.Log.w(
+                        TAG,
+                        "FILE_LOADED observed with pendingStopEndFiles=$pendingStops generation=$loadGeneration " +
+                            "live=$isLiveContent; resetting counter",
+                    )
+                }
+                markActiveFile(true, "file loaded")
                 // The new file opened successfully — cancel any pending error and clear a stale one.
                 // This callback runs on mpv's event thread (not main), so sync reads are safe here.
                 expectingPlayback = false
@@ -794,13 +863,19 @@ class OwnTVPlayer(
                     }
                 }
             }
-            // A file ended. This also fires for the *previous* item when we load a new one (next/prev),
-            // so don't error immediately — wait briefly; if the new file loads, FILE_LOADED cancels this.
+            // mpv's Kotlin wrapper does not expose mpv_event_end_file.reason, so classify the cases we
+            // know the app caused (replacement loadfile, manual stop, decode guard) before treating an
+            // END_FILE as a possible playback failure.
             MPVLib.MpvEvent.MPV_EVENT_END_FILE -> {
+                if (consumePendingStopEndFile()) return
+                markActiveFile(false, "end file")
                 if (expectingPlayback) {
                     val gen = loadGeneration
                     errorCheckJob?.cancel()
                     errorCheckJob = scope.launch {
+                        // Unclassified END_FILE is not always a final failure: slow or flaky live
+                        // streams can still report FILE_LOADED shortly after. Give mpv a short grace
+                        // window; FILE_LOADED clears expectingPlayback/cancels this path.
                         delay(1500)
                         if (!expectingPlayback || gen != loadGeneration) return@launch
                         // No internet → don't burn the retry budget on a dead connection; surface the


### PR DESCRIPTION
<!-- Thanks for contributing to OwnTV! Please fill this in so it's easy to review. -->

  ## What does this PR do?
  <!-- A short summary of the change. -->

  Improves Live TV preview/player startup behavior when switching channels.

  Technical changes:

  - Adds app-side classification for mpv `END_FILE` events caused by OwnTV itself.
  - Tracks whether mpv currently has an active file or active open attempt.
  - Tracks app-issued stop/replacement operations with a pending-stop counter.
  - Wraps replacement `loadfile` calls so the old stream's cleanup `END_FILE` can be classified as an intentional stop.
  - Wraps app-issued `stop` calls, including manual stop and decode-guard stop, so their resulting `END_FILE` events do not enter playback-failure handling.
  - Consumes classified stop `END_FILE` events before startup retry, fallback, error HUD, or live reconnect logic runs.
  - Resets stale pending-stop state on `FILE_LOADED` so a later real failure is not accidentally swallowed.
  - Documents why this app-side classification exists: the current Kotlin mpv wrapper does not expose `mpv_event_end_file.reason`.

  Existing recovery behavior is preserved for unclassified failures:

  - real startup retry,
  - `.ts` to `.m3u8` fallback,
  - decoder retry/software fallback,
  - live reconnect,
  - final playback error HUD.

  ## Why?
  <!-- The problem it solves, or the feature it adds. Link any related issue, e.g. "Closes #12". -->

  This fixes Live TV channel switching feeling slower or more broken than it actually is.

  When users move between channels in the Live TV list, preview playback could take much longer to appear because OwnTV sometimes treated normal cleanup from the previous stream as a failure of the newly selected
  stream. That could send playback through unnecessary retries, retry backoffs, and sometimes an unnecessary `.m3u8` fallback even when the `.ts` stream was fine.

  The preview pane also did not clearly show that playback was still starting, so slow preview startup could look like a blank/broken preview.

  This PR also fixes a related fullscreen symptom where the player could briefly show a false "Couldn't play this stream" error even though the stream continued loading and started playing a few seconds later.

  In short: normal channel switches and intentional stops should not look like playback failures to the user, and preview startup should show a loading state while the stream is opening.

 Also added a loading indicator to the Live preview pane while preview playback is starting.

  ## How was it tested?
  <!-- e.g. ran on an Android TV emulator (API XX), played a movie, checked EPG, etc. -->

  Tested against Android TV logcat captures from TCL Android TV playback sessions. 

  Verified from logs:
  
  ```text
  - Channel switching emits replacement `loadfile`.
  - The old stream's cleanup `END_FILE` is classified as an intentional stop.
  - Classified stop events return before retry, fallback, error, or reconnect logic.
  - `FILE_LOADED` still clears stale errors and marks playback as active.
  - Preview-to-fullscreen still reuses the active stream connection, ensure playing reusing existing stream; unmuting
  - Decode-guard stop is also classified as an intentional stop and does not auto-retry.
  - Real startup failure handling remains available for unclassified END_FILE.
  - The Live preview pane shows a spinner while preview video is requested but video dimensions have not arrived yet.
  
   ```


  ## Checklist

  - [x] Builds locally (./gradlew assembleDebug) and CI is green
  - [x] Tested on a TCL Android TV (D-pad navigation works)
  - [x] Keeps OwnTV player-only (no bundled channels/content)
  - [x] Commit messages are clear (they become the release notes)