### PR TITLE
Add span (range) hide/show for categories in Customize

### DIFF
--- a/app/src/main/java/tv/own/owntv/core/customize/CustomizationStore.kt
+++ b/app/src/main/java/tv/own/owntv/core/customize/CustomizationStore.kt
@@ -75,6 +75,12 @@ class CustomizationStore(private val context: Context) {
             it.copy(hiddenCategories = if (hidden) it.hiddenCategories + catKey else it.hiddenCategories - catKey)
         }
 
+    /** Hide/show a whole span of categories in one atomic edit (range select in Customize). */
+    suspend fun setCategoriesHidden(profileId: Long, type: MediaType, catKeys: Collection<String>, hidden: Boolean) =
+        update(profileId, type) {
+            it.copy(hiddenCategories = if (hidden) it.hiddenCategories + catKeys else it.hiddenCategories - catKeys)
+        }
+
     suspend fun setItemHidden(profileId: Long, type: MediaType, itemKey: String, label: String, hidden: Boolean) =
         update(profileId, type) {
             it.copy(hiddenItems = if (hidden) it.hiddenItems + (itemKey to label) else it.hiddenItems - itemKey)

--- a/app/src/main/java/tv/own/owntv/features/customize/CustomizeScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/customize/CustomizeScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.focusGroup
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
@@ -55,12 +56,16 @@ fun CustomizeScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
     val section by vm.section.collectAsStateWithLifecycle()
     val rows by vm.rows.collectAsStateWithLifecycle()
     val hiddenChannels by vm.hiddenChannels.collectAsStateWithLifecycle()
+    val rangeAnchorKey by vm.rangeAnchorKey.collectAsStateWithLifecycle()
     val colors = OwnTVTheme.colors
     var renaming by remember { mutableStateOf<CustomizeCatRow?>(null) }
+    // The category whose Hide button was clicked to close a range — opens the Show/Hide/Cancel prompt.
+    var rangeEnd by remember { mutableStateOf<CustomizeCatRow?>(null) }
     val firstFocus = remember { FocusRequester() }
     LaunchedEffect(Unit) { kotlinx.coroutines.delay(60); runCatching { firstFocus.requestFocus() } }
 
-    BackHandler { onBack() }
+    // While a span selection is in progress, Back cancels the selection instead of leaving the screen.
+    BackHandler { if (rangeAnchorKey != null) vm.cancelRange() else onBack() }
 
     Column(
         modifier = modifier
@@ -88,6 +93,27 @@ fun CustomizeScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
             SectionChip("Series", section == MediaType.SERIES) { vm.selectSection(MediaType.SERIES) }
         }
         Spacer(Modifier.height(16.dp))
+
+        if (rangeAnchorKey != null) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(colors.primaryContainer)
+                    .padding(horizontal = 16.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    "Span selection started. Press Show/Hide on the end item to select the span.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = colors.onPrimaryContainer,
+                    modifier = Modifier.weight(1f),
+                )
+                Spacer(Modifier.width(10.dp))
+                OwnTVButton("Cancel", onClick = { vm.cancelRange() }, style = OwnTVButtonStyle.SECONDARY)
+            }
+            Spacer(Modifier.height(12.dp))
+        }
 
         LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxSize()) {
             // Hidden Live channels first (channels are hidden from the Live preview pane) — kept on
@@ -140,10 +166,14 @@ fun CustomizeScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
             items(rows, key = { it.key }) { row ->
                 CategoryRow(
                     row = row,
+                    inRangeMode = rangeAnchorKey != null,
+                    isAnchor = row.key == rangeAnchorKey,
                     onMoveUp = { vm.move(row, up = true) },
                     onMoveDown = { vm.move(row, up = false) },
                     onRename = { renaming = row },
                     onToggleHidden = { vm.setCategoryHidden(row, !row.hidden) },
+                    onHideLongPress = { vm.beginRange(row) },
+                    onPickRangeEnd = { if (row.key == rangeAnchorKey) vm.cancelRange() else rangeEnd = row },
                 )
             }
         }
@@ -157,6 +187,51 @@ fun CustomizeScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
             onConfirm = { vm.renameCategory(row, it.takeIf { t -> t.isNotBlank() }); renaming = null },
             onDismiss = { renaming = null },
         )
