### PR TITLE
Fix empty Home screen stealing focus from sidebar

### DIFF
--- a/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
@@ -107,7 +107,6 @@ fun HomeScreen(
     val listState = androidx.compose.foundation.lazy.rememberLazyListState()
     val heroFocus = remember { FocusRequester() }
     val fallbackFocus = remember { FocusRequester() }
-    val emptyFocus = remember { FocusRequester() }
     val firstRowFocus = remember { FocusRequester() }
     var initialFocusApplied by remember { mutableStateOf(false) }
     var restoreFocusHandled by remember { mutableStateOf(false) }
@@ -151,12 +150,9 @@ fun HomeScreen(
         if (restoreFocus && restoreFocusHandled) return@LaunchedEffect
         val hasContent = !state.isEmpty
         if (!hasContent) {
-            if (!initialFocusApplied || restoreFocus) {
-                runCatching { emptyFocus.requestFocus() }
-                initialFocusApplied = true
-                restoreFocusHandled = restoreFocusHandled || restoreFocus
-                if (restoreFocus) onRestored()
-            }
+            initialFocusApplied = true
+            restoreFocusHandled = restoreFocusHandled || restoreFocus
+            if (restoreFocus) onRestored()
             return@LaunchedEffect
         }
 
@@ -177,8 +173,6 @@ fun HomeScreen(
     if (state.isEmpty) {
         EmptyHomeState(
             modifier = modifier.fillMaxSize(),
-            focusRequester = emptyFocus,
-            onChildFocused = onChildFocused,
         )
         return
     }
@@ -960,15 +954,11 @@ private fun HeroFallbackPane(
 @Composable
 private fun EmptyHomeState(
     modifier: Modifier = Modifier,
-    focusRequester: FocusRequester,
-    onChildFocused: () -> Unit,
 ) {
     val colors = OwnTVTheme.colors
     Box(
         modifier = modifier
-            .focusRequester(focusRequester)
-            .focusable()
-            .onFocusChanged { if (it.hasFocus) onChildFocused() }
+            .focusProperties { canFocus = false }
             .background(colors.surface),
         contentAlignment = Alignment.Center,
     ) {

--- a/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
@@ -108,8 +108,6 @@ fun HomeScreen(
     val heroFocus = remember { FocusRequester() }
     val fallbackFocus = remember { FocusRequester() }
     val firstRowFocus = remember { FocusRequester() }
-    var initialFocusApplied by remember { mutableStateOf(false) }
-    var restoreFocusHandled by remember { mutableStateOf(false) }
     var expandedHeroIndex by remember { mutableStateOf(-1) }
     var focusedHeroIndex by remember { mutableStateOf(-1) }
 
@@ -141,23 +139,11 @@ fun HomeScreen(
         }
     }
 
-    LaunchedEffect(restoreFocus) {
-        if (!restoreFocus) restoreFocusHandled = false
-    }
-
-    LaunchedEffect(restoreFocus, state.heroItems, state.continueMovies, state.continueSeries, state.favoriteLive) {
-        if (state.isEmpty && !restoreFocus && initialFocusApplied) return@LaunchedEffect
-        if (restoreFocus && restoreFocusHandled) return@LaunchedEffect
-        val hasContent = !state.isEmpty
-        if (!hasContent) {
-            initialFocusApplied = true
-            restoreFocusHandled = restoreFocusHandled || restoreFocus
+    LaunchedEffect(state.heroItems, state.continueMovies, state.continueSeries, state.favoriteLive) {
+        if (state.isEmpty) {
             if (restoreFocus) onRestored()
             return@LaunchedEffect
         }
-
-        if (!restoreFocus && initialFocusApplied) return@LaunchedEffect
-
         runCatching { listState.scrollToItem(0) }
         kotlinx.coroutines.delay(60)
         if (state.heroItems.isNotEmpty()) {
@@ -165,8 +151,6 @@ fun HomeScreen(
         } else {
             runCatching { fallbackFocus.requestFocus() }
         }
-        initialFocusApplied = true
-        restoreFocusHandled = restoreFocusHandled || restoreFocus
         if (restoreFocus) onRestored()
     }
 


### PR DESCRIPTION
## What does this PR do?

  Fixes two Home screen focus issues:

  1. **Empty Home steals focus from sidebar** — When the Home screen had no content, it programmatically requested focus on the empty pane, pulling the user out of the sidebar into an inert right panel. The empty
  pane is now non-focusable (`canFocus = false`), so D-pad navigation stays on the sidebar.

  2. **Hero row doesn't scroll to first item after returning from player** — The focus/scroll logic used `initialFocusApplied` and `restoreFocusHandled` guards that prevented re-scrolling when hero data refreshed
  after player exit. Replaced with a single `LaunchedEffect` keyed on the data lists — whenever hero or continue-watching data changes (initial load, tab switch, or player return), the list scrolls to position 0
  and focuses the first hero card.

  ## Which issue / improvement does it address?

  Fixes broken D-pad navigation on the Home screen:
  - Empty Home screen should never capture focus from the sidebar
  - Returning from playback should always show the updated hero list scrolled to the beginning

  ## How was it tested?

  - **Device(s) tested on:** TCL C6K Google TV
  - **What you exercised:**
    - Empty Home: navigate to Home icon in sidebar, verify focus stays on sidebar, D-pad right does not enter empty pane
    - Non-empty Home: switch tabs and return to Home, verify hero row scrolls to first item and receives focus
    - Play a video from Home hero row, press back, verify updated hero list is scrolled to start with first item focused

  ## Checklist
  - [x] Builds locally (`./gradlew assembleDebug`) and CI is green
  - [x] **Tested on a real Android TV / Fire TV device** (not emulator only) — D-pad/remote navigation works
  - [x] No user data is wiped (Room migrations stay additive)
  - [x] Keeps OwnTV player-only (no bundled channels/content)
  - [x] Commit messages are clear (they become the release notes)