### PR TITLE
[Draft · stacked on #29] MultiView: up to four live streams (grid + dominant)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### ✨ New features
+
+- **True picture-in-picture (watch two streams at once)** — you can now keep one live channel playing in a
+  corner window while you watch a *different* channel full-screen (or browse). On any channel's preview pane
+  press **Watch in corner** to dock it top-right; it keeps streaming on its own decoder, independent of the
+  main player. The window persists as you move between browsing and full-screen. Sound stays with the main
+  stream by default; the player HUD (and the corner's own buttons while browsing) let you **move the audio**
+  to the corner, **swap** the corner channel into the main window, or **close** it. The corner runs on a
+  second ExoPlayer instance with shallow buffers (the main mpv player is untouched), so the extra stream is
+  light on memory — a deliberate step toward a fuller MultiView grid later.
+
 ## v3.2.0 — 2026-06-22
 
 ### ✨ New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@
   stream by default; the player HUD (and the corner's own buttons while browsing) let you **move the audio**
   to the corner, **swap** the corner channel into the main window, or **close** it. Live PiP runs **two
   ExoPlayer instances** (OwnTV's live full-screen player is ExoPlayer; mpv is the VOD player and the live
-  fallback), so the corner is a deliberately **constrained second decoder** — capped to 720p30, stereo audio
-  (no surround passthrough), no subtitles, software-decoder fallback, and it never takes audio focus. That
-  leaves the 4K/HDR hardware decoder and surround output to the main stream, so the two coexist on TV
-  hardware. A deliberate step toward a fuller MultiView grid later.
+  fallback), so the corner is a deliberately **constrained second decoder** — a 720p resolution-cap hint
+  (picks a lower rendition when the stream is adaptive HLS; never transcodes), stereo audio (no surround
+  passthrough), no subtitles, **software-decoder fallback** when no second hardware decoder is free, and it
+  never takes audio focus. That keeps surround output (and, for adaptive streams, the 4K/HDR hardware decoder)
+  with the main stream, so the two coexist on TV hardware. A deliberate step toward a fuller MultiView grid.
 
 ## v3.2.0 — 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@
   press **Watch in corner** to dock it top-right; it keeps streaming on its own decoder, independent of the
   main player. The window persists as you move between browsing and full-screen. Sound stays with the main
   stream by default; the player HUD (and the corner's own buttons while browsing) let you **move the audio**
-  to the corner, **swap** the corner channel into the main window, or **close** it. The corner runs on a
-  second ExoPlayer instance with shallow buffers (the main mpv player is untouched), so the extra stream is
-  light on memory — a deliberate step toward a fuller MultiView grid later.
+  to the corner, **swap** the corner channel into the main window, or **close** it. Live PiP runs **two
+  ExoPlayer instances** (OwnTV's live full-screen player is ExoPlayer; mpv is the VOD player and the live
+  fallback), so the corner is a deliberately **constrained second decoder** — capped to 720p30, stereo audio
+  (no surround passthrough), no subtitles, software-decoder fallback, and it never takes audio focus. That
+  leaves the 4K/HDR hardware decoder and surround output to the main stream, so the two coexist on TV
+  hardware. A deliberate step toward a fuller MultiView grid later.
 
 ## v3.2.0 — 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### ✨ New features
 
+- **MultiView — up to four live streams at once** — open a channel's preview pane and press **MultiView** to
+  watch several live channels side by side, in two layouts: an **equal grid** (1 / 2-up / 2×2) or a
+  **dominant** layout with one large stream and the rest in a small strip. D-pad moves between tiles; the
+  focused tile is the only one you hear, and pressing **OK** makes it the big one. Add more streams from
+  inside the grid (**＋ Add stream**, from your recent channels) and toggle the layout or exit from the
+  bottom bar. Built to be **light on constrained boxes**: each tile is its own constrained ExoPlayer (capped
+  to 480p — a selection hint, never a transcode — with software-decoder fallback and no audio focus), the
+  tile count is **device-tiered** (low-RAM boxes cap at 2 rather than stutter on 4), and **every tile is
+  released the moment you leave MultiView**, so it holds no decoder or memory when closed. Reuses the PiP
+  engine; live channels only.
 - **True picture-in-picture (watch two streams at once)** — you can now keep one live channel playing in a
   corner window while you watch a *different* channel full-screen (or browse). On any channel's preview pane
   press **Watch in corner** to dock it top-right; it keeps streaming on its own decoder, independent of the
@@ -11,11 +21,11 @@
   stream by default; the player HUD (and the corner's own buttons while browsing) let you **move the audio**
   to the corner, **swap** the corner channel into the main window, or **close** it. Live PiP runs **two
   ExoPlayer instances** (OwnTV's live full-screen player is ExoPlayer; mpv is the VOD player and the live
-  fallback), so the corner is a deliberately **constrained second decoder** — a 720p resolution-cap hint
-  (picks a lower rendition when the stream is adaptive HLS; never transcodes), stereo audio (no surround
-  passthrough), no subtitles, **software-decoder fallback** when no second hardware decoder is free, and it
-  never takes audio focus. That keeps surround output (and, for adaptive streams, the 4K/HDR hardware decoder)
-  with the main stream, so the two coexist on TV hardware. A deliberate step toward a fuller MultiView grid.
+  fallback), so the corner is a deliberately **constrained second decoder** — a resolution-cap hint (picks a
+  lower rendition when the stream is adaptive HLS; never transcodes), stereo audio (no surround passthrough),
+  no subtitles, **software-decoder fallback** when no second hardware decoder is free, and it never takes
+  audio focus. That keeps surround output (and, for adaptive streams, the 4K/HDR hardware decoder) with the
+  main stream, so the two coexist on TV hardware. A deliberate step toward a fuller MultiView grid later.
 
 ## v3.2.0 — 2026-06-22
 

--- a/app/src/main/java/tv/own/owntv/di/PlayerModule.kt
+++ b/app/src/main/java/tv/own/owntv/di/PlayerModule.kt
@@ -13,4 +13,8 @@ val playerModule = module {
     single { OwnTVPlayer(androidContext(), get(), get(), get(), get()) }
     // ExoPlayer engine for the fast Live preview pane (mpv stays the full/fullscreen player).
     single { LivePreviewEngine(androidContext(), get(), get()) }
+    // Second, independent ExoPlayer for the picture-in-picture corner (true PiP — a different stream
+    // alongside the main one). Separate decoder/surface/audio from the preview engine above so both play.
+    single { tv.own.owntv.player.SecondaryLivePlayer(androidContext(), get(), get()) }
+    single { tv.own.owntv.features.multiview.PipController(get<tv.own.owntv.player.SecondaryLivePlayer>()) }
 }

--- a/app/src/main/java/tv/own/owntv/di/PlayerModule.kt
+++ b/app/src/main/java/tv/own/owntv/di/PlayerModule.kt
@@ -17,4 +17,18 @@ val playerModule = module {
     // alongside the main one). Separate decoder/surface/audio from the preview engine above so both play.
     single { tv.own.owntv.player.SecondaryLivePlayer(androidContext(), get(), get()) }
     single { tv.own.owntv.features.multiview.PipController(get<tv.own.owntv.player.SecondaryLivePlayer>()) }
+    // MultiView (up to 4 live tiles). Each tile is its own constrained ExoPlayer, created on demand and
+    // released when MultiView closes. Tile count is device-tiered (low-RAM boxes cap at 2) and each tile
+    // caps lower than a PiP corner — so several decoders coexist on weak hardware.
+    single {
+        tv.own.owntv.features.multiview.MultiViewController(
+            maxTiles = tv.own.owntv.features.multiview.MultiViewController.deviceMaxTiles(androidContext()),
+            engineFactory = {
+                tv.own.owntv.player.SecondaryLivePlayer(
+                    androidContext(), get(), get(),
+                    maxVideoHeight = tv.own.owntv.features.multiview.MultiViewController.TILE_MAX_HEIGHT,
+                )
+            },
+        )
+    }
 }

--- a/app/src/main/java/tv/own/owntv/features/live/LiveScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/live/LiveScreen.kt
@@ -69,6 +69,7 @@ fun LiveScreen(
     previewEnabled: Boolean = true,
     restoreFocus: Boolean = false,
     onRestored: () -> Unit = {},
+    onOpenMultiView: (ChannelEntity) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val vm: LiveViewModel = koinViewModel()
@@ -223,6 +224,7 @@ fun LiveScreen(
                 onMatchEpg = { matchingEpg = previewChannel },
                 onCatchup = { catchupChannel = previewChannel },
                 onWatchInCorner = { previewChannel?.let { pip.openCorner(it) } },
+                onMultiView = { previewChannel?.let { onOpenMultiView(it) } },
             )
         }
     }
@@ -316,6 +318,7 @@ private fun LivePreviewPane(
     onMatchEpg: () -> Unit,
     onCatchup: () -> Unit,
     onWatchInCorner: () -> Unit,
+    onMultiView: () -> Unit,
 ) {
     val colors = OwnTVTheme.colors
     val previewState by previewEngine.state.collectAsStateWithLifecycle()
@@ -378,6 +381,9 @@ private fun LivePreviewPane(
         // True picture-in-picture: open this channel in a corner window that keeps playing while you watch
         // (or browse) something else. Audio stays with the main stream until you hand it to the corner.
         OwnTVButton(label = "Watch in corner", onClick = onWatchInCorner, icon = OwnTVIcon.PIP)
+        Spacer(Modifier.height(10.dp))
+        // MultiView: open this channel as the first of up to four tiles (add more from inside the grid).
+        OwnTVButton(label = "MultiView", onClick = onMultiView, icon = OwnTVIcon.PIP, style = OwnTVButtonStyle.SECONDARY)
         Spacer(Modifier.height(10.dp))
         OwnTVButton(
             label = if (isFavorite) "Favorited" else "Favorite",

--- a/app/src/main/java/tv/own/owntv/features/live/LiveScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/live/LiveScreen.kt
@@ -72,6 +72,7 @@ fun LiveScreen(
     modifier: Modifier = Modifier,
 ) {
     val vm: LiveViewModel = koinViewModel()
+    val pip = org.koin.compose.koinInject<tv.own.owntv.features.multiview.PipController>()
     val railItems by vm.railItems.collectAsStateWithLifecycle()
     val selectedKey by vm.selectedKey.collectAsStateWithLifecycle()
     val count by vm.count.collectAsStateWithLifecycle()
@@ -221,6 +222,7 @@ fun LiveScreen(
                 onHide = { previewChannel?.let { vm.hideChannel(it) } },
                 onMatchEpg = { matchingEpg = previewChannel },
                 onCatchup = { catchupChannel = previewChannel },
+                onWatchInCorner = { previewChannel?.let { pip.openCorner(it) } },
             )
         }
     }
@@ -313,6 +315,7 @@ private fun LivePreviewPane(
     onHide: () -> Unit,
     onMatchEpg: () -> Unit,
     onCatchup: () -> Unit,
+    onWatchInCorner: () -> Unit,
 ) {
     val colors = OwnTVTheme.colors
     val previewState by previewEngine.state.collectAsStateWithLifecycle()
@@ -372,6 +375,10 @@ private fun LivePreviewPane(
         }
 
         Spacer(Modifier.height(16.dp))
+        // True picture-in-picture: open this channel in a corner window that keeps playing while you watch
+        // (or browse) something else. Audio stays with the main stream until you hand it to the corner.
+        OwnTVButton(label = "Watch in corner", onClick = onWatchInCorner, icon = OwnTVIcon.PIP)
+        Spacer(Modifier.height(10.dp))
         OwnTVButton(
             label = if (isFavorite) "Favorited" else "Favorite",
             onClick = onToggleFavorite,

--- a/app/src/main/java/tv/own/owntv/features/multiview/MultiViewController.kt
+++ b/app/src/main/java/tv/own/owntv/features/multiview/MultiViewController.kt
@@ -1,0 +1,167 @@
+package tv.own.owntv.features.multiview
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import tv.own.owntv.core.database.entity.ChannelEntity
+import tv.own.owntv.player.CornerEngine
+import tv.own.owntv.player.MediaMeta
+
+/** How the MultiView tiles are arranged on screen. */
+enum class MultiLayout {
+    /** Every tile the same size (1 / 2-up / 3-up / 2×2). */
+    GRID,
+
+    /** One dominant tile filling most of the screen, the rest as a small strip beside it. */
+    DOMINANT,
+}
+
+/**
+ * Drives **MultiView** — up to [MAX] live streams on screen at once (PR 2, building on the PiP engine).
+ *
+ * Architecture: OwnTV's live full-screen player is ExoPlayer, so MultiView is simply **N ExoPlayer tiles**.
+ * Each tile is a [tv.own.owntv.player.SecondaryLivePlayer] — the same constrained second decoder hardened
+ * for PiP (a resolution-cap hint, stereo, no subtitles, software-decoder fallback, no audio focus), which is
+ * exactly what running several concurrent decoders on TV hardware needs. The cap is smaller than a PiP corner
+ * (a quarter-screen tile never needs 720p); it picks a lower rendition for adaptive streams (no transcoding),
+ * and for single-resolution streams the safeguard is the software-decoder fallback — so on a weak SoC four
+ * full-res streams lean on CPU rather than failing. Concurrent-decoder limits are real; tile count may need
+ * to be device-tiered (like [tv.own.owntv.player.PlayerBudget]) in a follow-up.
+ *
+ * Only the **active** tile is audible (audio follows D-pad focus — two soundtracks would be cacophony) and,
+ * in [MultiLayout.DOMINANT], the active tile is the large one. The engine pool is created lazily and reused
+ * across sessions; [exit] stops every decoder so MultiView never holds streams open in the background.
+ *
+ * Pure state + thin engine calls, so the whole thing is unit-testable with fake [CornerEngine]s — no real
+ * decoder is ever spun up in a test.
+ */
+class MultiViewController(
+    /** Hard ceiling for this device — [MAX] on capable hardware, fewer on low-RAM boxes (see [deviceMaxTiles]). */
+    val maxTiles: Int,
+    private val engineFactory: () -> CornerEngine,
+) {
+
+    private val pool = arrayOfNulls<CornerEngine>(MAX)
+
+    private val _tiles = MutableStateFlow<List<ChannelEntity>>(emptyList())
+    /** The channels currently on screen, one per tile (index = tile slot). */
+    val tiles: StateFlow<List<ChannelEntity>> = _tiles.asStateFlow()
+
+    private val _activeIndex = MutableStateFlow(0)
+    /** The focused tile — the only audible one, and the dominant one in [MultiLayout.DOMINANT]. */
+    val activeIndex: StateFlow<Int> = _activeIndex.asStateFlow()
+
+    private val _layout = MutableStateFlow(MultiLayout.GRID)
+    val layout: StateFlow<MultiLayout> = _layout.asStateFlow()
+
+    private val _active = MutableStateFlow(false)
+    /** True while the MultiView screen is up. */
+    val active: StateFlow<Boolean> = _active.asStateFlow()
+
+    /** The engine backing tile [index] (lazily created). The UI renders its surface. */
+    fun engineAt(index: Int): CornerEngine = pool[index] ?: engineFactory().also { pool[index] = it }
+
+    /** Enter MultiView with [channels] (clamped to [maxTiles]); the first tile starts active/audible. */
+    fun enter(channels: List<ChannelEntity>) {
+        val take = channels.take(maxTiles)
+        if (take.isEmpty()) return
+        _tiles.value = take
+        _activeIndex.value = 0
+        _active.value = true
+        take.forEachIndexed { i, ch -> startTile(i, ch) }
+        applyAudio()
+    }
+
+    /** True while another tile can be added on this device (room under [maxTiles]). */
+    val canAddTile: Boolean get() = _tiles.value.size < maxTiles
+
+    /** Add [channel] as a new tile if there's room (< [maxTiles]); it starts muted (the active tile keeps audio). */
+    fun addTile(channel: ChannelEntity) {
+        val current = _tiles.value
+        if (current.size >= maxTiles) return
+        val index = current.size
+        _tiles.value = current + channel
+        _active.value = true
+        startTile(index, channel)
+        applyAudio()
+    }
+
+    /** Remove tile [index], stopping its decoder. Exits MultiView if it was the last tile. */
+    fun removeTile(index: Int) {
+        val current = _tiles.value
+        if (index !in current.indices) return
+        // The engine pool is positional; free the now-unused tail slot, then rebuild the list.
+        pool[current.lastIndex]?.release(); pool[current.lastIndex] = null
+        // Reassign channels to slots 0..n-2 so engine[i] always matches tiles[i].
+        val remaining = current.toMutableList().apply { removeAt(index) }
+        if (remaining.isEmpty()) { exit(); return }
+        _tiles.value = remaining
+        remaining.forEachIndexed { i, ch -> startTile(i, ch) } // re-bind slots to the new order (idempotent)
+        _activeIndex.value = _activeIndex.value.coerceIn(0, remaining.lastIndex)
+        applyAudio()
+    }
+
+    /** Move focus to tile [index] — it becomes the only audible one (and the dominant one in DOMINANT mode). */
+    fun setActive(index: Int) {
+        if (index !in _tiles.value.indices) return
+        _activeIndex.value = index
+        applyAudio()
+    }
+
+    /** Make tile [index] the large/dominant tile (and switch to the dominant layout). */
+    fun promoteToDominant(index: Int) {
+        if (index !in _tiles.value.indices) return
+        _activeIndex.value = index
+        _layout.value = MultiLayout.DOMINANT
+        applyAudio()
+    }
+
+    /** Toggle between the equal grid and the dominant-plus-small layout. */
+    fun toggleLayout() {
+        _layout.value = if (_layout.value == MultiLayout.GRID) MultiLayout.DOMINANT else MultiLayout.GRID
+    }
+
+    /** Leave MultiView, **releasing** every tile's player so MultiView holds no decoder or memory while
+     *  closed — important on resource-constrained boxes. The (cheap) instances are rebuilt on next entry. */
+    fun exit() {
+        for (i in pool.indices) { pool[i]?.release(); pool[i] = null }
+        _tiles.value = emptyList()
+        _activeIndex.value = 0
+        _layout.value = MultiLayout.GRID
+        _active.value = false
+    }
+
+    private fun startTile(index: Int, channel: ChannelEntity) {
+        val engine = engineAt(index)
+        if (engine.currentUrl != channel.streamUrl) {
+            engine.play(channel.streamUrl, meta = MediaMeta(title = channel.name, logoUrl = channel.logoUrl), muted = true)
+        }
+    }
+
+    /** Exactly one tile is audible: the active one. Pure rule, also exercised in tests. */
+    private fun applyAudio() {
+        val active = _activeIndex.value
+        _tiles.value.indices.forEach { i -> pool[i]?.setMuted(i != active) }
+    }
+
+    companion object {
+        /** Absolute ceiling on simultaneous streams (capable hardware). */
+        const val MAX = 4
+
+        /** Per-tile resolution cap — a quarter-screen tile never needs more, and keeping it low is what lets
+         *  several software-decoded streams coexist on a weak SoC (selection hint only; never transcodes). */
+        const val TILE_MAX_HEIGHT = 480
+
+        /**
+         * How many tiles this device should allow. Low-RAM boxes (the `isLowRamDevice` flag, or < ~3 GB)
+         * realistically can't run four concurrent decoders, so they cap at 2 — better two solid streams than
+         * four stuttering ones. Mirrors the device-scaled philosophy of [tv.own.owntv.player.PlayerBudget].
+         */
+        fun deviceMaxTiles(context: android.content.Context): Int {
+            val am = context.getSystemService(android.content.Context.ACTIVITY_SERVICE) as android.app.ActivityManager
+            val info = android.app.ActivityManager.MemoryInfo().also { am.getMemoryInfo(it) }
+            val totalGb = info.totalMem / (1024.0 * 1024.0 * 1024.0)
+            return if (am.isLowRamDevice || totalGb < 3.0) 2 else MAX
+        }
+    }
+}

--- a/app/src/main/java/tv/own/owntv/features/multiview/MultiViewScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/multiview/MultiViewScreen.kt
@@ -1,0 +1,257 @@
+@file:OptIn(androidx.media3.common.util.UnstableApi::class)
+
+package tv.own.owntv.features.multiview
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.clickable
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import tv.own.owntv.core.database.entity.ChannelEntity
+import tv.own.owntv.player.CornerState
+import tv.own.owntv.player.SecondaryVideoSurface
+import tv.own.owntv.ui.theme.OwnTVTheme
+
+/**
+ * MultiView — up to four live streams on screen at once, in either an equal **grid** or a **dominant**
+ * (one large + a small strip) layout. D-pad focus moves between tiles; the focused tile is the only audible
+ * one. Pressing OK on a tile promotes it to the dominant layout. Back exits (the controller releases every
+ * decoder). Each tile renders a [SecondaryVideoSurface] — the constrained second-decoder pattern from PiP.
+ */
+@Composable
+fun MultiViewScreen(
+    controller: MultiViewController,
+    addableChannels: List<ChannelEntity>,
+    onExit: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val tiles by controller.tiles.collectAsStateWithLifecycle()
+    val activeIndex by controller.activeIndex.collectAsStateWithLifecycle()
+    val layout by controller.layout.collectAsStateWithLifecycle()
+    var picking by remember { mutableStateOf(false) }
+
+    BackHandler { if (picking) picking = false else onExit() }
+
+    Box(modifier.fillMaxSize().background(Color.Black)) {
+        when {
+            tiles.isEmpty() -> Unit
+            layout == MultiLayout.DOMINANT && tiles.size > 1 ->
+                DominantLayout(tiles, activeIndex, controller)
+            else -> GridLayout(tiles, activeIndex, controller)
+        }
+
+        // Bottom control row: layout toggle, add a stream (if there's room on this device), exit.
+        Row(
+            modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 10.dp).focusGroup(),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            BarButton(if (layout == MultiLayout.GRID) "▦ Grid" else "▣ Dominant") { controller.toggleLayout() }
+            if (tiles.size < controller.maxTiles) BarButton("＋ Add stream") { picking = true }
+            BarButton("✕ Exit") { onExit() }
+        }
+
+        if (picking) {
+            AddStreamPicker(
+                channels = addableChannels.filter { ch -> tiles.none { it.id == ch.id } },
+                onPick = { controller.addTile(it); picking = false },
+                onDismiss = { picking = false },
+            )
+        }
+    }
+}
+
+/** A small focusable text button for the MultiView control bar. */
+@Composable
+private fun BarButton(label: String, onClick: () -> Unit) {
+    tv.own.owntv.ui.components.FocusableSurface(
+        onClick = onClick,
+        shape = RoundedCornerShape(10.dp),
+        focusedScale = 1.08f,
+        focusedContainerColor = Color.White.copy(alpha = 0.30f),
+        unfocusedContainerColor = Color.White.copy(alpha = 0.14f),
+        selectedContainerColor = Color.White.copy(alpha = 0.14f),
+    ) { _ ->
+        Text(
+            label,
+            style = MaterialTheme.typography.labelLarge,
+            color = Color.White,
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 7.dp),
+        )
+    }
+}
+
+/** Pick another channel to add as a tile — sourced from the caller's recently-watched list (no new data). */
+@Composable
+private fun AddStreamPicker(channels: List<ChannelEntity>, onPick: (ChannelEntity) -> Unit, onDismiss: () -> Unit) {
+    val firstFocus = remember { FocusRequester() }
+    LaunchedEffect(Unit) { if (channels.isNotEmpty()) runCatching { firstFocus.requestFocus() } }
+    Box(
+        Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.75f)).focusGroup(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            Modifier.fillMaxWidth(0.5f).clip(RoundedCornerShape(16.dp)).background(OwnTVTheme.colors.surfaceContainerHigh).padding(20.dp),
+        ) {
+            Text("Add a stream", style = MaterialTheme.typography.titleLarge, color = OwnTVTheme.colors.onSurface)
+            androidx.compose.foundation.layout.Spacer(Modifier.padding(top = 4.dp))
+            if (channels.isEmpty()) {
+                Text("No recent channels to add.", style = MaterialTheme.typography.bodyMedium, color = OwnTVTheme.colors.onSurfaceVariant)
+            } else {
+                androidx.compose.foundation.lazy.LazyColumn(
+                    Modifier.fillMaxWidth().heightIn(max = 320.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    androidx.compose.foundation.lazy.items(channels, key = { it.id }) { ch ->
+                        tv.own.owntv.ui.components.FocusableSurface(
+                            onClick = { onPick(ch) },
+                            modifier = if (ch.id == channels.first().id) Modifier.fillMaxWidth().focusRequester(firstFocus) else Modifier.fillMaxWidth(),
+                            shape = RoundedCornerShape(10.dp),
+                            contentAlignment = Alignment.CenterStart,
+                        ) { _ ->
+                            Text(ch.name, style = MaterialTheme.typography.titleMedium, color = OwnTVTheme.colors.onSurface, modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp), maxLines = 1)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** Equal-size tiles: 1 = full, 2 = side-by-side, 3 = two over one, 4 = 2×2. */
+@Composable
+private fun GridLayout(tiles: List<ChannelEntity>, activeIndex: Int, controller: MultiViewController) {
+    val gap = 4.dp
+    when (tiles.size) {
+        1 -> TileRow(tiles, 0, activeIndex, controller, Modifier.fillMaxSize())
+        2 -> TileRow(tiles, 0, activeIndex, controller, Modifier.fillMaxSize(), count = 2)
+        3 -> Column(Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(gap)) {
+            TileRow(tiles, 0, activeIndex, controller, Modifier.fillMaxWidth().weight(1f), count = 2)
+            TileRow(tiles, 2, activeIndex, controller, Modifier.fillMaxWidth().weight(1f), count = 1)
+        }
+        else -> Column(Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(gap)) {
+            TileRow(tiles, 0, activeIndex, controller, Modifier.fillMaxWidth().weight(1f), count = 2)
+            TileRow(tiles, 2, activeIndex, controller, Modifier.fillMaxWidth().weight(1f), count = 2)
+        }
+    }
+}
+
+/** A row of [count] tiles starting at [start]. */
+@Composable
+private fun TileRow(
+    tiles: List<ChannelEntity>,
+    start: Int,
+    activeIndex: Int,
+    controller: MultiViewController,
+    modifier: Modifier,
+    count: Int = 1,
+) {
+    Row(modifier, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        for (offset in 0 until count) {
+            val index = start + offset
+            if (index in tiles.indices) {
+                Tile(index, tiles[index], active = index == activeIndex, controller, Modifier.fillMaxHeight().weight(1f))
+            }
+        }
+    }
+}
+
+/** Dominant layout: the active tile fills the left ~3/4; the others stack down the right ~1/4. */
+@Composable
+private fun DominantLayout(tiles: List<ChannelEntity>, activeIndex: Int, controller: MultiViewController) {
+    val big = activeIndex.coerceIn(0, tiles.lastIndex) // guard against a transient tiles/active mismatch
+    Row(Modifier.fillMaxSize(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        Tile(big, tiles[big], active = true, controller, Modifier.fillMaxHeight().weight(3f))
+        Column(Modifier.fillMaxHeight().weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            tiles.forEachIndexed { i, ch ->
+                if (i != big) Tile(i, ch, active = false, controller, Modifier.fillMaxWidth().weight(1f))
+            }
+        }
+    }
+}
+
+/** One tile: the stream's video, a title strip, and a focus/active border. Focus → audio; OK → make dominant. */
+@Composable
+private fun Tile(
+    index: Int,
+    channel: ChannelEntity,
+    active: Boolean,
+    controller: MultiViewController,
+    modifier: Modifier,
+) {
+    val engine = remember(index) { controller.engineAt(index) }
+    val state by engine.state.collectAsStateWithLifecycle()
+    val focusRequester = remember { FocusRequester() }
+    // Pull focus to the active tile when MultiView opens / the active tile changes.
+    LaunchedEffect(active) { if (active) runCatching { focusRequester.requestFocus() } }
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color.Black)
+            .border(
+                width = if (active) 3.dp else 1.dp,
+                color = if (active) OwnTVTheme.colors.primary else Color.White.copy(alpha = 0.3f),
+                shape = RoundedCornerShape(8.dp),
+            )
+            .focusRequester(focusRequester)
+            .onFocusChanged { if (it.isFocused) controller.setActive(index) }
+            // clickable is itself focusable, so it's the single focus target (OK = make this tile dominant).
+            .clickable { controller.promoteToDominant(index) },
+    ) {
+        if (state == CornerState.ERROR) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("Couldn't play", style = MaterialTheme.typography.labelMedium, color = Color.White)
+            }
+        } else {
+            SecondaryVideoSurface(engine = engine, modifier = Modifier.fillMaxSize())
+        }
+        if (state == CornerState.LOADING) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                tv.own.owntv.ui.components.OwnTVSpinner(sizeDp = 22)
+            }
+        }
+        Row(
+            modifier = Modifier.align(Alignment.TopStart).fillMaxWidth()
+                .background(Brush.verticalGradient(listOf(Color.Black.copy(alpha = 0.6f), Color.Transparent)))
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(
+                if (active) "🔊" else "",
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.White,
+            )
+            Text(channel.name, style = MaterialTheme.typography.labelMedium, color = Color.White, maxLines = 1)
+        }
+    }
+}

--- a/app/src/main/java/tv/own/owntv/features/multiview/PipAudio.kt
+++ b/app/src/main/java/tv/own/owntv/features/multiview/PipAudio.kt
@@ -1,0 +1,29 @@
+package tv.own.owntv.features.multiview
+
+/**
+ * Which window should be muted while a picture-in-picture corner is on screen. Only **one** window is
+ * audible at a time (two simultaneous soundtracks would be cacophony). Pure + Android-free so the rule is
+ * unit-testable without spinning up real decoders.
+ *
+ * @property muteMain null = leave the main player's mute untouched (there is no main window present, e.g.
+ *   while browsing — touching it would interfere with normal playback); true/false = set it explicitly.
+ * @property muteCorner the corner engine's target mute state.
+ */
+data class PipAudioPlan(val muteMain: Boolean?, val muteCorner: Boolean)
+
+object PipAudio {
+    /**
+     * @param cornerActive  a corner stream is on screen.
+     * @param mainPresent   a main player (full-screen or docked) is also showing.
+     * @param audioOnCorner the user has handed the sound to the corner.
+     * @return the mute plan, or null when no corner is active (don't touch either engine — normal playback).
+     */
+    fun plan(cornerActive: Boolean, mainPresent: Boolean, audioOnCorner: Boolean): PipAudioPlan? = when {
+        !cornerActive -> null
+        // Browse with only a corner up → it's the only stream, so it gets the sound; leave the main alone.
+        !mainPresent -> PipAudioPlan(muteMain = null, muteCorner = false)
+        // Both windows present → exactly one is audible, per the user's choice.
+        audioOnCorner -> PipAudioPlan(muteMain = true, muteCorner = false)
+        else -> PipAudioPlan(muteMain = false, muteCorner = true)
+    }
+}

--- a/app/src/main/java/tv/own/owntv/features/multiview/PipController.kt
+++ b/app/src/main/java/tv/own/owntv/features/multiview/PipController.kt
@@ -1,0 +1,54 @@
+package tv.own.owntv.features.multiview
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import tv.own.owntv.core.database.entity.ChannelEntity
+import tv.own.owntv.player.CornerEngine
+import tv.own.owntv.player.MediaMeta
+
+/**
+ * App-wide state for the **picture-in-picture corner window** — the second simultaneous stream. Owns the
+ * corner [CornerEngine] (its decoder) and tracks which channel the corner is on, so the shell can mount a
+ * persistent corner overlay that survives moving between the browse UI and full-screen.
+ *
+ * This is intentionally thin: it starts/stops the corner stream and remembers the corner channel. Audio
+ * arbitration (only one window audible at a time) and the swap-with-main gesture are orchestrated by the
+ * shell, which is the only place that knows what the *main* player is currently doing (mpv vs ExoPlayer).
+ *
+ * A single corner today (true PiP = 1 + 1). The same controller generalises to the 2×2 MultiView grid
+ * later by holding a list of engines instead of one.
+ */
+class PipController(val engine: CornerEngine) {
+
+    private val _active = MutableStateFlow(false)
+    /** True while a corner window is on screen (a second stream is running). */
+    val active: StateFlow<Boolean> = _active.asStateFlow()
+
+    private val _channel = MutableStateFlow<ChannelEntity?>(null)
+    /** The channel playing in the corner (for its title, and to swap it into the main window). */
+    val channel: StateFlow<ChannelEntity?> = _channel.asStateFlow()
+
+    /** Open [channel] in the corner (or switch the corner to it). Starts muted so the main stream keeps the
+     *  sound; the user hands audio to the corner explicitly. No-op-safe to call repeatedly with the same one. */
+    fun openCorner(channel: ChannelEntity, muted: Boolean = true) {
+        _channel.value = channel
+        _active.value = true
+        if (engine.currentUrl != channel.streamUrl) {
+            engine.play(
+                channel.streamUrl,
+                meta = MediaMeta(title = channel.name, logoUrl = channel.logoUrl),
+                muted = muted,
+            )
+        } else {
+            engine.setMuted(muted)
+        }
+    }
+
+    /** Close the corner window and free its decoder/connection. */
+    fun closeCorner() {
+        _active.value = false
+        _channel.value = null
+        engine.stop()
+    }
+}

--- a/app/src/main/java/tv/own/owntv/features/shell/OwnTVShell.kt
+++ b/app/src/main/java/tv/own/owntv/features/shell/OwnTVShell.kt
@@ -121,6 +121,11 @@ fun OwnTVShell(
     // Which section armed the current fullscreen stream — picks whose channel list CH+/CH- step through.
     var zapSource by remember { mutableStateOf<MainSection?>(null) }
 
+    // MultiView (PR #2): up to four live tiles. Channels to add come from the recently-watched list.
+    val mv = koinInject<tv.own.owntv.features.multiview.MultiViewController>()
+    val mvActive by mv.active.collectAsStateWithLifecycle()
+    val recentChannels by liveVm.recentlyWatched.collectAsStateWithLifecycle()
+
     // Opening content from a browse screen goes fullscreen — UNLESS the player is already docked as a
     // mini-player, in which case it stays docked and just swaps to the newly-selected stream (the VM
     // already started it), so picking a channel updates the PiP window in place (#6).
@@ -171,6 +176,25 @@ fun OwnTVShell(
         }
         Unit
     }
+    // Enter MultiView seeded with [channel] (plus the PiP corner channel, if one is up). Stops the single-
+    // stream players so ONLY MultiView's tile engines run — no main decoder competing with the tiles.
+    val enterMultiView: (tv.own.owntv.core.database.entity.ChannelEntity) -> Unit = { channel ->
+        val seed = buildList {
+            add(channel)
+            cornerChannel?.let { if (it.id != channel.id) add(it) }
+        }
+        pip.closeCorner(); audioOnCorner = false
+        liveVm.clearLiveOnExo() // stop the live ExoPlayer (preview/main)
+        player.stop()           // stop mpv (VOD), if it was the main
+        playerMode = PlayerMode.NONE
+        mv.enter(seed)
+    }
+    val exitMultiView = {
+        mv.exit()
+        restoreFocus = true
+        runCatching { sidebarFocus.requestFocus() }
+        Unit
+    }
     // Browse: promote the corner channel to full-screen, closing the corner.
     val expandCorner = {
         cornerChannel?.let { ch ->
@@ -213,8 +237,9 @@ fun OwnTVShell(
     }
 
     Box(modifier = modifier.fillMaxSize().background(colors.background)) {
-      // Browse UI — hidden while the player is fullscreen (stays visible behind the docked mini-player).
-      if (playerMode != PlayerMode.FULLSCREEN) {
+      // Browse UI — hidden while the player is fullscreen (stays visible behind the docked mini-player) and
+      // while MultiView owns the screen (so its hidden Live preview decoder doesn't run behind the tiles).
+      if (playerMode != PlayerMode.FULLSCREEN && !mvActive) {
         Column(modifier = Modifier.fillMaxSize()) {
           if (isOffline) OfflineBanner()
           Row(modifier = Modifier.weight(1f).fillMaxWidth()) {
@@ -265,6 +290,7 @@ fun OwnTVShell(
                         previewEnabled = playerMode == PlayerMode.NONE,
                         restoreFocus = restoreFocus,
                         onRestored = { restoreFocus = false },
+                        onOpenMultiView = enterMultiView,
                         modifier = Modifier.fillMaxSize(),
                     )
 
@@ -398,6 +424,17 @@ fun OwnTVShell(
                 MiniPlayer(player = if (liveOnExo) liveVm.previewEngine else mpvEngine, onExpand = expandPlayer, onClose = exitPlayer, modifier = Modifier.fillMaxSize())
             }
         }
+      }
+
+      // MultiView — up to four live tiles, full-screen above everything. The single-stream players were
+      // stopped on entry, so only the tile engines run; exiting releases them all.
+      if (mvActive) {
+        tv.own.owntv.features.multiview.MultiViewScreen(
+            controller = mv,
+            addableChannels = recentChannels,
+            onExit = exitMultiView,
+            modifier = Modifier.fillMaxSize(),
+        )
       }
 
       // True picture-in-picture corner — a second, independent stream in the upper-right corner, drawn over

--- a/app/src/main/java/tv/own/owntv/features/shell/OwnTVShell.kt
+++ b/app/src/main/java/tv/own/owntv/features/shell/OwnTVShell.kt
@@ -98,6 +98,13 @@ fun OwnTVShell(
     var restoreFocus by remember { mutableStateOf(false) }
     val player = koinInject<OwnTVPlayer>()
     val mpvEngine = remember(player) { tv.own.owntv.player.MpvPlaybackEngine(player) }
+    // True picture-in-picture: a second, independent stream in a corner window, mounted at the shell's top
+    // level so it persists across the browse UI <-> full-screen. Audio belongs to one window at a time —
+    // by default the main stream, until the user hands sound to the corner (audioOnCorner).
+    val pip = koinInject<tv.own.owntv.features.multiview.PipController>()
+    val cornerActive by pip.active.collectAsStateWithLifecycle()
+    val cornerChannel by pip.channel.collectAsStateWithLifecycle()
+    var audioOnCorner by remember { mutableStateOf(false) }
     // Same activity-scoped instances the Live/Guide screens use — lets the fullscreen HUD zap channels
     // up/down (CH+/CH-) through whichever section's list opened the stream.
     val liveVm = org.koin.androidx.compose.koinViewModel<tv.own.owntv.features.live.LiveViewModel>()
@@ -138,6 +145,54 @@ fun OwnTVShell(
         restoreFocus = true
         runCatching { sidebarFocus.requestFocus() }
         Unit
+    }
+
+    // --- True PiP corner: audio arbitration + window gestures -------------------------------------
+    // Mute/unmute the main stream regardless of which engine owns it (promoted-live ExoPlayer vs mpv).
+    val setMainMuted: (Boolean) -> Unit = { muted ->
+        if (liveOnExo) liveVm.previewEngine.setMuted(muted) else player.setMuted(muted)
+    }
+    val closeCorner = {
+        setMainMuted(false) // hand the sound back to the main window
+        audioOnCorner = false
+        pip.closeCorner()
+        Unit
+    }
+    val toggleCornerAudio = { audioOnCorner = !audioOnCorner }
+    // Full-screen swap (live main only): exchange the corner stream with the main one.
+    val swapCorner = {
+        val cornerCh = cornerChannel
+        val mainCh = liveVm.previewChannel.value
+        if (cornerCh != null && mainCh != null) {
+            pip.openCorner(mainCh)         // old main → corner (starts muted)
+            zapSource = MainSection.LIVE_TV
+            liveVm.ensurePlaying(cornerCh) // old corner → main window
+            audioOnCorner = false          // sound follows the (new) main window
+        }
+        Unit
+    }
+    // Browse: promote the corner channel to full-screen, closing the corner.
+    val expandCorner = {
+        cornerChannel?.let { ch ->
+            audioOnCorner = false
+            pip.closeCorner()
+            zapSource = MainSection.LIVE_TV
+            onSelectSection(MainSection.LIVE_TV)
+            liveVm.watchFullscreen(ch, listOf(ch))
+            playerMode = PlayerMode.FULLSCREEN
+        }
+        Unit
+    }
+    // Only one window is audible at a time. The decision is a pure function (PipAudio) so it's unit-tested;
+    // a null plan (no corner) leaves both engines untouched, so normal playback never has its mute changed.
+    LaunchedEffect(cornerActive, audioOnCorner, playerMode, liveOnExo) {
+        val plan = tv.own.owntv.features.multiview.PipAudio.plan(
+            cornerActive = cornerActive,
+            mainPresent = playerMode != PlayerMode.NONE,
+            audioOnCorner = audioOnCorner,
+        ) ?: return@LaunchedEffect
+        plan.muteMain?.let { setMainMuted(it) }
+        pip.engine.setMuted(plan.muteCorner)
     }
 
     LaunchedEffect(Unit) { runCatching { sidebarFocus.requestFocus() } }
@@ -330,11 +385,37 @@ fun OwnTVShell(
                     onGoToLive = if (isLiveChannel) liveVm::goToLive else null,
                     onScrubLive = if (isLiveChannel && canRewindLive) liveVm::scrubLive else null,
                     timeshiftOffsetSec = if (isLiveChannel) timeshiftOffset else null,
+                    // True PiP corner controls — present only while a second stream is in the corner.
+                    // Swap is offered only when the main stream is a promoted live channel (both ExoPlayer),
+                    // so the exchange is clean; audio/close are always available with a corner up.
+                    onCornerSwap = if (cornerActive && liveOnExo) swapCorner else null,
+                    onCornerAudio = if (cornerActive) toggleCornerAudio else null,
+                    onCornerClose = if (cornerActive) closeCorner else null,
+                    cornerAudioOn = audioOnCorner,
                     modifier = Modifier.fillMaxSize(),
                 )
             } else {
                 MiniPlayer(player = if (liveOnExo) liveVm.previewEngine else mpvEngine, onExpand = expandPlayer, onClose = exitPlayer, modifier = Modifier.fillMaxSize())
             }
+        }
+      }
+
+      // True picture-in-picture corner — a second, independent stream in the upper-right corner, drawn over
+      // both the browse UI and the full-screen player (its SurfaceView is z-ordered above the main surface).
+      // While full-screen the player HUD owns the corner's controls, so the window itself is video-only then.
+      if (cornerActive) {
+        Box(
+            modifier = Modifier.align(Alignment.TopEnd).padding(24.dp).size(width = 320.dp, height = 180.dp),
+        ) {
+            tv.own.owntv.player.PipCornerWindow(
+                engine = pip.engine,
+                showControls = playerMode != PlayerMode.FULLSCREEN,
+                audioOnCorner = audioOnCorner,
+                onToggleAudio = toggleCornerAudio,
+                onSwap = expandCorner, // window's expand button promotes the corner channel to full-screen
+                onClose = closeCorner,
+                modifier = Modifier.fillMaxSize(),
+            )
         }
       }
 

--- a/app/src/main/java/tv/own/owntv/player/CornerEngine.kt
+++ b/app/src/main/java/tv/own/owntv/player/CornerEngine.kt
@@ -22,6 +22,9 @@ interface CornerEngine {
 
     fun play(url: String, meta: MediaMeta = MediaMeta(), muted: Boolean = true)
     fun setMuted(muted: Boolean)
+    /** Stop playback and free the decoder/connection, keeping the instance for reuse. */
     fun stop()
+    /** Fully tear down the underlying player and free all its memory (used when a tile is gone for good). */
+    fun release()
     fun setSurface(surface: Surface?)
 }

--- a/app/src/main/java/tv/own/owntv/player/CornerEngine.kt
+++ b/app/src/main/java/tv/own/owntv/player/CornerEngine.kt
@@ -1,0 +1,27 @@
+package tv.own.owntv.player
+
+import android.view.Surface
+import kotlinx.coroutines.flow.StateFlow
+
+/** Playback state of the picture-in-picture corner stream. */
+enum class CornerState { IDLE, LOADING, PLAYING, ERROR }
+
+/**
+ * The picture-in-picture corner's video engine, abstracted so the orchestration ([tv.own.owntv.features.
+ * multiview.PipController]) and UI bind to an interface rather than the concrete ExoPlayer wrapper. This
+ * keeps the corner logic unit-testable with a lightweight fake — no Android, no ExoPlayer, no device — which
+ * is also the cheapest way to verify it (a second real decoder is exactly what we *don't* want to spin up in
+ * a test). [SecondaryLivePlayer] is the production implementation.
+ */
+interface CornerEngine {
+    val state: StateFlow<CornerState>
+    val meta: StateFlow<MediaMeta>
+
+    /** URL the corner is currently on (null when stopped) — lets the controller skip a redundant reload. */
+    val currentUrl: String?
+
+    fun play(url: String, meta: MediaMeta = MediaMeta(), muted: Boolean = true)
+    fun setMuted(muted: Boolean)
+    fun stop()
+    fun setSurface(surface: Surface?)
+}

--- a/app/src/main/java/tv/own/owntv/player/PipCorner.kt
+++ b/app/src/main/java/tv/own/owntv/player/PipCorner.kt
@@ -37,9 +37,9 @@ import tv.own.owntv.ui.components.OwnTVIcon
  * surface (`setZOrderMediaOverlay(true)`) so the corner draws on top of the full-screen stream behind it.
  *
  * Two overlapping SurfaceViews are the right tool here: both are hardware-overlay candidates, so on a TV
- * with ≥2 overlay planes (most) neither stream falls back to GPU composition. (mpv documents that putting
- * a *regular* view over its surface knocks 4K off the direct path — a second SurfaceView avoids that on
- * capable hardware; on a single-plane device the compositor blends them, which still works, just warmer.)
+ * with ≥2 overlay planes (most) neither stream falls back to GPU composition. (Both engines document that a
+ * *regular* view over a video surface knocks 4K off the direct scan-out path — a second SurfaceView avoids
+ * that on capable hardware; on a single-plane device the compositor blends them, which still works, warmer.)
  */
 @Composable
 fun SecondaryVideoSurface(engine: CornerEngine, modifier: Modifier = Modifier, keepAwake: Boolean = true) {

--- a/app/src/main/java/tv/own/owntv/player/PipCorner.kt
+++ b/app/src/main/java/tv/own/owntv/player/PipCorner.kt
@@ -1,0 +1,159 @@
+@file:OptIn(androidx.media3.common.util.UnstableApi::class)
+
+package tv.own.owntv.player
+
+import android.view.SurfaceHolder
+import android.view.SurfaceView
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import tv.own.owntv.ui.components.FocusableSurface
+import tv.own.owntv.ui.components.OwnTVIcon
+
+/**
+ * Hosts the [CornerEngine]'s video on its own [SurfaceView], **z-ordered above** the main player's
+ * surface (`setZOrderMediaOverlay(true)`) so the corner draws on top of the full-screen stream behind it.
+ *
+ * Two overlapping SurfaceViews are the right tool here: both are hardware-overlay candidates, so on a TV
+ * with ≥2 overlay planes (most) neither stream falls back to GPU composition. (mpv documents that putting
+ * a *regular* view over its surface knocks 4K off the direct path — a second SurfaceView avoids that on
+ * capable hardware; on a single-plane device the compositor blends them, which still works, just warmer.)
+ */
+@Composable
+fun SecondaryVideoSurface(engine: CornerEngine, modifier: Modifier = Modifier, keepAwake: Boolean = true) {
+    AndroidView(
+        modifier = modifier,
+        factory = { ctx ->
+            SurfaceView(ctx).apply {
+                // Must be set before the surface is created — lifts this surface above the main one behind it.
+                setZOrderMediaOverlay(true)
+                holder.addCallback(object : SurfaceHolder.Callback {
+                    override fun surfaceCreated(holder: SurfaceHolder) = engine.setSurface(holder.surface)
+                    override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {}
+                    override fun surfaceDestroyed(holder: SurfaceHolder) = engine.setSurface(null)
+                })
+            }
+        },
+        update = { it.keepScreenOn = keepAwake },
+    )
+}
+
+/**
+ * The picture-in-picture corner window: the second stream's video in a rounded, bordered box with a title
+ * and a loading spinner, plus — when [showControls] is set — a focusable D-pad control row (audio · swap ·
+ * close). During the browse UI the corner carries its own controls (navigate to it with the remote, like
+ * the docked mini-player); while the main player is full-screen the player HUD drives these instead, so the
+ * corner is rendered video-only ([showControls] = false).
+ */
+@Composable
+fun PipCornerWindow(
+    engine: CornerEngine,
+    showControls: Boolean,
+    audioOnCorner: Boolean,
+    onToggleAudio: () -> Unit,
+    onSwap: () -> Unit,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by engine.state.collectAsStateWithLifecycle()
+    val meta by engine.meta.collectAsStateWithLifecycle()
+    val loading = state == CornerState.LOADING
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(Color.Black)
+            .border(
+                width = if (audioOnCorner) 2.dp else 1.dp,
+                color = if (audioOnCorner) tv.own.owntv.ui.theme.OwnTVTheme.colors.primary else Color.White.copy(alpha = 0.35f),
+                shape = RoundedCornerShape(12.dp),
+            ),
+    ) {
+        if (state == CornerState.ERROR) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("Couldn't play", style = MaterialTheme.typography.labelMedium, color = Color.White)
+            }
+        } else {
+            SecondaryVideoSurface(engine = engine, modifier = Modifier.fillMaxSize())
+        }
+        if (loading) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                tv.own.owntv.ui.components.OwnTVSpinner(sizeDp = 22)
+            }
+        }
+
+        // Title strip (top) — channel name on a slight scrim, with a small "PiP" marker.
+        Row(
+            modifier = Modifier.align(Alignment.TopStart).fillMaxWidth()
+                .background(Brush.verticalGradient(listOf(Color.Black.copy(alpha = 0.6f), Color.Transparent)))
+                .padding(horizontal = 8.dp, vertical = 5.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(
+                if (audioOnCorner) "PiP · 🔊" else "PiP",
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.White.copy(alpha = 0.8f),
+            )
+            Text(
+                meta.title ?: "",
+                style = MaterialTheme.typography.labelMedium,
+                color = Color.White,
+                maxLines = 1,
+            )
+        }
+
+        if (showControls) {
+            Row(
+                modifier = Modifier.align(Alignment.BottomStart).fillMaxWidth()
+                    .background(Brush.verticalGradient(listOf(Color.Transparent, Color.Black.copy(alpha = 0.75f))))
+                    .padding(8.dp).focusGroup(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                PipBtn(if (audioOnCorner) OwnTVIcon.VOLUME_HIGH else OwnTVIcon.VOLUME_MUTE, onClick = onToggleAudio)
+                Spacer(Modifier.weight(1f))
+                PipBtn(OwnTVIcon.FULLSCREEN, onClick = onSwap) // swap the corner stream into the main window
+                PipBtn(OwnTVIcon.CLOSE, onClick = onClose)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PipBtn(icon: OwnTVIcon, onClick: () -> Unit) {
+    FocusableSurface(
+        onClick = onClick,
+        modifier = Modifier.size(32.dp),
+        shape = CircleShape,
+        focusedScale = 1.12f,
+        focusedContainerColor = Color.White.copy(alpha = 0.28f),
+        unfocusedContainerColor = Color.White.copy(alpha = 0.12f),
+        selectedContainerColor = Color.White.copy(alpha = 0.12f),
+        contentAlignment = Alignment.Center,
+    ) { _ ->
+        OwnTVIcon(icon, tint = Color.White, filled = true, modifier = Modifier.size(16.dp))
+    }
+}

--- a/app/src/main/java/tv/own/owntv/player/PlayerHud.kt
+++ b/app/src/main/java/tv/own/owntv/player/PlayerHud.kt
@@ -78,6 +78,12 @@ fun PlayerHud(
     onGoToLive: (() -> Unit)? = null,
     onScrubLive: ((Int) -> Unit)? = null, // timeline scrub: +sec = back, −sec = toward live
     timeshiftOffsetSec: Int? = null,
+    // True picture-in-picture corner controls — shown only while a second (corner) stream is running.
+    // onCornerClose non-null = a corner is active; cornerAudioOn = the corner currently has the sound.
+    onCornerSwap: (() -> Unit)? = null,   // swap the corner stream into the main window (and vice versa)
+    onCornerAudio: (() -> Unit)? = null,  // move the audio between the main and corner windows
+    onCornerClose: (() -> Unit)? = null,  // close the corner window
+    cornerAudioOn: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     val isPlaying by player.isPlaying.collectAsStateWithLifecycle()
@@ -173,6 +179,8 @@ fun PlayerHud(
                     speedLabel = formatSpeed(speed),
                     onScrubLive = onScrubLive, timeshiftOffsetSec = timeshiftOffsetSec,
                     onOpenDialog = { dialog = it }, onPip = onPip, onBack = onBack,
+                    onCornerSwap = onCornerSwap, onCornerAudio = onCornerAudio, onCornerClose = onCornerClose,
+                    cornerAudioOn = cornerAudioOn,
                     modifier = Modifier.align(Alignment.BottomStart),
                 )
             }
@@ -337,7 +345,10 @@ private fun BottomBar(
     player: PlaybackEngine, isLive: Boolean, position: Long, duration: Long,
     volume: Int, audioCount: Int, subCount: Int, zoomMode: ZoomMode, speedLabel: String,
     onScrubLive: ((Int) -> Unit)?, timeshiftOffsetSec: Int?,
-    onOpenDialog: (HudDialog) -> Unit, onPip: (() -> Unit)?, onBack: () -> Unit, modifier: Modifier = Modifier,
+    onOpenDialog: (HudDialog) -> Unit, onPip: (() -> Unit)?, onBack: () -> Unit,
+    onCornerSwap: (() -> Unit)? = null, onCornerAudio: (() -> Unit)? = null, onCornerClose: (() -> Unit)? = null,
+    cornerAudioOn: Boolean = false,
+    modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.fillMaxWidth().padding(horizontal = 28.dp, vertical = 20.dp)) {
         when {
@@ -368,6 +379,14 @@ private fun BottomBar(
                 // Aspect/zoom works in every mode now — direct mode resizes the surface view itself
                 // (see MpvVideoSurface), GL mode scales internally.
                 CtrlButton(OwnTVIcon.ASPECT, active = zoomMode != ZoomMode.FIT) { onOpenDialog(HudDialog.ZOOM) }
+                // Corner (true PiP) controls — present only while a second stream is in the corner.
+                if (onCornerClose != null) {
+                    if (onCornerAudio != null) {
+                        CtrlButton(if (cornerAudioOn) OwnTVIcon.VOLUME_HIGH else OwnTVIcon.VOLUME_MUTE, active = cornerAudioOn) { onCornerAudio?.invoke() }
+                    }
+                    if (onCornerSwap != null) CtrlButton(OwnTVIcon.PIP, active = true) { onCornerSwap?.invoke() }
+                    CtrlButton(OwnTVIcon.CLOSE) { onCornerClose?.invoke() }
+                }
                 if (onPip != null) CtrlButton(OwnTVIcon.PIP) { onPip() }
                 CtrlButton(OwnTVIcon.FULLSCREEN_EXIT) { onBack() }
             }

--- a/app/src/main/java/tv/own/owntv/player/SecondaryLivePlayer.kt
+++ b/app/src/main/java/tv/own/owntv/player/SecondaryLivePlayer.kt
@@ -1,0 +1,196 @@
+package tv.own.owntv.player
+
+import android.content.Context
+import android.view.Surface
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.common.VideoSize
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.okhttp.OkHttpDataSource
+import androidx.media3.exoplayer.DefaultLoadControl
+import androidx.media3.exoplayer.DefaultRenderersFactory
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import okhttp3.OkHttpClient
+import tv.own.owntv.core.network.HttpClient
+
+/**
+ * A **second**, independent ExoPlayer that drives the picture-in-picture corner window — the half of
+ * "true PiP" that lets you watch a different stream alongside the main one. It is deliberately separate
+ * from [LivePreviewEngine] (which is busy being the in-pane preview / promoted-fullscreen live engine):
+ * the two never share a player, a surface, or audio focus, so both can decode at once.
+ *
+ * ExoPlayer (not mpv) for the corner because a second mpv context would be heavy and invasive, whereas
+ * ExoPlayer instances are light and independently constructable — the same reasoning that put the live
+ * preview on ExoPlayer. mpv stays the single full-screen player, untouched.
+ *
+ * Scope: **live channels only** for now (no VOD seek/resume state). Like the other engines, all calls
+ * must be on the main thread (ExoPlayer is single-threaded); the corner surface attaches/detaches its
+ * [Surface] from the holder callback and the controller calls [play]/[stop]/[setMuted] from the UI.
+ *
+ * Memory note: a second decoder competes for the device's player budget (see [PlayerBudget] — TV-class
+ * boxes get OOM-killed at a few hundred MB PSS). Buffers here are intentionally shallow, and the corner
+ * is a single extra stream (not four), which real Android TV hardware comfortably handles in practice.
+ */
+@UnstableApi
+class SecondaryLivePlayer(
+    private val context: Context,
+    private val okHttpClient: OkHttpClient,
+    private val diagnostics: PlayerDiagnostics,
+) : CornerEngine {
+
+    private var player: ExoPlayer? = null
+    private var surface: Surface? = null
+    private var muted: Boolean = true
+
+    private val _state = MutableStateFlow(CornerState.IDLE)
+    override val state: StateFlow<CornerState> = _state.asStateFlow()
+    private val _isPlaying = MutableStateFlow(false)
+    val isPlaying: StateFlow<Boolean> = _isPlaying.asStateFlow()
+    private val _buffering = MutableStateFlow(false)
+    val buffering: StateFlow<Boolean> = _buffering.asStateFlow()
+    private val _videoHeight = MutableStateFlow<Int?>(null)
+    val videoHeight: StateFlow<Int?> = _videoHeight.asStateFlow()
+    private val _meta = MutableStateFlow(MediaMeta())
+    override val meta: StateFlow<MediaMeta> = _meta.asStateFlow()
+
+    /** URL the corner is currently on (null when stopped) — lets the controller skip a redundant reload. */
+    override var currentUrl: String? = null
+        private set
+
+    // Live auto-reconnect — a channel that played and then dropped (provider hiccup / Wi-Fi blip) re-fetches
+    // from the live edge instead of dead-ending, mirroring LivePreviewEngine but simpler (no track menus).
+    private val mainHandler = android.os.Handler(android.os.Looper.getMainLooper())
+    private var hasPlayed = false
+    private var retryCount = 0
+    private val stallWatchdog = Runnable { reconnect("buffering stalled") }
+
+    private val listener = object : Player.Listener {
+        override fun onPlaybackStateChanged(playbackState: Int) {
+            when (playbackState) {
+                Player.STATE_BUFFERING -> {
+                    _state.value = CornerState.LOADING; _buffering.value = true
+                    if (hasPlayed) { mainHandler.removeCallbacks(stallWatchdog); mainHandler.postDelayed(stallWatchdog, STALL_MS) }
+                }
+                Player.STATE_READY -> {
+                    _state.value = CornerState.PLAYING; _buffering.value = false
+                    hasPlayed = true; retryCount = 0; mainHandler.removeCallbacks(stallWatchdog)
+                }
+                else -> { _buffering.value = false; mainHandler.removeCallbacks(stallWatchdog) }
+            }
+        }
+
+        override fun onIsPlayingChanged(isPlaying: Boolean) { _isPlaying.value = isPlaying }
+
+        override fun onVideoSizeChanged(videoSize: VideoSize) {
+            if (videoSize.height > 0) _videoHeight.value = videoSize.height
+        }
+
+        override fun onPlayerError(error: PlaybackException) {
+            android.util.Log.w(TAG, "corner ExoPlayer error: ${error.errorCodeName}", error)
+            if (hasPlayed) { reconnect("error ${error.errorCodeName}"); return } // mid-stream drop → reconnect
+            _state.value = CornerState.ERROR; _isPlaying.value = false; _buffering.value = false
+        }
+    }
+
+    /** Attach the corner SurfaceView's surface, or null when it's destroyed. */
+    override fun setSurface(s: Surface?) {
+        surface = s
+        if (s != null) player?.setVideoSurface(s) else player?.clearVideoSurface()
+    }
+
+    /** Start (or switch to) [url] in the corner. Starts muted by default — the main stream keeps the audio
+     *  until the user explicitly hands sound to the corner. Never throws: a stream ExoPlayer can't open just
+     *  shows the error state (the corner is best-effort; the main player is unaffected either way). */
+    override fun play(url: String, meta: MediaMeta, muted: Boolean) {
+        diagnostics.start(); diagnostics.markLoad()
+        this.muted = muted
+        currentUrl = url
+        hasPlayed = false; retryCount = 0; mainHandler.removeCallbacks(stallWatchdog)
+        _videoHeight.value = null
+        _meta.value = meta
+        _state.value = CornerState.LOADING
+        _buffering.value = true
+        runCatching {
+            val p = player ?: build().also { player = it }
+            surface?.let { p.setVideoSurface(it) }
+            p.volume = if (muted) 0f else 1f
+            p.setMediaItem(MediaItem.fromUri(url))
+            p.prepare()
+            p.playWhenReady = true
+        }.onFailure {
+            android.util.Log.w(TAG, "corner play() failed for $url", it)
+            _state.value = CornerState.ERROR
+        }
+    }
+
+    override fun setMuted(m: Boolean) {
+        muted = m
+        player?.volume = if (m) 0f else 1f
+    }
+
+    /** Stop playback and free the decoder/connection, keeping the instance for the next corner channel. */
+    override fun stop() {
+        currentUrl = null
+        hasPlayed = false; retryCount = 0; mainHandler.removeCallbacks(stallWatchdog)
+        _videoHeight.value = null
+        _isPlaying.value = false
+        _buffering.value = false
+        _state.value = CornerState.IDLE
+        player?.run { stop(); clearMediaItems() }
+    }
+
+    fun release() {
+        mainHandler.removeCallbacks(stallWatchdog)
+        player?.run { removeListener(listener); release() }
+        player = null
+        surface = null
+        currentUrl = null
+        _state.value = CornerState.IDLE
+    }
+
+    private fun reconnect(reason: String) {
+        mainHandler.removeCallbacks(stallWatchdog)
+        val p = player
+        val url = currentUrl
+        if (p == null || url == null || retryCount >= MAX_RECONNECTS) {
+            _state.value = CornerState.ERROR; _isPlaying.value = false; _buffering.value = false
+            return
+        }
+        retryCount++
+        _state.value = CornerState.LOADING; _buffering.value = true
+        android.util.Log.w(TAG, "corner reconnect ($reason) — attempt $retryCount/$MAX_RECONNECTS")
+        mainHandler.postDelayed({
+            if (currentUrl != url) return@postDelayed // superseded (channel changed / closed)
+            runCatching {
+                p.setMediaItem(MediaItem.fromUri(url)) // fresh fetch (live edge)
+                p.prepare()
+                p.playWhenReady = true
+            }.onFailure { _state.value = CornerState.ERROR }
+        }, (1500L * retryCount).coerceAtMost(4000L))
+    }
+
+    private fun build(): ExoPlayer {
+        val dataSource = OkHttpDataSource.Factory(okHttpClient).setUserAgent(HttpClient.DEFAULT_USER_AGENT)
+        // Shallow buffers — the corner only needs to start quickly, not buffer deep (keeps memory down).
+        val loadControl = DefaultLoadControl.Builder()
+            .setBufferDurationsMs(2_000, 8_000, 1_000, 2_000)
+            .build()
+        return ExoPlayer.Builder(context)
+            .setRenderersFactory(DefaultRenderersFactory(context))
+            .setMediaSourceFactory(DefaultMediaSourceFactory(dataSource))
+            .setLoadControl(loadControl)
+            .build()
+            .apply { addListener(listener) }
+    }
+
+    companion object {
+        private const val TAG = "SecondaryLivePlayer"
+        private const val MAX_RECONNECTS = 6
+        private const val STALL_MS = 12_000L
+    }
+}

--- a/app/src/main/java/tv/own/owntv/player/SecondaryLivePlayer.kt
+++ b/app/src/main/java/tv/own/owntv/player/SecondaryLivePlayer.kt
@@ -33,7 +33,7 @@ import tv.own.owntv.core.network.HttpClient
  * independently constructable, and it matches whatever the live main is already doing.
  *
  * Coexistence: two ExoPlayers competing for the device's scarce hardware decoders / single audio-passthrough
- * path is the real risk on TV hardware, so [build] constrains this corner — a 720p resolution-cap selection
+ * path is the real risk on TV hardware, so [build] constrains this corner — a resolution-cap track-selection
  * hint (picks a lower rendition when the stream is adaptive; a no-op, never a transcode, when it isn't),
  * stereo/AAC audio (no surround passthrough), subtitles disabled, **software-decoder fallback** (the real
  * safeguard when no second hardware decoder is free), and it never takes audio focus. That keeps the surround
@@ -52,6 +52,9 @@ class SecondaryLivePlayer(
     private val context: Context,
     private val okHttpClient: OkHttpClient,
     private val diagnostics: PlayerDiagnostics,
+    /** Resolution cap for this instance. 720p suits a single PiP corner; MultiView tiles pass a smaller cap
+     *  (a quarter-screen tile never needs more) so up to four concurrent decoders stay within the budget. */
+    private val maxVideoHeight: Int = 720,
 ) : CornerEngine {
 
     private var player: ExoPlayer? = null
@@ -155,7 +158,7 @@ class SecondaryLivePlayer(
         player?.run { stop(); clearMediaItems() }
     }
 
-    fun release() {
+    override fun release() {
         mainHandler.removeCallbacks(stallWatchdog)
         player?.run { removeListener(listener); release() }
         player = null
@@ -194,17 +197,17 @@ class SecondaryLivePlayer(
         // The corner is a SECOND ExoPlayer running alongside the main one (which, for live, is also ExoPlayer).
         // It's deliberately constrained so the two instances coexist on real TV hardware, where concurrent
         // hardware decoders / audio passthrough are scarce:
-        //  • Cap the corner to 720p30. This is a track-SELECTION hint, NOT transcoding: for an ADAPTIVE stream
-        //    (multi-variant HLS/DASH, common in IPTV) ExoPlayer picks a lower rendition the provider already
-        //    sends — a real saving (smaller decoder, less bandwidth). For a single-resolution stream there's
-        //    nothing lower to pick, so it decodes the full stream (the cap is a harmless no-op); the safeguard
-        //    there is decoder fallback below, plus the small surface (cheap HW downscale for display).
+        //  • Cap the video ([maxVideoHeight]p, 30fps). This is a track-SELECTION hint, NOT transcoding: for an
+        //    ADAPTIVE stream (multi-variant HLS/DASH, common in IPTV) ExoPlayer picks a lower rendition the
+        //    provider already sends — a real saving (smaller decoder, less bandwidth). For a single-resolution
+        //    stream there's nothing lower to pick, so it decodes the full stream (the cap is a harmless no-op);
+        //    the safeguard there is decoder fallback below, plus the small surface (cheap HW downscale).
         //  • Downmix to stereo + prefer AAC — the corner must not grab the single audio-passthrough path
         //    (AC3/E-AC3/DTS surround), so the main keeps its surround output intact.
         //  • No subtitles in the corner (it's a thumbnail) — avoids a second image-subtitle render path.
         val trackSelector = DefaultTrackSelector(context)
         trackSelector.parameters = trackSelector.buildUponParameters()
-            .setMaxVideoSize(1280, 720)
+            .setMaxVideoSize(maxVideoHeight * 16 / 9, maxVideoHeight)
             .setMaxVideoFrameRate(30)
             .setMaxAudioChannelCount(2)
             .setPreferredAudioMimeType(MimeTypes.AUDIO_AAC)

--- a/app/src/main/java/tv/own/owntv/player/SecondaryLivePlayer.kt
+++ b/app/src/main/java/tv/own/owntv/player/SecondaryLivePlayer.kt
@@ -2,7 +2,9 @@ package tv.own.owntv.player
 
 import android.content.Context
 import android.view.Surface
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MimeTypes
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.VideoSize
@@ -12,6 +14,7 @@ import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,20 +24,26 @@ import tv.own.owntv.core.network.HttpClient
 /**
  * A **second**, independent ExoPlayer that drives the picture-in-picture corner window — the half of
  * "true PiP" that lets you watch a different stream alongside the main one. It is deliberately separate
- * from [LivePreviewEngine] (which is busy being the in-pane preview / promoted-fullscreen live engine):
- * the two never share a player, a surface, or audio focus, so both can decode at once.
+ * from [LivePreviewEngine] (the in-pane preview / promoted-fullscreen live engine): the two never share a
+ * player, a surface, or audio focus, so both can decode at once.
  *
- * ExoPlayer (not mpv) for the corner because a second mpv context would be heavy and invasive, whereas
- * ExoPlayer instances are light and independently constructable — the same reasoning that put the live
- * preview on ExoPlayer. mpv stays the single full-screen player, untouched.
+ * Architecture: OwnTV's **live** full-screen player is ExoPlayer ([LivePreviewEngine] promoted; mpv is the
+ * fallback and the **VOD** full-screen player). So live PiP runs **two ExoPlayer instances** at once — the
+ * main one plus this corner. ExoPlayer (not a second mpv context) because instances are light and
+ * independently constructable, and it matches whatever the live main is already doing.
  *
- * Scope: **live channels only** for now (no VOD seek/resume state). Like the other engines, all calls
- * must be on the main thread (ExoPlayer is single-threaded); the corner surface attaches/detaches its
- * [Surface] from the holder callback and the controller calls [play]/[stop]/[setMuted] from the UI.
+ * Coexistence: two ExoPlayers competing for the device's scarce hardware decoders / single audio-passthrough
+ * path is the real risk on TV hardware, so [build] constrains this corner — capped to 720p30, stereo/AAC
+ * audio (no surround passthrough), subtitles disabled, software-decoder fallback enabled, and it never takes
+ * audio focus. That leaves the 4K/HDR hardware decoder and surround output to the main stream.
+ *
+ * Scope: **live channels only** for now (no VOD seek/resume state). Like the other engines, all calls must
+ * be on the main thread (ExoPlayer is single-threaded); the corner surface attaches/detaches its [Surface]
+ * from the holder callback and the controller calls [play]/[stop]/[setMuted] from the UI.
  *
  * Memory note: a second decoder competes for the device's player budget (see [PlayerBudget] — TV-class
- * boxes get OOM-killed at a few hundred MB PSS). Buffers here are intentionally shallow, and the corner
- * is a single extra stream (not four), which real Android TV hardware comfortably handles in practice.
+ * boxes get OOM-killed at a few hundred MB PSS). Buffers here are intentionally shallow, and the corner is
+ * a single capped-resolution extra stream, which real Android TV hardware handles in practice.
  */
 @UnstableApi
 class SecondaryLivePlayer(
@@ -180,12 +189,36 @@ class SecondaryLivePlayer(
         val loadControl = DefaultLoadControl.Builder()
             .setBufferDurationsMs(2_000, 8_000, 1_000, 2_000)
             .build()
+        // The corner is a SECOND ExoPlayer running alongside the main one (which, for live, is also ExoPlayer).
+        // It's deliberately constrained so the two instances coexist on real TV hardware, where concurrent
+        // hardware decoders / audio passthrough are scarce:
+        //  • Cap the corner to 720p30 — a small overlay never needs 4K, and it frees the 4K/HDR hardware
+        //    decoder for the main stream (two simultaneous 4K HEVC sessions exceed most TV SoCs).
+        //  • Downmix to stereo + prefer AAC — the corner must not grab the single audio-passthrough path
+        //    (AC3/E-AC3/DTS surround), so the main keeps its surround output intact.
+        //  • No subtitles in the corner (it's a thumbnail) — avoids a second image-subtitle render path.
+        val trackSelector = DefaultTrackSelector(context)
+        trackSelector.parameters = trackSelector.buildUponParameters()
+            .setMaxVideoSize(1280, 720)
+            .setMaxVideoFrameRate(30)
+            .setMaxAudioChannelCount(2)
+            .setPreferredAudioMimeType(MimeTypes.AUDIO_AAC)
+            .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true)
+            .build()
+        // Fall back to a software codec if no second hardware decoder is free, rather than failing the corner.
+        val renderers = DefaultRenderersFactory(context).setEnableDecoderFallback(true)
         return ExoPlayer.Builder(context)
-            .setRenderersFactory(DefaultRenderersFactory(context))
+            .setRenderersFactory(renderers)
+            .setTrackSelector(trackSelector)
             .setMediaSourceFactory(DefaultMediaSourceFactory(dataSource))
             .setLoadControl(loadControl)
             .build()
-            .apply { addListener(listener) }
+            .apply {
+                // Never take audio focus — the main player owns it. The corner is muted unless the user hands
+                // it the sound, and even then it shares the session without yanking focus from the main stream.
+                setAudioAttributes(androidx.media3.common.AudioAttributes.DEFAULT, /* handleAudioFocus = */ false)
+                addListener(listener)
+            }
     }
 
     companion object {

--- a/app/src/main/java/tv/own/owntv/player/SecondaryLivePlayer.kt
+++ b/app/src/main/java/tv/own/owntv/player/SecondaryLivePlayer.kt
@@ -33,9 +33,11 @@ import tv.own.owntv.core.network.HttpClient
  * independently constructable, and it matches whatever the live main is already doing.
  *
  * Coexistence: two ExoPlayers competing for the device's scarce hardware decoders / single audio-passthrough
- * path is the real risk on TV hardware, so [build] constrains this corner — capped to 720p30, stereo/AAC
- * audio (no surround passthrough), subtitles disabled, software-decoder fallback enabled, and it never takes
- * audio focus. That leaves the 4K/HDR hardware decoder and surround output to the main stream.
+ * path is the real risk on TV hardware, so [build] constrains this corner — a 720p resolution-cap selection
+ * hint (picks a lower rendition when the stream is adaptive; a no-op, never a transcode, when it isn't),
+ * stereo/AAC audio (no surround passthrough), subtitles disabled, **software-decoder fallback** (the real
+ * safeguard when no second hardware decoder is free), and it never takes audio focus. That keeps the surround
+ * output — and, for adaptive streams, the 4K/HDR hardware decoder — with the main stream.
  *
  * Scope: **live channels only** for now (no VOD seek/resume state). Like the other engines, all calls must
  * be on the main thread (ExoPlayer is single-threaded); the corner surface attaches/detaches its [Surface]
@@ -192,8 +194,11 @@ class SecondaryLivePlayer(
         // The corner is a SECOND ExoPlayer running alongside the main one (which, for live, is also ExoPlayer).
         // It's deliberately constrained so the two instances coexist on real TV hardware, where concurrent
         // hardware decoders / audio passthrough are scarce:
-        //  • Cap the corner to 720p30 — a small overlay never needs 4K, and it frees the 4K/HDR hardware
-        //    decoder for the main stream (two simultaneous 4K HEVC sessions exceed most TV SoCs).
+        //  • Cap the corner to 720p30. This is a track-SELECTION hint, NOT transcoding: for an ADAPTIVE stream
+        //    (multi-variant HLS/DASH, common in IPTV) ExoPlayer picks a lower rendition the provider already
+        //    sends — a real saving (smaller decoder, less bandwidth). For a single-resolution stream there's
+        //    nothing lower to pick, so it decodes the full stream (the cap is a harmless no-op); the safeguard
+        //    there is decoder fallback below, plus the small surface (cheap HW downscale for display).
         //  • Downmix to stereo + prefer AAC — the corner must not grab the single audio-passthrough path
         //    (AC3/E-AC3/DTS surround), so the main keeps its surround output intact.
         //  • No subtitles in the corner (it's a thumbnail) — avoids a second image-subtitle render path.
@@ -205,7 +210,9 @@ class SecondaryLivePlayer(
             .setPreferredAudioMimeType(MimeTypes.AUDIO_AAC)
             .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true)
             .build()
-        // Fall back to a software codec if no second hardware decoder is free, rather than failing the corner.
+        // The real coexistence safeguard: if no second HARDWARE decoder is free (TV SoCs typically allow only
+        // 1–2 concurrent), fall back to a SOFTWARE codec instead of failing the corner. SW decode costs CPU —
+        // the honest price of a second full-resolution stream when the provider offers no smaller rendition.
         val renderers = DefaultRenderersFactory(context).setEnableDecoderFallback(true)
         return ExoPlayer.Builder(context)
             .setRenderersFactory(renderers)

--- a/app/src/test/java/tv/own/owntv/features/multiview/MultiViewControllerTest.kt
+++ b/app/src/test/java/tv/own/owntv/features/multiview/MultiViewControllerTest.kt
@@ -1,0 +1,124 @@
+package tv.own.owntv.features.multiview
+
+import android.view.Surface
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tv.own.owntv.core.database.entity.ChannelEntity
+import tv.own.owntv.player.CornerEngine
+import tv.own.owntv.player.CornerState
+import tv.own.owntv.player.MediaMeta
+
+/**
+ * Verifies MultiView orchestration with fake engines — no real decoders. Focuses on the things that matter
+ * for correctness and for being light on resources: only the active tile is audible, the device tile cap is
+ * honoured, and **every tile is released on exit** (nothing keeps decoding in the background).
+ */
+class MultiViewControllerTest {
+
+    private class FakeEngine : CornerEngine {
+        override val state: StateFlow<CornerState> = MutableStateFlow(CornerState.IDLE)
+        override val meta: StateFlow<MediaMeta> = MutableStateFlow(MediaMeta())
+        override var currentUrl: String? = null
+        var muted = true
+        var released = false
+        var stops = 0
+        override fun play(url: String, meta: MediaMeta, muted: Boolean) { currentUrl = url; this.muted = muted }
+        override fun setMuted(muted: Boolean) { this.muted = muted }
+        override fun stop() { stops++; currentUrl = null }
+        override fun release() { released = true; currentUrl = null }
+        override fun setSurface(surface: Surface?) {}
+    }
+
+    /** A controller whose engines are fakes we can inspect (one fake per slot, created on demand). */
+    private fun controller(maxTiles: Int = 4): Pair<MultiViewController, List<FakeEngine>> {
+        val created = mutableListOf<FakeEngine>()
+        val c = MultiViewController(maxTiles = maxTiles, engineFactory = { FakeEngine().also { created += it } })
+        return c to created
+    }
+
+    private fun channel(id: Long, url: String) =
+        ChannelEntity(id = id, sourceId = 1, name = "Ch$id", streamUrl = url)
+
+    @Test
+    fun enter_startsTilesAndOnlyActiveIsAudible() {
+        val (c, engines) = controller()
+        c.enter(listOf(channel(1, "a"), channel(2, "b"), channel(3, "c")))
+
+        assertTrue(c.active.value)
+        assertEquals(3, c.tiles.value.size)
+        assertEquals(0, c.activeIndex.value)
+        // Exactly one engine (the active tile) is unmuted.
+        assertEquals(1, engines.count { !it.muted })
+        assertFalse("active tile must be audible", engines[0].muted)
+    }
+
+    @Test
+    fun setActive_movesAudioToTheFocusedTile() {
+        val (c, engines) = controller()
+        c.enter(listOf(channel(1, "a"), channel(2, "b")))
+
+        c.setActive(1)
+
+        assertEquals(1, c.activeIndex.value)
+        assertTrue("previously-active tile is muted", engines[0].muted)
+        assertFalse("newly-focused tile is audible", engines[1].muted)
+    }
+
+    @Test
+    fun promoteToDominant_setsActiveAndSwitchesLayout() {
+        val (c, _) = controller()
+        c.enter(listOf(channel(1, "a"), channel(2, "b")))
+
+        c.promoteToDominant(1)
+
+        assertEquals(1, c.activeIndex.value)
+        assertEquals(MultiLayout.DOMINANT, c.layout.value)
+    }
+
+    @Test
+    fun toggleLayout_flipsGridAndDominant() {
+        val (c, _) = controller()
+        c.enter(listOf(channel(1, "a")))
+        assertEquals(MultiLayout.GRID, c.layout.value)
+        c.toggleLayout(); assertEquals(MultiLayout.DOMINANT, c.layout.value)
+        c.toggleLayout(); assertEquals(MultiLayout.GRID, c.layout.value)
+    }
+
+    @Test
+    fun deviceCap_isHonoured_onEnterAndAdd() {
+        val (c, _) = controller(maxTiles = 2)
+        c.enter(listOf(channel(1, "a"), channel(2, "b"), channel(3, "c"))) // 3 offered, device allows 2
+        assertEquals(2, c.tiles.value.size)
+        assertFalse(c.canAddTile)
+        c.addTile(channel(4, "d")) // must be refused
+        assertEquals(2, c.tiles.value.size)
+    }
+
+    @Test
+    fun exit_releasesEveryTile_soNothingStreamsInBackground() {
+        val (c, engines) = controller()
+        c.enter(listOf(channel(1, "a"), channel(2, "b"), channel(3, "c")))
+
+        c.exit()
+
+        assertFalse(c.active.value)
+        assertTrue(c.tiles.value.isEmpty())
+        assertEquals("all three tile engines must be released", 3, engines.count { it.released })
+    }
+
+    @Test
+    fun removeTile_freesASlotAndKeepsOneAudible() {
+        val (c, _) = controller()
+        c.enter(listOf(channel(1, "a"), channel(2, "b"), channel(3, "c")))
+
+        c.removeTile(1)
+
+        assertEquals(2, c.tiles.value.size)
+        assertTrue(c.canAddTile) // back under the cap
+        assertTrue(c.active.value)
+    }
+}

--- a/app/src/test/java/tv/own/owntv/features/multiview/PipAudioTest.kt
+++ b/app/src/test/java/tv/own/owntv/features/multiview/PipAudioTest.kt
@@ -1,0 +1,44 @@
+package tv.own.owntv.features.multiview
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/** The "only one window is audible at a time" rule for true picture-in-picture. */
+class PipAudioTest {
+
+    @Test
+    fun noCorner_leavesBothEnginesAlone() {
+        // No corner → null plan, so the shell touches neither mute (normal playback is never disturbed).
+        assertNull(PipAudio.plan(cornerActive = false, mainPresent = false, audioOnCorner = false))
+        assertNull(PipAudio.plan(cornerActive = false, mainPresent = true, audioOnCorner = true))
+    }
+
+    @Test
+    fun browseOnlyCorner_cornerIsAudible_mainUntouched() {
+        // Browsing with just a corner up: it's the only stream, so it gets the sound; main left alone (null).
+        val plan = PipAudio.plan(cornerActive = true, mainPresent = false, audioOnCorner = false)
+        assertEquals(PipAudioPlan(muteMain = null, muteCorner = false), plan)
+    }
+
+    @Test
+    fun browseOnlyCorner_audioFlagIrrelevant_whenNoMain() {
+        // With no main present the audioOnCorner flag can't steal sound from a window that isn't there.
+        val plan = PipAudio.plan(cornerActive = true, mainPresent = false, audioOnCorner = true)
+        assertEquals(PipAudioPlan(muteMain = null, muteCorner = false), plan)
+    }
+
+    @Test
+    fun bothWindows_default_mainAudible_cornerMuted() {
+        // Full-screen + corner, default: the main stream keeps the sound, the corner is silent video.
+        val plan = PipAudio.plan(cornerActive = true, mainPresent = true, audioOnCorner = false)
+        assertEquals(PipAudioPlan(muteMain = false, muteCorner = true), plan)
+    }
+
+    @Test
+    fun bothWindows_audioOnCorner_cornerAudible_mainMuted() {
+        // User hands sound to the corner: corner unmuted, main muted — exactly one is audible.
+        val plan = PipAudio.plan(cornerActive = true, mainPresent = true, audioOnCorner = true)
+        assertEquals(PipAudioPlan(muteMain = true, muteCorner = false), plan)
+    }
+}

--- a/app/src/test/java/tv/own/owntv/features/multiview/PipControllerTest.kt
+++ b/app/src/test/java/tv/own/owntv/features/multiview/PipControllerTest.kt
@@ -1,0 +1,107 @@
+package tv.own.owntv.features.multiview
+
+import android.view.Surface
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tv.own.owntv.core.database.entity.ChannelEntity
+import tv.own.owntv.player.CornerEngine
+import tv.own.owntv.player.CornerState
+import tv.own.owntv.player.MediaMeta
+
+/**
+ * Verifies the picture-in-picture corner orchestration using a fake engine — no ExoPlayer, no Android, no
+ * second decoder (which is exactly the resource we don't want a test to spend). Confirms the corner activates
+ * with the right channel, starts muted (so the main keeps the audio), reuses the decoder instead of reloading
+ * the same channel, switches on a new channel, and frees the decoder on close.
+ */
+class PipControllerTest {
+
+    /** Records control calls and tracks [currentUrl] the way the real engine does, without any playback. */
+    private class FakeCornerEngine : CornerEngine {
+        override val state: StateFlow<CornerState> = MutableStateFlow(CornerState.IDLE)
+        override val meta: StateFlow<MediaMeta> = MutableStateFlow(MediaMeta())
+        override var currentUrl: String? = null
+
+        val playCalls = mutableListOf<Triple<String, MediaMeta, Boolean>>()
+        val muteCalls = mutableListOf<Boolean>()
+        var stopCalls = 0
+
+        override fun play(url: String, meta: MediaMeta, muted: Boolean) {
+            playCalls += Triple(url, meta, muted)
+            currentUrl = url
+        }
+        override fun setMuted(muted: Boolean) { muteCalls += muted }
+        override fun stop() { stopCalls++; currentUrl = null }
+        override fun setSurface(surface: Surface?) {}
+    }
+
+    private fun channel(id: Long, url: String) =
+        ChannelEntity(id = id, sourceId = 1, name = "Ch$id", streamUrl = url)
+
+    @Test
+    fun initiallyInactive() {
+        val pip = PipController(FakeCornerEngine())
+        assertFalse(pip.active.value)
+        assertNull(pip.channel.value)
+    }
+
+    @Test
+    fun openCorner_activatesAndPlaysMutedByDefault() {
+        val engine = FakeCornerEngine()
+        val pip = PipController(engine)
+        val ch = channel(1, "http://a")
+
+        pip.openCorner(ch)
+
+        assertTrue(pip.active.value)
+        assertEquals(ch, pip.channel.value)
+        assertEquals(1, engine.playCalls.size)
+        assertEquals("http://a", engine.playCalls[0].first)
+        assertTrue("corner must start muted so the main stream keeps the audio", engine.playCalls[0].third)
+    }
+
+    @Test
+    fun openCorner_sameChannel_doesNotReload() {
+        val engine = FakeCornerEngine()
+        val pip = PipController(engine)
+        val ch = channel(1, "http://a")
+
+        pip.openCorner(ch)
+        pip.openCorner(ch) // same URL → must NOT spin up the decoder again (just re-apply mute)
+
+        assertEquals(1, engine.playCalls.size)
+        assertEquals(1, engine.muteCalls.size)
+        assertTrue(pip.active.value)
+    }
+
+    @Test
+    fun openCorner_differentChannel_switchesStream() {
+        val engine = FakeCornerEngine()
+        val pip = PipController(engine)
+
+        pip.openCorner(channel(1, "http://a"))
+        pip.openCorner(channel(2, "http://b"))
+
+        assertEquals(2, engine.playCalls.size)
+        assertEquals("http://b", engine.playCalls[1].first)
+        assertEquals(2L, pip.channel.value?.id)
+    }
+
+    @Test
+    fun closeCorner_deactivatesAndStops() {
+        val engine = FakeCornerEngine()
+        val pip = PipController(engine)
+        pip.openCorner(channel(1, "http://a"))
+
+        pip.closeCorner()
+
+        assertFalse(pip.active.value)
+        assertNull(pip.channel.value)
+        assertEquals(1, engine.stopCalls)
+    }
+}

--- a/app/src/test/java/tv/own/owntv/features/multiview/PipControllerTest.kt
+++ b/app/src/test/java/tv/own/owntv/features/multiview/PipControllerTest.kt
@@ -37,6 +37,7 @@ class PipControllerTest {
         }
         override fun setMuted(muted: Boolean) { muteCalls += muted }
         override fun stop() { stopCalls++; currentUrl = null }
+        override fun release() { currentUrl = null }
         override fun setSurface(surface: Surface?) {}
     }
 


### PR DESCRIPTION
> ⚠️ **Draft, stacked on #29 — do not merge before #29.** This branch is based on the true-PiP branch, so until #29 merges its commits appear in this diff. Once #29 lands I'll rebase onto `main` for a clean diff. Opening early for visibility.

## What

**MultiView — up to four live streams at once**, in two layouts (as requested):
- **Equal grid** — 1 / 2-up / 2×2.
- **Dominant** — one large tile + the rest in a small strip.

D-pad moves focus between tiles; the **focused tile is the only audible one**; **OK** promotes a tile to dominant. Entry is a **MultiView** button on a channel's Live preview pane; more tiles are added from inside the grid (**＋ Add stream**, from recent channels), with a layout toggle and exit in the bottom bar.

## Architecture-aware (per your #29 review)

Since the **live** full-screen player is ExoPlayer, each tile is its own **constrained `SecondaryLivePlayer`** — the same hardened second decoder from #29. No mpv involved.

## Resource-conscious for weak Android TV boxes

This was the explicit design goal:

- **Per-tile cap 480p** — a quarter-screen tile never needs more; it's a track-**selection** hint (picks a lower adaptive rendition where offered), **never a transcode**, with **software-decoder fallback** when no hardware decoder is free.
- **Device-tiered tile cap** — low-RAM boxes (`isLowRamDevice` / <3 GB) allow **2 tiles, not 4** (à la `PlayerBudget`): two solid streams beat four stuttering ones.
- **Tiles released on exit** (not just stopped) — MultiView holds **no decoder or memory** when closed; the browse UI behind it is **unmounted** so its Live-preview decoder doesn't run under the tiles.
- Only the active tile is audible; tiles never take audio focus; engines are created lazily per slot.

## Tests

`MultiViewControllerTest` (pure JVM, fake engines — no real decoders): audio arbitration (only active tile audible), **device cap honored**, **release-on-exit frees every tile**, layout toggle, focus/promote.

## Notes

- Authored without a local Android toolchain — **CI is the first real compile**.
- Concurrent-decoder limits are real; the device-tiered cap is the first lever — happy to tune (caps, per-tile res, dominant-tile gets a higher cap) based on hardware testing.
- Live channels only (no per-tile VOD seek state), consistent with #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)