+    }
+
+    rangeEnd?.let { row ->
+        val count = vm.keysInRange(row)?.size ?: 0
+        RangeHideDialog(
+            count = count,
+            onHide = { vm.applyRange(row, hidden = true); rangeEnd = null },
+            onShow = { vm.applyRange(row, hidden = false); rangeEnd = null },
+            onDismiss = { vm.cancelRange(); rangeEnd = null },
+        )
+    }
+}
+
+/**
+ * Confirms a range select: hide or show every category in the chosen span (or cancel). [count] is
+ * the number of categories the span covers, inclusive.
+ */
+@Composable
+private fun RangeHideDialog(count: Int, onHide: () -> Unit, onShow: () -> Unit, onDismiss: () -> Unit) {
+    val colors = OwnTVTheme.colors
+    val hideFocus = remember { FocusRequester() }
+    LaunchedEffect(Unit) { runCatching { hideFocus.requestFocus() } }
+    BackHandler { onDismiss() }
+    Box(
+        modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.75f)).focusGroup(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            Modifier.width(480.dp).clip(RoundedCornerShape(20.dp)).background(colors.surfaceContainerHigh).padding(28.dp),
+        ) {
+            Text("Hide or show categories", style = MaterialTheme.typography.titleLarge, color = colors.onSurface)
+            Spacer(Modifier.height(6.dp))
+            Text(
+                "$count ${if (count == 1) "category" else "categories"} selected.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = colors.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(22.dp))
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                OwnTVButton("Cancel", onClick = onDismiss, style = OwnTVButtonStyle.SECONDARY)
+                Spacer(Modifier.weight(1f))
+                OwnTVButton("Show", onClick = onShow, style = OwnTVButtonStyle.SECONDARY)
+                OwnTVButton("Hide", onClick = onHide, modifier = Modifier.focusRequester(hideFocus))
+            }
+        }
     }
 }
 
