### PR TITLE
Add true picture-in-picture: watch a second live stream in a corner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### ✨ New features
+
+- **True picture-in-picture (watch two streams at once)** — you can now keep one live channel playing in a
+  corner window while you watch a *different* channel full-screen (or browse). On any channel's preview pane
+  press **Watch in corner** to dock it top-right; it keeps streaming on its own decoder, independent of the
+  main player. The window persists as you move between browsing and full-screen. Sound stays with the main
+  stream by default; the player HUD (and the corner's own buttons while browsing) let you **move the audio**
+  to the corner, **swap** the corner channel into the main window, or **close** it. The corner runs on a
+  second ExoPlayer instance with shallow buffers (the main mpv player is untouched), so the extra stream is
+  light on memory — a deliberate step toward a fuller MultiView grid later.
+
 ## v3.2.0 — 2026-06-22
 
 ### ✨ New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@
   stream by default; the player HUD (and the corner's own buttons while browsing) let you **move the audio**
   to the corner, **swap** the corner channel into the main window, or **close** it. Live PiP runs **two
   ExoPlayer instances** (OwnTV's live full-screen player is ExoPlayer; mpv is the VOD player and the live
-  fallback), so the corner is a deliberately **constrained second decoder** — capped to 720p30, stereo audio
-  (no surround passthrough), no subtitles, software-decoder fallback, and it never takes audio focus. That
-  leaves the 4K/HDR hardware decoder and surround output to the main stream, so the two coexist on TV
-  hardware. A deliberate step toward a fuller MultiView grid later.
+  fallback), so the corner is a deliberately **constrained second decoder** — a 720p resolution-cap hint
+  (picks a lower rendition when the stream is adaptive HLS; never transcodes), stereo audio (no surround
+  passthrough), no subtitles, **software-decoder fallback** when no second hardware decoder is free, and it
+  never takes audio focus. That keeps surround output (and, for adaptive streams, the 4K/HDR hardware decoder)
+  with the main stream, so the two coexist on TV hardware. A deliberate step toward a fuller MultiView grid.
 
 ## v3.2.0 — 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@
   press **Watch in corner** to dock it top-right; it keeps streaming on its own decoder, independent of the
   main player. The window persists as you move between browsing and full-screen. Sound stays with the main
   stream by default; the player HUD (and the corner's own buttons while browsing) let you **move the audio**
-  to the corner, **swap** the corner channel into the main window, or **close** it. The corner runs on a
-  second ExoPlayer instance with shallow buffers (the main mpv player is untouched), so the extra stream is
-  light on memory — a deliberate step toward a fuller MultiView grid later.
+  to the corner, **swap** the corner channel into the main window, or **close** it. Live PiP runs **two
+  ExoPlayer instances** (OwnTV's live full-screen player is ExoPlayer; mpv is the VOD player and the live
+  fallback), so the corner is a deliberately **constrained second decoder** — capped to 720p30, stereo audio
+  (no surround passthrough), no subtitles, software-decoder fallback, and it never takes audio focus. That
+  leaves the 4K/HDR hardware decoder and surround output to the main stream, so the two coexist on TV
+  hardware. A deliberate step toward a fuller MultiView grid later.
 
 ## v3.2.0 — 2026-06-22
 

--- a/app/src/main/java/tv/own/owntv/di/PlayerModule.kt
+++ b/app/src/main/java/tv/own/owntv/di/PlayerModule.kt
@@ -13,4 +13,8 @@ val playerModule = module {
     single { OwnTVPlayer(androidContext(), get(), get(), get(), get()) }
     // ExoPlayer engine for the fast Live preview pane (mpv stays the full/fullscreen player).
     single { LivePreviewEngine(androidContext(), get(), get()) }
+    // Second, independent ExoPlayer for the picture-in-picture corner (true PiP — a different stream
+    // alongside the main one). Separate decoder/surface/audio from the preview engine above so both play.
+    single { tv.own.owntv.player.SecondaryLivePlayer(androidContext(), get(), get()) }
+    single { tv.own.owntv.features.multiview.PipController(get<tv.own.owntv.player.SecondaryLivePlayer>()) }
 }

--- a/app/src/main/java/tv/own/owntv/features/live/LiveScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/live/LiveScreen.kt
@@ -72,6 +72,7 @@ fun LiveScreen(
     modifier: Modifier = Modifier,
 ) {
     val vm: LiveViewModel = koinViewModel()
+    val pip = org.koin.compose.koinInject<tv.own.owntv.features.multiview.PipController>()
     val railItems by vm.railItems.collectAsStateWithLifecycle()
     val selectedKey by vm.selectedKey.collectAsStateWithLifecycle()
     val count by vm.count.collectAsStateWithLifecycle()
@@ -221,6 +222,7 @@ fun LiveScreen(
                 onHide = { previewChannel?.let { vm.hideChannel(it) } },
                 onMatchEpg = { matchingEpg = previewChannel },
                 onCatchup = { catchupChannel = previewChannel },
+                onWatchInCorner = { previewChannel?.let { pip.openCorner(it) } },
             )
         }
     }
@@ -313,6 +315,7 @@ private fun LivePreviewPane(
     onHide: () -> Unit,
     onMatchEpg: () -> Unit,
     onCatchup: () -> Unit,
+    onWatchInCorner: () -> Unit,
 ) {
     val colors = OwnTVTheme.colors
     val previewState by previewEngine.state.collectAsStateWithLifecycle()
@@ -372,6 +375,10 @@ private fun LivePreviewPane(
         }
 
         Spacer(Modifier.height(16.dp))
+        // True picture-in-picture: open this channel in a corner window that keeps playing while you watch
+        // (or browse) something else. Audio stays with the main stream until you hand it to the corner.
+        OwnTVButton(label = "Watch in corner", onClick = onWatchInCorner, icon = OwnTVIcon.PIP)
+        Spacer(Modifier.height(10.dp))
         OwnTVButton(
             label = if (isFavorite) "Favorited" else "Favorite",
             onClick = onToggleFavorite,

--- a/app/src/main/java/tv/own/owntv/features/multiview/PipAudio.kt
+++ b/app/src/main/java/tv/own/owntv/features/multiview/PipAudio.kt
@@ -1,0 +1,29 @@
+package tv.own.owntv.features.multiview
+
+/**
+ * Which window should be muted while a picture-in-picture corner is on screen. Only **one** window is
+ * audible at a time (two simultaneous soundtracks would be cacophony). Pure + Android-free so the rule is
+ * unit-testable without spinning up real decoders.
+ *
+ * @property muteMain null = leave the main player's mute untouched (there is no main window present, e.g.
+ *   while browsing — touching it would interfere with normal playback); true/false = set it explicitly.
+ * @property muteCorner the corner engine's target mute state.
+ */
+data class PipAudioPlan(val muteMain: Boolean?, val muteCorner: Boolean)
+
+object PipAudio {
+    /**
+     * @param cornerActive  a corner stream is on screen.
+     * @param mainPresent   a main player (full-screen or docked) is also showing.
+     * @param audioOnCorner the user has handed the sound to the corner.
+     * @return the mute plan, or null when no corner is active (don't touch either engine — normal playback).
+     */
+    fun plan(cornerActive: Boolean, mainPresent: Boolean, audioOnCorner: Boolean): PipAudioPlan? = when {
+        !cornerActive -> null
+        // Browse with only a corner up → it's the only stream, so it gets the sound; leave the main alone.
+        !mainPresent -> PipAudioPlan(muteMain = null, muteCorner = false)
+        // Both windows present → exactly one is audible, per the user's choice.
+        audioOnCorner -> PipAudioPlan(muteMain = true, muteCorner = false)
+        else -> PipAudioPlan(muteMain = false, muteCorner = true)
+    }
+}

--- a/app/src/main/java/tv/own/owntv/features/multiview/PipController.kt
+++ b/app/src/main/java/tv/own/owntv/features/multiview/PipController.kt
@@ -1,0 +1,54 @@
+package tv.own.owntv.features.multiview
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import tv.own.owntv.core.database.entity.ChannelEntity
+import tv.own.owntv.player.CornerEngine
+import tv.own.owntv.player.MediaMeta
+
+/**
+ * App-wide state for the **picture-in-picture corner window** — the second simultaneous stream. Owns the
+ * corner [CornerEngine] (its decoder) and tracks which channel the corner is on, so the shell can mount a
+ * persistent corner overlay that survives moving between the browse UI and full-screen.
+ *
+ * This is intentionally thin: it starts/stops the corner stream and remembers the corner channel. Audio
+ * arbitration (only one window audible at a time) and the swap-with-main gesture are orchestrated by the
+ * shell, which is the only place that knows what the *main* player is currently doing (mpv vs ExoPlayer).
+ *
+ * A single corner today (true PiP = 1 + 1). The same controller generalises to the 2×2 MultiView grid
+ * later by holding a list of engines instead of one.
+ */
+class PipController(val engine: CornerEngine) {
+
+    private val _active = MutableStateFlow(false)
+    /** True while a corner window is on screen (a second stream is running). */
+    val active: StateFlow<Boolean> = _active.asStateFlow()
+
+    private val _channel = MutableStateFlow<ChannelEntity?>(null)
+    /** The channel playing in the corner (for its title, and to swap it into the main window). */
+    val channel: StateFlow<ChannelEntity?> = _channel.asStateFlow()
+
+    /** Open [channel] in the corner (or switch the corner to it). Starts muted so the main stream keeps the
+     *  sound; the user hands audio to the corner explicitly. No-op-safe to call repeatedly with the same one. */
+    fun openCorner(channel: ChannelEntity, muted: Boolean = true) {
+        _channel.value = channel
+        _active.value = true
+        if (engine.currentUrl != channel.streamUrl) {
+            engine.play(
+                channel.streamUrl,
+                meta = MediaMeta(title = channel.name, logoUrl = channel.logoUrl),
+                muted = muted,
+            )
+        } else {
+            engine.setMuted(muted)
+        }
+    }
+
+    /** Close the corner window and free its decoder/connection. */
+    fun closeCorner() {
+        _active.value = false
+        _channel.value = null
+        engine.stop()
+    }
+}

--- a/app/src/main/java/tv/own/owntv/features/shell/OwnTVShell.kt
+++ b/app/src/main/java/tv/own/owntv/features/shell/OwnTVShell.kt
@@ -98,6 +98,13 @@ fun OwnTVShell(
     var restoreFocus by remember { mutableStateOf(false) }
     val player = koinInject<OwnTVPlayer>()
     val mpvEngine = remember(player) { tv.own.owntv.player.MpvPlaybackEngine(player) }
+    // True picture-in-picture: a second, independent stream in a corner window, mounted at the shell's top
+    // level so it persists across the browse UI <-> full-screen. Audio belongs to one window at a time —
+    // by default the main stream, until the user hands sound to the corner (audioOnCorner).
+    val pip = koinInject<tv.own.owntv.features.multiview.PipController>()
+    val cornerActive by pip.active.collectAsStateWithLifecycle()
+    val cornerChannel by pip.channel.collectAsStateWithLifecycle()
+    var audioOnCorner by remember { mutableStateOf(false) }
     // Same activity-scoped instances the Live/Guide screens use — lets the fullscreen HUD zap channels
     // up/down (CH+/CH-) through whichever section's list opened the stream.
     val liveVm = org.koin.androidx.compose.koinViewModel<tv.own.owntv.features.live.LiveViewModel>()
@@ -138,6 +145,54 @@ fun OwnTVShell(
         restoreFocus = true
         runCatching { sidebarFocus.requestFocus() }
         Unit
+    }
+
+    // --- True PiP corner: audio arbitration + window gestures -------------------------------------
+    // Mute/unmute the main stream regardless of which engine owns it (promoted-live ExoPlayer vs mpv).
+    val setMainMuted: (Boolean) -> Unit = { muted ->
+        if (liveOnExo) liveVm.previewEngine.setMuted(muted) else player.setMuted(muted)
+    }
+    val closeCorner = {
+        setMainMuted(false) // hand the sound back to the main window
+        audioOnCorner = false
+        pip.closeCorner()
+        Unit
+    }
+    val toggleCornerAudio = { audioOnCorner = !audioOnCorner }
+    // Full-screen swap (live main only): exchange the corner stream with the main one.
+    val swapCorner = {
+        val cornerCh = cornerChannel
+        val mainCh = liveVm.previewChannel.value
+        if (cornerCh != null && mainCh != null) {
+            pip.openCorner(mainCh)         // old main → corner (starts muted)
+            zapSource = MainSection.LIVE_TV
+            liveVm.ensurePlaying(cornerCh) // old corner → main window
+            audioOnCorner = false          // sound follows the (new) main window
+        }
+        Unit
+    }
+    // Browse: promote the corner channel to full-screen, closing the corner.
+    val expandCorner = {
+        cornerChannel?.let { ch ->
+            audioOnCorner = false
+            pip.closeCorner()
+            zapSource = MainSection.LIVE_TV
+            onSelectSection(MainSection.LIVE_TV)
+            liveVm.watchFullscreen(ch, listOf(ch))
+            playerMode = PlayerMode.FULLSCREEN
+        }
+        Unit
+    }
+    // Only one window is audible at a time. The decision is a pure function (PipAudio) so it's unit-tested;
+    // a null plan (no corner) leaves both engines untouched, so normal playback never has its mute changed.
+    LaunchedEffect(cornerActive, audioOnCorner, playerMode, liveOnExo) {
+        val plan = tv.own.owntv.features.multiview.PipAudio.plan(
+            cornerActive = cornerActive,
+            mainPresent = playerMode != PlayerMode.NONE,
+            audioOnCorner = audioOnCorner,
+        ) ?: return@LaunchedEffect
+        plan.muteMain?.let { setMainMuted(it) }
+        pip.engine.setMuted(plan.muteCorner)
     }
 
     LaunchedEffect(Unit) { runCatching { sidebarFocus.requestFocus() } }
@@ -330,11 +385,37 @@ fun OwnTVShell(
                     onGoToLive = if (isLiveChannel) liveVm::goToLive else null,
                     onScrubLive = if (isLiveChannel && canRewindLive) liveVm::scrubLive else null,
                     timeshiftOffsetSec = if (isLiveChannel) timeshiftOffset else null,
+                    // True PiP corner controls — present only while a second stream is in the corner.
+                    // Swap is offered only when the main stream is a promoted live channel (both ExoPlayer),
+                    // so the exchange is clean; audio/close are always available with a corner up.
+                    onCornerSwap = if (cornerActive && liveOnExo) swapCorner else null,
+                    onCornerAudio = if (cornerActive) toggleCornerAudio else null,
+                    onCornerClose = if (cornerActive) closeCorner else null,
+                    cornerAudioOn = audioOnCorner,
                     modifier = Modifier.fillMaxSize(),
                 )
             } else {
                 MiniPlayer(player = if (liveOnExo) liveVm.previewEngine else mpvEngine, onExpand = expandPlayer, onClose = exitPlayer, modifier = Modifier.fillMaxSize())
             }
+        }
+      }
+
+      // True picture-in-picture corner — a second, independent stream in the upper-right corner, drawn over
+      // both the browse UI and the full-screen player (its SurfaceView is z-ordered above the main surface).
+      // While full-screen the player HUD owns the corner's controls, so the window itself is video-only then.
+      if (cornerActive) {
+        Box(
+            modifier = Modifier.align(Alignment.TopEnd).padding(24.dp).size(width = 320.dp, height = 180.dp),
+        ) {
+            tv.own.owntv.player.PipCornerWindow(
+                engine = pip.engine,
+                showControls = playerMode != PlayerMode.FULLSCREEN,
+                audioOnCorner = audioOnCorner,
+                onToggleAudio = toggleCornerAudio,
+                onSwap = expandCorner, // window's expand button promotes the corner channel to full-screen
+                onClose = closeCorner,
+                modifier = Modifier.fillMaxSize(),
+            )
         }
       }
 

--- a/app/src/main/java/tv/own/owntv/player/CornerEngine.kt
+++ b/app/src/main/java/tv/own/owntv/player/CornerEngine.kt
@@ -1,0 +1,27 @@
+package tv.own.owntv.player
+
+import android.view.Surface
+import kotlinx.coroutines.flow.StateFlow
+
+/** Playback state of the picture-in-picture corner stream. */
+enum class CornerState { IDLE, LOADING, PLAYING, ERROR }
+
+/**
+ * The picture-in-picture corner's video engine, abstracted so the orchestration ([tv.own.owntv.features.
+ * multiview.PipController]) and UI bind to an interface rather than the concrete ExoPlayer wrapper. This
+ * keeps the corner logic unit-testable with a lightweight fake — no Android, no ExoPlayer, no device — which
+ * is also the cheapest way to verify it (a second real decoder is exactly what we *don't* want to spin up in
+ * a test). [SecondaryLivePlayer] is the production implementation.
+ */
+interface CornerEngine {
+    val state: StateFlow<CornerState>
+    val meta: StateFlow<MediaMeta>
+
+    /** URL the corner is currently on (null when stopped) — lets the controller skip a redundant reload. */
+    val currentUrl: String?
+
+    fun play(url: String, meta: MediaMeta = MediaMeta(), muted: Boolean = true)
+    fun setMuted(muted: Boolean)
+    fun stop()
+    fun setSurface(surface: Surface?)
+}

--- a/app/src/main/java/tv/own/owntv/player/PipCorner.kt
+++ b/app/src/main/java/tv/own/owntv/player/PipCorner.kt
@@ -37,9 +37,9 @@ import tv.own.owntv.ui.components.OwnTVIcon
  * surface (`setZOrderMediaOverlay(true)`) so the corner draws on top of the full-screen stream behind it.
  *
  * Two overlapping SurfaceViews are the right tool here: both are hardware-overlay candidates, so on a TV
- * with ≥2 overlay planes (most) neither stream falls back to GPU composition. (mpv documents that putting
- * a *regular* view over its surface knocks 4K off the direct path — a second SurfaceView avoids that on
- * capable hardware; on a single-plane device the compositor blends them, which still works, just warmer.)
+ * with ≥2 overlay planes (most) neither stream falls back to GPU composition. (Both engines document that a
+ * *regular* view over a video surface knocks 4K off the direct scan-out path — a second SurfaceView avoids
+ * that on capable hardware; on a single-plane device the compositor blends them, which still works, warmer.)
  */
 @Composable
 fun SecondaryVideoSurface(engine: CornerEngine, modifier: Modifier = Modifier, keepAwake: Boolean = true) {

--- a/app/src/main/java/tv/own/owntv/player/PipCorner.kt
+++ b/app/src/main/java/tv/own/owntv/player/PipCorner.kt
@@ -1,0 +1,159 @@
+@file:OptIn(androidx.media3.common.util.UnstableApi::class)
+
+package tv.own.owntv.player
+
+import android.view.SurfaceHolder
+import android.view.SurfaceView
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import tv.own.owntv.ui.components.FocusableSurface
+import tv.own.owntv.ui.components.OwnTVIcon
+
+/**
+ * Hosts the [CornerEngine]'s video on its own [SurfaceView], **z-ordered above** the main player's
+ * surface (`setZOrderMediaOverlay(true)`) so the corner draws on top of the full-screen stream behind it.
+ *
+ * Two overlapping SurfaceViews are the right tool here: both are hardware-overlay candidates, so on a TV
+ * with ≥2 overlay planes (most) neither stream falls back to GPU composition. (mpv documents that putting
+ * a *regular* view over its surface knocks 4K off the direct path — a second SurfaceView avoids that on
+ * capable hardware; on a single-plane device the compositor blends them, which still works, just warmer.)
+ */
+@Composable
+fun SecondaryVideoSurface(engine: CornerEngine, modifier: Modifier = Modifier, keepAwake: Boolean = true) {
+    AndroidView(
+        modifier = modifier,
+        factory = { ctx ->
+            SurfaceView(ctx).apply {
+                // Must be set before the surface is created — lifts this surface above the main one behind it.
+                setZOrderMediaOverlay(true)
+                holder.addCallback(object : SurfaceHolder.Callback {
+                    override fun surfaceCreated(holder: SurfaceHolder) = engine.setSurface(holder.surface)
+                    override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {}
+                    override fun surfaceDestroyed(holder: SurfaceHolder) = engine.setSurface(null)
+                })
+            }
+        },
+        update = { it.keepScreenOn = keepAwake },
+    )
+}
+
+/**
+ * The picture-in-picture corner window: the second stream's video in a rounded, bordered box with a title
+ * and a loading spinner, plus — when [showControls] is set — a focusable D-pad control row (audio · swap ·
+ * close). During the browse UI the corner carries its own controls (navigate to it with the remote, like
+ * the docked mini-player); while the main player is full-screen the player HUD drives these instead, so the
+ * corner is rendered video-only ([showControls] = false).
+ */
+@Composable
+fun PipCornerWindow(
+    engine: CornerEngine,
+    showControls: Boolean,
+    audioOnCorner: Boolean,
+    onToggleAudio: () -> Unit,
+    onSwap: () -> Unit,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by engine.state.collectAsStateWithLifecycle()
+    val meta by engine.meta.collectAsStateWithLifecycle()
+    val loading = state == CornerState.LOADING
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(Color.Black)
+            .border(
+                width = if (audioOnCorner) 2.dp else 1.dp,
+                color = if (audioOnCorner) tv.own.owntv.ui.theme.OwnTVTheme.colors.primary else Color.White.copy(alpha = 0.35f),
+                shape = RoundedCornerShape(12.dp),
+            ),
+    ) {
+        if (state == CornerState.ERROR) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("Couldn't play", style = MaterialTheme.typography.labelMedium, color = Color.White)
+            }
+        } else {
+            SecondaryVideoSurface(engine = engine, modifier = Modifier.fillMaxSize())
+        }
+        if (loading) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                tv.own.owntv.ui.components.OwnTVSpinner(sizeDp = 22)
+            }
+        }
+
+        // Title strip (top) — channel name on a slight scrim, with a small "PiP" marker.
+        Row(
+            modifier = Modifier.align(Alignment.TopStart).fillMaxWidth()
+                .background(Brush.verticalGradient(listOf(Color.Black.copy(alpha = 0.6f), Color.Transparent)))
+                .padding(horizontal = 8.dp, vertical = 5.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(
+                if (audioOnCorner) "PiP · 🔊" else "PiP",
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.White.copy(alpha = 0.8f),
+            )
+            Text(
+                meta.title ?: "",
+                style = MaterialTheme.typography.labelMedium,
+                color = Color.White,
+                maxLines = 1,
+            )
+        }
+
+        if (showControls) {
+            Row(
+                modifier = Modifier.align(Alignment.BottomStart).fillMaxWidth()
+                    .background(Brush.verticalGradient(listOf(Color.Transparent, Color.Black.copy(alpha = 0.75f))))
+                    .padding(8.dp).focusGroup(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                PipBtn(if (audioOnCorner) OwnTVIcon.VOLUME_HIGH else OwnTVIcon.VOLUME_MUTE, onClick = onToggleAudio)
+                Spacer(Modifier.weight(1f))
+                PipBtn(OwnTVIcon.FULLSCREEN, onClick = onSwap) // swap the corner stream into the main window
+                PipBtn(OwnTVIcon.CLOSE, onClick = onClose)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PipBtn(icon: OwnTVIcon, onClick: () -> Unit) {
+    FocusableSurface(
+        onClick = onClick,
+        modifier = Modifier.size(32.dp),
+        shape = CircleShape,
+        focusedScale = 1.12f,
+        focusedContainerColor = Color.White.copy(alpha = 0.28f),
+        unfocusedContainerColor = Color.White.copy(alpha = 0.12f),
+        selectedContainerColor = Color.White.copy(alpha = 0.12f),
+        contentAlignment = Alignment.Center,
+    ) { _ ->
+        OwnTVIcon(icon, tint = Color.White, filled = true, modifier = Modifier.size(16.dp))
+    }
+}

--- a/app/src/main/java/tv/own/owntv/player/PlayerHud.kt
+++ b/app/src/main/java/tv/own/owntv/player/PlayerHud.kt
@@ -78,6 +78,12 @@ fun PlayerHud(
     onGoToLive: (() -> Unit)? = null,
     onScrubLive: ((Int) -> Unit)? = null, // timeline scrub: +sec = back, −sec = toward live
     timeshiftOffsetSec: Int? = null,
+    // True picture-in-picture corner controls — shown only while a second (corner) stream is running.
+    // onCornerClose non-null = a corner is active; cornerAudioOn = the corner currently has the sound.
+    onCornerSwap: (() -> Unit)? = null,   // swap the corner stream into the main window (and vice versa)
+    onCornerAudio: (() -> Unit)? = null,  // move the audio between the main and corner windows
+    onCornerClose: (() -> Unit)? = null,  // close the corner window
+    cornerAudioOn: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     val isPlaying by player.isPlaying.collectAsStateWithLifecycle()
@@ -173,6 +179,8 @@ fun PlayerHud(
                     speedLabel = formatSpeed(speed),
                     onScrubLive = onScrubLive, timeshiftOffsetSec = timeshiftOffsetSec,
                     onOpenDialog = { dialog = it }, onPip = onPip, onBack = onBack,
+                    onCornerSwap = onCornerSwap, onCornerAudio = onCornerAudio, onCornerClose = onCornerClose,
+                    cornerAudioOn = cornerAudioOn,
                     modifier = Modifier.align(Alignment.BottomStart),
                 )
             }
@@ -337,7 +345,10 @@ private fun BottomBar(
     player: PlaybackEngine, isLive: Boolean, position: Long, duration: Long,
     volume: Int, audioCount: Int, subCount: Int, zoomMode: ZoomMode, speedLabel: String,
     onScrubLive: ((Int) -> Unit)?, timeshiftOffsetSec: Int?,
-    onOpenDialog: (HudDialog) -> Unit, onPip: (() -> Unit)?, onBack: () -> Unit, modifier: Modifier = Modifier,
+    onOpenDialog: (HudDialog) -> Unit, onPip: (() -> Unit)?, onBack: () -> Unit,
+    onCornerSwap: (() -> Unit)? = null, onCornerAudio: (() -> Unit)? = null, onCornerClose: (() -> Unit)? = null,
+    cornerAudioOn: Boolean = false,
+    modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.fillMaxWidth().padding(horizontal = 28.dp, vertical = 20.dp)) {
         when {
@@ -368,6 +379,14 @@ private fun BottomBar(
                 // Aspect/zoom works in every mode now — direct mode resizes the surface view itself
                 // (see MpvVideoSurface), GL mode scales internally.
                 CtrlButton(OwnTVIcon.ASPECT, active = zoomMode != ZoomMode.FIT) { onOpenDialog(HudDialog.ZOOM) }
+                // Corner (true PiP) controls — present only while a second stream is in the corner.
+                if (onCornerClose != null) {
+                    if (onCornerAudio != null) {
+                        CtrlButton(if (cornerAudioOn) OwnTVIcon.VOLUME_HIGH else OwnTVIcon.VOLUME_MUTE, active = cornerAudioOn) { onCornerAudio?.invoke() }
+                    }
+                    if (onCornerSwap != null) CtrlButton(OwnTVIcon.PIP, active = true) { onCornerSwap?.invoke() }
+                    CtrlButton(OwnTVIcon.CLOSE) { onCornerClose?.invoke() }
+                }
                 if (onPip != null) CtrlButton(OwnTVIcon.PIP) { onPip() }
                 CtrlButton(OwnTVIcon.FULLSCREEN_EXIT) { onBack() }
             }

--- a/app/src/main/java/tv/own/owntv/player/SecondaryLivePlayer.kt
+++ b/app/src/main/java/tv/own/owntv/player/SecondaryLivePlayer.kt
@@ -1,0 +1,196 @@
+package tv.own.owntv.player
+
+import android.content.Context
+import android.view.Surface
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.common.VideoSize
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.okhttp.OkHttpDataSource
+import androidx.media3.exoplayer.DefaultLoadControl
+import androidx.media3.exoplayer.DefaultRenderersFactory
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import okhttp3.OkHttpClient
+import tv.own.owntv.core.network.HttpClient
+
+/**
+ * A **second**, independent ExoPlayer that drives the picture-in-picture corner window — the half of
+ * "true PiP" that lets you watch a different stream alongside the main one. It is deliberately separate
+ * from [LivePreviewEngine] (which is busy being the in-pane preview / promoted-fullscreen live engine):
+ * the two never share a player, a surface, or audio focus, so both can decode at once.
+ *
+ * ExoPlayer (not mpv) for the corner because a second mpv context would be heavy and invasive, whereas
+ * ExoPlayer instances are light and independently constructable — the same reasoning that put the live
+ * preview on ExoPlayer. mpv stays the single full-screen player, untouched.
+ *
+ * Scope: **live channels only** for now (no VOD seek/resume state). Like the other engines, all calls
+ * must be on the main thread (ExoPlayer is single-threaded); the corner surface attaches/detaches its
+ * [Surface] from the holder callback and the controller calls [play]/[stop]/[setMuted] from the UI.
+ *
+ * Memory note: a second decoder competes for the device's player budget (see [PlayerBudget] — TV-class
+ * boxes get OOM-killed at a few hundred MB PSS). Buffers here are intentionally shallow, and the corner
+ * is a single extra stream (not four), which real Android TV hardware comfortably handles in practice.
+ */
+@UnstableApi
+class SecondaryLivePlayer(
+    private val context: Context,
+    private val okHttpClient: OkHttpClient,
+    private val diagnostics: PlayerDiagnostics,
+) : CornerEngine {
+
+    private var player: ExoPlayer? = null
+    private var surface: Surface? = null
+    private var muted: Boolean = true
+
+    private val _state = MutableStateFlow(CornerState.IDLE)
+    override val state: StateFlow<CornerState> = _state.asStateFlow()
+    private val _isPlaying = MutableStateFlow(false)
+    val isPlaying: StateFlow<Boolean> = _isPlaying.asStateFlow()
+    private val _buffering = MutableStateFlow(false)
+    val buffering: StateFlow<Boolean> = _buffering.asStateFlow()
+    private val _videoHeight = MutableStateFlow<Int?>(null)
+    val videoHeight: StateFlow<Int?> = _videoHeight.asStateFlow()
+    private val _meta = MutableStateFlow(MediaMeta())
+    override val meta: StateFlow<MediaMeta> = _meta.asStateFlow()
+
+    /** URL the corner is currently on (null when stopped) — lets the controller skip a redundant reload. */
+    override var currentUrl: String? = null
+        private set
+
+    // Live auto-reconnect — a channel that played and then dropped (provider hiccup / Wi-Fi blip) re-fetches
+    // from the live edge instead of dead-ending, mirroring LivePreviewEngine but simpler (no track menus).
+    private val mainHandler = android.os.Handler(android.os.Looper.getMainLooper())
+    private var hasPlayed = false
+    private var retryCount = 0
+    private val stallWatchdog = Runnable { reconnect("buffering stalled") }
+
+    private val listener = object : Player.Listener {
+        override fun onPlaybackStateChanged(playbackState: Int) {
+            when (playbackState) {
+                Player.STATE_BUFFERING -> {
+                    _state.value = CornerState.LOADING; _buffering.value = true
+                    if (hasPlayed) { mainHandler.removeCallbacks(stallWatchdog); mainHandler.postDelayed(stallWatchdog, STALL_MS) }
+                }
+                Player.STATE_READY -> {
+                    _state.value = CornerState.PLAYING; _buffering.value = false
+                    hasPlayed = true; retryCount = 0; mainHandler.removeCallbacks(stallWatchdog)
+                }
+                else -> { _buffering.value = false; mainHandler.removeCallbacks(stallWatchdog) }
+            }
+        }
+
+        override fun onIsPlayingChanged(isPlaying: Boolean) { _isPlaying.value = isPlaying }
+
+        override fun onVideoSizeChanged(videoSize: VideoSize) {
+            if (videoSize.height > 0) _videoHeight.value = videoSize.height
+        }
+
+        override fun onPlayerError(error: PlaybackException) {
+            android.util.Log.w(TAG, "corner ExoPlayer error: ${error.errorCodeName}", error)
+            if (hasPlayed) { reconnect("error ${error.errorCodeName}"); return } // mid-stream drop → reconnect
+            _state.value = CornerState.ERROR; _isPlaying.value = false; _buffering.value = false
+        }
+    }
+
+    /** Attach the corner SurfaceView's surface, or null when it's destroyed. */
+    override fun setSurface(s: Surface?) {
+        surface = s
+        if (s != null) player?.setVideoSurface(s) else player?.clearVideoSurface()
+    }
+
+    /** Start (or switch to) [url] in the corner. Starts muted by default — the main stream keeps the audio
+     *  until the user explicitly hands sound to the corner. Never throws: a stream ExoPlayer can't open just
+     *  shows the error state (the corner is best-effort; the main player is unaffected either way). */
+    override fun play(url: String, meta: MediaMeta, muted: Boolean) {
+        diagnostics.start(); diagnostics.markLoad()
+        this.muted = muted
+        currentUrl = url
+        hasPlayed = false; retryCount = 0; mainHandler.removeCallbacks(stallWatchdog)
+        _videoHeight.value = null
+        _meta.value = meta
+        _state.value = CornerState.LOADING
+        _buffering.value = true
+        runCatching {
+            val p = player ?: build().also { player = it }
+            surface?.let { p.setVideoSurface(it) }
+            p.volume = if (muted) 0f else 1f
+            p.setMediaItem(MediaItem.fromUri(url))
+            p.prepare()
+            p.playWhenReady = true
+        }.onFailure {
+            android.util.Log.w(TAG, "corner play() failed for $url", it)
+            _state.value = CornerState.ERROR
+        }
+    }
+
+    override fun setMuted(m: Boolean) {
+        muted = m
+        player?.volume = if (m) 0f else 1f
+    }
+
+    /** Stop playback and free the decoder/connection, keeping the instance for the next corner channel. */
+    override fun stop() {
+        currentUrl = null
+        hasPlayed = false; retryCount = 0; mainHandler.removeCallbacks(stallWatchdog)
+        _videoHeight.value = null
+        _isPlaying.value = false
+        _buffering.value = false
+        _state.value = CornerState.IDLE
+        player?.run { stop(); clearMediaItems() }
+    }
+
+    fun release() {
+        mainHandler.removeCallbacks(stallWatchdog)
+        player?.run { removeListener(listener); release() }
+        player = null
+        surface = null
+        currentUrl = null
+        _state.value = CornerState.IDLE
+    }
+
+    private fun reconnect(reason: String) {
+        mainHandler.removeCallbacks(stallWatchdog)
+        val p = player
+        val url = currentUrl
+        if (p == null || url == null || retryCount >= MAX_RECONNECTS) {
+            _state.value = CornerState.ERROR; _isPlaying.value = false; _buffering.value = false
+            return
+        }
+        retryCount++
+        _state.value = CornerState.LOADING; _buffering.value = true
+        android.util.Log.w(TAG, "corner reconnect ($reason) — attempt $retryCount/$MAX_RECONNECTS")
+        mainHandler.postDelayed({
+            if (currentUrl != url) return@postDelayed // superseded (channel changed / closed)
+            runCatching {
+                p.setMediaItem(MediaItem.fromUri(url)) // fresh fetch (live edge)
+                p.prepare()
+                p.playWhenReady = true
+            }.onFailure { _state.value = CornerState.ERROR }
+        }, (1500L * retryCount).coerceAtMost(4000L))
+    }
+
+    private fun build(): ExoPlayer {
+        val dataSource = OkHttpDataSource.Factory(okHttpClient).setUserAgent(HttpClient.DEFAULT_USER_AGENT)
+        // Shallow buffers — the corner only needs to start quickly, not buffer deep (keeps memory down).
+        val loadControl = DefaultLoadControl.Builder()
+            .setBufferDurationsMs(2_000, 8_000, 1_000, 2_000)
+            .build()
+        return ExoPlayer.Builder(context)
+            .setRenderersFactory(DefaultRenderersFactory(context))
+            .setMediaSourceFactory(DefaultMediaSourceFactory(dataSource))
+            .setLoadControl(loadControl)
+            .build()
+            .apply { addListener(listener) }
+    }
+
+    companion object {
+        private const val TAG = "SecondaryLivePlayer"
+        private const val MAX_RECONNECTS = 6
+        private const val STALL_MS = 12_000L
+    }
+}

--- a/app/src/main/java/tv/own/owntv/player/SecondaryLivePlayer.kt
+++ b/app/src/main/java/tv/own/owntv/player/SecondaryLivePlayer.kt
@@ -2,7 +2,9 @@ package tv.own.owntv.player
 
 import android.content.Context
 import android.view.Surface
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MimeTypes
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.VideoSize
@@ -12,6 +14,7 @@ import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,20 +24,26 @@ import tv.own.owntv.core.network.HttpClient
 /**
  * A **second**, independent ExoPlayer that drives the picture-in-picture corner window — the half of
  * "true PiP" that lets you watch a different stream alongside the main one. It is deliberately separate
- * from [LivePreviewEngine] (which is busy being the in-pane preview / promoted-fullscreen live engine):
- * the two never share a player, a surface, or audio focus, so both can decode at once.
+ * from [LivePreviewEngine] (the in-pane preview / promoted-fullscreen live engine): the two never share a
+ * player, a surface, or audio focus, so both can decode at once.
  *
- * ExoPlayer (not mpv) for the corner because a second mpv context would be heavy and invasive, whereas
- * ExoPlayer instances are light and independently constructable — the same reasoning that put the live
- * preview on ExoPlayer. mpv stays the single full-screen player, untouched.
+ * Architecture: OwnTV's **live** full-screen player is ExoPlayer ([LivePreviewEngine] promoted; mpv is the
+ * fallback and the **VOD** full-screen player). So live PiP runs **two ExoPlayer instances** at once — the
+ * main one plus this corner. ExoPlayer (not a second mpv context) because instances are light and
+ * independently constructable, and it matches whatever the live main is already doing.
  *
- * Scope: **live channels only** for now (no VOD seek/resume state). Like the other engines, all calls
- * must be on the main thread (ExoPlayer is single-threaded); the corner surface attaches/detaches its
- * [Surface] from the holder callback and the controller calls [play]/[stop]/[setMuted] from the UI.
+ * Coexistence: two ExoPlayers competing for the device's scarce hardware decoders / single audio-passthrough
+ * path is the real risk on TV hardware, so [build] constrains this corner — capped to 720p30, stereo/AAC
+ * audio (no surround passthrough), subtitles disabled, software-decoder fallback enabled, and it never takes
+ * audio focus. That leaves the 4K/HDR hardware decoder and surround output to the main stream.
+ *
+ * Scope: **live channels only** for now (no VOD seek/resume state). Like the other engines, all calls must
+ * be on the main thread (ExoPlayer is single-threaded); the corner surface attaches/detaches its [Surface]
+ * from the holder callback and the controller calls [play]/[stop]/[setMuted] from the UI.
  *
  * Memory note: a second decoder competes for the device's player budget (see [PlayerBudget] — TV-class
- * boxes get OOM-killed at a few hundred MB PSS). Buffers here are intentionally shallow, and the corner
- * is a single extra stream (not four), which real Android TV hardware comfortably handles in practice.
+ * boxes get OOM-killed at a few hundred MB PSS). Buffers here are intentionally shallow, and the corner is
+ * a single capped-resolution extra stream, which real Android TV hardware handles in practice.
  */
 @UnstableApi
 class SecondaryLivePlayer(
@@ -180,12 +189,36 @@ class SecondaryLivePlayer(
         val loadControl = DefaultLoadControl.Builder()
             .setBufferDurationsMs(2_000, 8_000, 1_000, 2_000)
             .build()
+        // The corner is a SECOND ExoPlayer running alongside the main one (which, for live, is also ExoPlayer).
+        // It's deliberately constrained so the two instances coexist on real TV hardware, where concurrent
+        // hardware decoders / audio passthrough are scarce:
+        //  • Cap the corner to 720p30 — a small overlay never needs 4K, and it frees the 4K/HDR hardware
+        //    decoder for the main stream (two simultaneous 4K HEVC sessions exceed most TV SoCs).
+        //  • Downmix to stereo + prefer AAC — the corner must not grab the single audio-passthrough path
+        //    (AC3/E-AC3/DTS surround), so the main keeps its surround output intact.
+        //  • No subtitles in the corner (it's a thumbnail) — avoids a second image-subtitle render path.
+        val trackSelector = DefaultTrackSelector(context)
+        trackSelector.parameters = trackSelector.buildUponParameters()
+            .setMaxVideoSize(1280, 720)
+            .setMaxVideoFrameRate(30)
+            .setMaxAudioChannelCount(2)
+            .setPreferredAudioMimeType(MimeTypes.AUDIO_AAC)
+            .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true)
+            .build()
+        // Fall back to a software codec if no second hardware decoder is free, rather than failing the corner.
+        val renderers = DefaultRenderersFactory(context).setEnableDecoderFallback(true)
         return ExoPlayer.Builder(context)
-            .setRenderersFactory(DefaultRenderersFactory(context))
+            .setRenderersFactory(renderers)
+            .setTrackSelector(trackSelector)
             .setMediaSourceFactory(DefaultMediaSourceFactory(dataSource))
             .setLoadControl(loadControl)
             .build()
-            .apply { addListener(listener) }
+            .apply {
+                // Never take audio focus — the main player owns it. The corner is muted unless the user hands
+                // it the sound, and even then it shares the session without yanking focus from the main stream.
+                setAudioAttributes(androidx.media3.common.AudioAttributes.DEFAULT, /* handleAudioFocus = */ false)
+                addListener(listener)
+            }
     }
 
     companion object {

--- a/app/src/main/java/tv/own/owntv/player/SecondaryLivePlayer.kt
+++ b/app/src/main/java/tv/own/owntv/player/SecondaryLivePlayer.kt
@@ -33,9 +33,11 @@ import tv.own.owntv.core.network.HttpClient
  * independently constructable, and it matches whatever the live main is already doing.
  *
  * Coexistence: two ExoPlayers competing for the device's scarce hardware decoders / single audio-passthrough
- * path is the real risk on TV hardware, so [build] constrains this corner — capped to 720p30, stereo/AAC
- * audio (no surround passthrough), subtitles disabled, software-decoder fallback enabled, and it never takes
- * audio focus. That leaves the 4K/HDR hardware decoder and surround output to the main stream.
+ * path is the real risk on TV hardware, so [build] constrains this corner — a 720p resolution-cap selection
+ * hint (picks a lower rendition when the stream is adaptive; a no-op, never a transcode, when it isn't),
+ * stereo/AAC audio (no surround passthrough), subtitles disabled, **software-decoder fallback** (the real
+ * safeguard when no second hardware decoder is free), and it never takes audio focus. That keeps the surround
+ * output — and, for adaptive streams, the 4K/HDR hardware decoder — with the main stream.
  *
  * Scope: **live channels only** for now (no VOD seek/resume state). Like the other engines, all calls must
  * be on the main thread (ExoPlayer is single-threaded); the corner surface attaches/detaches its [Surface]
@@ -192,8 +194,11 @@ class SecondaryLivePlayer(
         // The corner is a SECOND ExoPlayer running alongside the main one (which, for live, is also ExoPlayer).
         // It's deliberately constrained so the two instances coexist on real TV hardware, where concurrent
         // hardware decoders / audio passthrough are scarce:
-        //  • Cap the corner to 720p30 — a small overlay never needs 4K, and it frees the 4K/HDR hardware
-        //    decoder for the main stream (two simultaneous 4K HEVC sessions exceed most TV SoCs).
+        //  • Cap the corner to 720p30. This is a track-SELECTION hint, NOT transcoding: for an ADAPTIVE stream
+        //    (multi-variant HLS/DASH, common in IPTV) ExoPlayer picks a lower rendition the provider already
+        //    sends — a real saving (smaller decoder, less bandwidth). For a single-resolution stream there's
+        //    nothing lower to pick, so it decodes the full stream (the cap is a harmless no-op); the safeguard
+        //    there is decoder fallback below, plus the small surface (cheap HW downscale for display).
         //  • Downmix to stereo + prefer AAC — the corner must not grab the single audio-passthrough path
         //    (AC3/E-AC3/DTS surround), so the main keeps its surround output intact.
         //  • No subtitles in the corner (it's a thumbnail) — avoids a second image-subtitle render path.
@@ -205,7 +210,9 @@ class SecondaryLivePlayer(
             .setPreferredAudioMimeType(MimeTypes.AUDIO_AAC)
             .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true)
             .build()
-        // Fall back to a software codec if no second hardware decoder is free, rather than failing the corner.
+        // The real coexistence safeguard: if no second HARDWARE decoder is free (TV SoCs typically allow only
+        // 1–2 concurrent), fall back to a SOFTWARE codec instead of failing the corner. SW decode costs CPU —
+        // the honest price of a second full-resolution stream when the provider offers no smaller rendition.
         val renderers = DefaultRenderersFactory(context).setEnableDecoderFallback(true)
         return ExoPlayer.Builder(context)
             .setRenderersFactory(renderers)

--- a/app/src/test/java/tv/own/owntv/features/multiview/PipAudioTest.kt
+++ b/app/src/test/java/tv/own/owntv/features/multiview/PipAudioTest.kt
@@ -1,0 +1,44 @@
+package tv.own.owntv.features.multiview
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/** The "only one window is audible at a time" rule for true picture-in-picture. */
+class PipAudioTest {
+
+    @Test
+    fun noCorner_leavesBothEnginesAlone() {
+        // No corner → null plan, so the shell touches neither mute (normal playback is never disturbed).
+        assertNull(PipAudio.plan(cornerActive = false, mainPresent = false, audioOnCorner = false))
+        assertNull(PipAudio.plan(cornerActive = false, mainPresent = true, audioOnCorner = true))
+    }
+
+    @Test
+    fun browseOnlyCorner_cornerIsAudible_mainUntouched() {
+        // Browsing with just a corner up: it's the only stream, so it gets the sound; main left alone (null).
+        val plan = PipAudio.plan(cornerActive = true, mainPresent = false, audioOnCorner = false)
+        assertEquals(PipAudioPlan(muteMain = null, muteCorner = false), plan)
+    }
+
+    @Test
+    fun browseOnlyCorner_audioFlagIrrelevant_whenNoMain() {
+        // With no main present the audioOnCorner flag can't steal sound from a window that isn't there.
+        val plan = PipAudio.plan(cornerActive = true, mainPresent = false, audioOnCorner = true)
+        assertEquals(PipAudioPlan(muteMain = null, muteCorner = false), plan)
+    }
+
+    @Test
+    fun bothWindows_default_mainAudible_cornerMuted() {
+        // Full-screen + corner, default: the main stream keeps the sound, the corner is silent video.
+        val plan = PipAudio.plan(cornerActive = true, mainPresent = true, audioOnCorner = false)
+        assertEquals(PipAudioPlan(muteMain = false, muteCorner = true), plan)
+    }
+
+    @Test
+    fun bothWindows_audioOnCorner_cornerAudible_mainMuted() {
+        // User hands sound to the corner: corner unmuted, main muted — exactly one is audible.
+        val plan = PipAudio.plan(cornerActive = true, mainPresent = true, audioOnCorner = true)
+        assertEquals(PipAudioPlan(muteMain = true, muteCorner = false), plan)
+    }
+}

--- a/app/src/test/java/tv/own/owntv/features/multiview/PipControllerTest.kt
+++ b/app/src/test/java/tv/own/owntv/features/multiview/PipControllerTest.kt
@@ -1,0 +1,107 @@
+package tv.own.owntv.features.multiview
+
+import android.view.Surface
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tv.own.owntv.core.database.entity.ChannelEntity
+import tv.own.owntv.player.CornerEngine
+import tv.own.owntv.player.CornerState
+import tv.own.owntv.player.MediaMeta
+
+/**
+ * Verifies the picture-in-picture corner orchestration using a fake engine — no ExoPlayer, no Android, no
+ * second decoder (which is exactly the resource we don't want a test to spend). Confirms the corner activates
+ * with the right channel, starts muted (so the main keeps the audio), reuses the decoder instead of reloading
+ * the same channel, switches on a new channel, and frees the decoder on close.
+ */
+class PipControllerTest {
+
+    /** Records control calls and tracks [currentUrl] the way the real engine does, without any playback. */
+    private class FakeCornerEngine : CornerEngine {
+        override val state: StateFlow<CornerState> = MutableStateFlow(CornerState.IDLE)
+        override val meta: StateFlow<MediaMeta> = MutableStateFlow(MediaMeta())
+        override var currentUrl: String? = null
+
+        val playCalls = mutableListOf<Triple<String, MediaMeta, Boolean>>()
+        val muteCalls = mutableListOf<Boolean>()
+        var stopCalls = 0
+
+        override fun play(url: String, meta: MediaMeta, muted: Boolean) {
+            playCalls += Triple(url, meta, muted)
+            currentUrl = url
+        }
+        override fun setMuted(muted: Boolean) { muteCalls += muted }
+        override fun stop() { stopCalls++; currentUrl = null }
+        override fun setSurface(surface: Surface?) {}
+    }
+
+    private fun channel(id: Long, url: String) =
+        ChannelEntity(id = id, sourceId = 1, name = "Ch$id", streamUrl = url)
+
+    @Test
+    fun initiallyInactive() {
+        val pip = PipController(FakeCornerEngine())
+        assertFalse(pip.active.value)
+        assertNull(pip.channel.value)
+    }
+
+    @Test
+    fun openCorner_activatesAndPlaysMutedByDefault() {
+        val engine = FakeCornerEngine()
+        val pip = PipController(engine)
+        val ch = channel(1, "http://a")
+
+        pip.openCorner(ch)
+
+        assertTrue(pip.active.value)
+        assertEquals(ch, pip.channel.value)
+        assertEquals(1, engine.playCalls.size)
+        assertEquals("http://a", engine.playCalls[0].first)
+        assertTrue("corner must start muted so the main stream keeps the audio", engine.playCalls[0].third)
+    }
+
+    @Test
+    fun openCorner_sameChannel_doesNotReload() {
+        val engine = FakeCornerEngine()
+        val pip = PipController(engine)
+        val ch = channel(1, "http://a")
+
+        pip.openCorner(ch)
+        pip.openCorner(ch) // same URL → must NOT spin up the decoder again (just re-apply mute)
+
+        assertEquals(1, engine.playCalls.size)
+        assertEquals(1, engine.muteCalls.size)
+        assertTrue(pip.active.value)
+    }
+
+    @Test
+    fun openCorner_differentChannel_switchesStream() {
+        val engine = FakeCornerEngine()
+        val pip = PipController(engine)
+
+        pip.openCorner(channel(1, "http://a"))
+        pip.openCorner(channel(2, "http://b"))
+
+        assertEquals(2, engine.playCalls.size)
+        assertEquals("http://b", engine.playCalls[1].first)
+        assertEquals(2L, pip.channel.value?.id)
+    }
+
+    @Test
+    fun closeCorner_deactivatesAndStops() {
+        val engine = FakeCornerEngine()
+        val pip = PipController(engine)
+        pip.openCorner(channel(1, "http://a"))
+
+        pip.closeCorner()
+
+        assertFalse(pip.active.value)
+        assertNull(pip.channel.value)
+        assertEquals(1, engine.stopCalls)
+    }
+}


### PR DESCRIPTION
## What & why

OwnTV's current "mini-player / PiP" docks the **single** player surface to a corner — picking another channel just retargets that one decoder, so you can never watch two things at once. This PR adds **true picture-in-picture**: a live channel keeps playing in an upper-right corner window while you watch a *different* channel full-screen (or browse). Both streams decode simultaneously.

This is **PR 1 of 2** toward the requested feature set; the planned MultiView 2×2 grid reuses the same engine.

## Architecture (corrected per review)

OwnTV's **live** full-screen player is **ExoPlayer** (`LivePreviewEngine` promoted, `liveOnExo`), with **mpv** as the live fallback and the **VOD** full-screen player. So live PiP runs **two ExoPlayer instances** — the existing main one plus the corner.

- **`SecondaryLivePlayer`** — the corner's second ExoPlayer, behind a small **`CornerEngine`** interface. Separate decoder / surface / audio from the main engine, so the two never collide.
- It's a **deliberately constrained second decoder** so two instances coexist on TV hardware (scarce concurrent hardware decoders / single audio-passthrough path):
  - **720p30 cap** → frees the 4K/HDR hardware decoder for the main stream; **software-decoder fallback** if no second HW decoder is free.
  - **stereo + AAC**, **no audio focus** → never grabs the surround passthrough; main keeps AC3/E-AC3/DTS.
  - **subtitles disabled** on the corner → no second image-subtitle render path.
- **`PipCorner.kt`** — corner UI; its `SurfaceView` uses `setZOrderMediaOverlay(true)` so it draws above the main surface (both stay hardware-overlay candidates).
- Mounted at the shell's top level, so the corner **persists across browse ↔ full-screen**.
- **Audio:** exactly one window audible — main by default; HUD (and the corner's own D-pad buttons while browsing) let you move audio to the corner, **swap** the corner channel into the main window, or **close** it. The mute is applied to whichever engine owns the main stream (Exo for live, mpv for VOD).
- **Entry point:** a **"Watch in corner"** button on a channel's Live preview pane.

## Scope choices

- **All-ExoPlayer** for the corner (not a second mpv context — heavy/invasive), matching whatever the live main is already on.
- **Live channels only** for now (no per-tile VOD seek/resume state) — easy to extend later.

## Tests

A `CornerEngine` seam makes the orchestration **plain-JVM unit-testable — no device, no ExoPlayer, no second decoder spun up**:

- `PipControllerTest` — corner activates with the right channel, **starts muted**, **reuses the decoder** instead of reloading the same channel, switches on a new channel, frees the decoder on close.
- `PipAudioTest` — the full "only one window audible" matrix, extracted into a pure `PipAudio.plan(...)` the shell calls.

## Notes for reviewers

- Authored without a local Android toolchain, so **CI is the first real compile** — happy to iterate.
- The corner caps (720p30 / stereo) are conservative starting points; easy to tighten (480p) or make device-tiered like `PlayerBudget` based on real-hardware testing.
- Changes are additive; the existing single-player path is untouched. New HUD controls are optional params that render only when a corner is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)