@@ -188,14 +263,23 @@ private fun SectionChip(label: String, selected: Boolean, modifier: Modifier = M
 @Composable
 private fun CategoryRow(
     row: CustomizeCatRow,
+    inRangeMode: Boolean,
+    isAnchor: Boolean,
     onMoveUp: () -> Unit,
     onMoveDown: () -> Unit,
     onRename: () -> Unit,
     onToggleHidden: () -> Unit,
+    onHideLongPress: () -> Unit,
+    onPickRangeEnd: () -> Unit,
 ) {
     val colors = OwnTVTheme.colors
     Row(
-        modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(12.dp)).background(colors.surfaceContainerHigh).padding(horizontal = 16.dp, vertical = 8.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            // Tint the anchor while a range is in progress so its starting point is obvious.
+            .background(if (isAnchor) colors.primaryContainer else colors.surfaceContainerHigh)
+            .padding(horizontal = 16.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(Modifier.weight(1f)) {
@@ -229,6 +313,13 @@ private fun CategoryRow(
         Spacer(Modifier.width(6.dp))
         OwnTVButton("Rename", onClick = onRename, style = OwnTVButtonStyle.SECONDARY)
         Spacer(Modifier.width(6.dp))
-        OwnTVButton(if (row.hidden) "Show" else "Hide", onClick = onToggleHidden, style = OwnTVButtonStyle.SECONDARY)
+        OwnTVButton(
+            label = if (row.hidden) "Show" else "Hide",
+            // Long-press anchors a range; a normal press picks the span end while a range is active,
+            // otherwise it toggles just this category.
+            onClick = { if (inRangeMode) onPickRangeEnd() else onToggleHidden() },
+            onLongClick = onHideLongPress,
+            style = OwnTVButtonStyle.SECONDARY,
+        )
     }
 }

--- a/app/src/main/java/tv/own/owntv/features/customize/CustomizeViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/customize/CustomizeViewModel.kt
@@ -59,8 +59,15 @@ class CustomizeViewModel(
     private val _section = MutableStateFlow(MediaType.LIVE)
     val section: StateFlow<MediaType> = _section.asStateFlow()
 
+    // Range select: key of the anchor category (first long-pressed Hide button), or null when no
+    // range is in progress. The UI highlights the anchor and shows a hint while this is set.
+    private val _rangeAnchorKey = MutableStateFlow<String?>(null)
+    val rangeAnchorKey: StateFlow<String?> = _rangeAnchorKey.asStateFlow()
+
     fun selectSection(type: MediaType) {
         _section.value = type
+        // A pending range belongs to the section it was started in — switching sections cancels it.
+        _rangeAnchorKey.value = null
     }
 
     /** Categories of the selected section, in their customized order, including hidden ones. */
@@ -127,5 +134,40 @@ class CustomizeViewModel(
         viewModelScope.launch {
             customize.setItemHidden(ctx.value.profileId, MediaType.LIVE, key, "", false)
         }
+    }
+
+    // --- range (span) select: long-press a Hide button to anchor, click another to set the end ---
+
+    /** Begins a range at [row] (its Hide button was long-pressed). */
+    fun beginRange(row: CustomizeCatRow) {
+        _rangeAnchorKey.value = row.key
+    }
+
+    fun cancelRange() {
+        _rangeAnchorKey.value = null
+    }
+
+    /**
+     * Keys of every category between the current anchor and [endRow], inclusive, in displayed
+     * order — independent of which end was picked first. Null if there is no valid anchor.
+     */
+    fun keysInRange(endRow: CustomizeCatRow): List<String>? {
+        val anchorKey = _rangeAnchorKey.value ?: return null
+        val current = rows.value
+        val anchorIndex = current.indexOfFirst { it.key == anchorKey }
+        val endIndex = current.indexOfFirst { it.key == endRow.key }
+        if (anchorIndex < 0 || endIndex < 0) return null
+        val lo = minOf(anchorIndex, endIndex)
+        val hi = maxOf(anchorIndex, endIndex)
+        return current.subList(lo, hi + 1).map { it.key }
+    }
+
+    /** Applies hide/show to the whole span ending at [endRow], then clears the range. */
+    fun applyRange(endRow: CustomizeCatRow, hidden: Boolean) {
+        val keys = keysInRange(endRow) ?: return
+        viewModelScope.launch {
+            customize.setCategoriesHidden(ctx.value.profileId, _section.value, keys, hidden)
+        }
+        _rangeAnchorKey.value = null
     }
 }

--- a/app/src/main/java/tv/own/owntv/ui/components/OwnTVButton.kt
+++ b/app/src/main/java/tv/own/owntv/ui/components/OwnTVButton.kt
@@ -28,6 +28,7 @@ fun OwnTVButton(
     style: OwnTVButtonStyle = OwnTVButtonStyle.PRIMARY,
     icon: OwnTVIcon? = null,
     enabled: Boolean = true,
+    onLongClick: (() -> Unit)? = null,
 ) {
     val colors = OwnTVTheme.colors
     val shape = RoundedCornerShape(50) // M3 full/pill button
@@ -36,6 +37,7 @@ fun OwnTVButton(
 
     FocusableSurface(
         onClick = onClick,
+        onLongClick = onLongClick,
         modifier = modifier,
         enabled = enabled,
         shape = shape,


### PR DESCRIPTION
## What does this PR do?
Adds a shift-click-style **span (range) select** to Settings → Customize so you can hide or show a whole run of categories at once instead of one button at a time.

## Why?
Providers often ship hundreds of categories; hiding them individually is tedious. This is remote-friendly for Android TV: long-press a category's Show/Hide button to start a span at that group, then a normal Show/Hide press on another group selects the inclusive range and opens a Hide / Show / Cancel prompt. The anchor row is tinted, a banner explains the next step, and Back cancels an in-progress selection. Works in Live TV, Movies and Series; the span is persisted in one atomic CustomizationStore edit so it survives re-syncs.

## How was it tested?
Ran on an Android TV emulator (Television 1080p, API 36): started a span via long-press, selected an end item, confirmed Hide and Show both apply across the range, verified Back cancels the selection, and that a normal short press still toggles a single category. `./gradlew assembleDebug` and `./gradlew testDebugUnitTest` pass locally.

## Checklist
- [x] Builds locally (`./gradlew assembleDebug`) and CI is green
- [x] Tested on an Android TV emulator or device (D-pad navigation works)
- [x] Keeps OwnTV player-only (no bundled channels/content)
- [x] Commit messages are clear (they become the release notes)