### PR TITLE
Player HUD: don't steal D-pad focus from overlays drawn above it (channel-list overlay)

### DIFF
--- a/app/src/main/java/tv/own/owntv/features/shell/OwnTVShell.kt
+++ b/app/src/main/java/tv/own/owntv/features/shell/OwnTVShell.kt
@@ -471,6 +471,9 @@ fun OwnTVShell(
                     player = if (liveOnExo) liveVm.previewEngine else mpvEngine, // HUD drives the active engine
                     onBack = exitPlayer,
                     onPip = dockPlayer, // PiP/dock works for live on either engine now
+                    // The channel-list overlay draws ABOVE the HUD; while it's open the HUD goes inert so
+                    // its hide/error focus grabs can't yank D-pad focus off the overlay.
+                    inert = showChannelList,
                     onChannelUp = zap?.let { z -> { z(-1) } },
                     onChannelDown = zap?.let { z -> { z(1) } },
                     onOpenChannelList = if (isLiveChannel && liveCanZap) { { showChannelList = true } } else null,

--- a/app/src/main/java/tv/own/owntv/player/PlayerHud.kt
+++ b/app/src/main/java/tv/own/owntv/player/PlayerHud.kt
@@ -69,6 +69,11 @@ fun PlayerHud(
     player: PlaybackEngine,
     onBack: () -> Unit,
     onPip: (() -> Unit)? = null,
+    // True while the shell draws an overlay ABOVE the HUD (e.g. the channel-list overlay). The HUD goes
+    // inert: its auto-hide timer pauses and — crucially — it makes no focus requests, so it can't yank
+    // D-pad focus off the overlay. The existing dialog guard below covers only the HUD's OWN dialogs;
+    // shell-level overlays need this flag. Default false = no behavior change for other callers.
+    inert: Boolean = false,
     onChannelUp: (() -> Unit)? = null,
     onChannelDown: (() -> Unit)? = null,
     // Live: open the channel-list overlay (Left while the controls are hidden). Null = not a live channel.
@@ -124,13 +129,14 @@ fun PlayerHud(
     val zap: (Int) -> Unit = { d -> (if (d < 0) onChannelUp else onChannelDown)?.invoke(); channelFlash++ }
 
     LaunchedEffect(forceShow) { if (forceShow) controlsVisible = true }
-    LaunchedEffect(controlsVisible, wakeTick, forceShow) {
-        if (controlsVisible && !forceShow) { delay(4500); controlsVisible = false }
+    LaunchedEffect(controlsVisible, wakeTick, forceShow, inert) {
+        // Don't auto-hide under an overlay — hiding is what triggers the catch-all focus grab below.
+        if (controlsVisible && !forceShow && !inert) { delay(4500); controlsVisible = false }
     }
-    LaunchedEffect(controlsVisible, error, dialog) {
-        // Never steal focus while a dialog is open (its rows own it); when the dialog closes this
-        // re-runs and hands focus back to the HUD.
-        if (dialog != HudDialog.NONE) return@LaunchedEffect
+    LaunchedEffect(controlsVisible, error, dialog, inert) {
+        // Never steal focus while a dialog is open (its rows own it) or while a shell overlay is up
+        // (inert — the overlay owns the D-pad); when either closes this re-runs and hands focus back.
+        if (dialog != HudDialog.NONE || inert) return@LaunchedEffect
         if (controlsVisible) {
             if (error != null) runCatching { retryFocus.requestFocus() } else runCatching { playFocus.requestFocus() }
         } else runCatching { catchFocus.requestFocus() }


### PR DESCRIPTION
## The bug

The HUD's focus containment requests focus whenever its controls hide (the 4.5 s auto-hide → `catchFocus`) or an error lands (→ `retryFocus`). The v4.0.0 focus overhaul guards this for the HUD's **own dialogs** (`dialog != HudDialog.NONE`), but not for overlays the **shell** composes above the player — like the channel-list overlay (Left while controls are hidden).

**Repro (Fire TV Stick 4K Max):** watching live full-screen, open the channel-list overlay, then either wake the HUD first (so its 4.5 s hide timer is running) or let the stream hiccup mid-browse. When the timer fires (or the error lands), the HUD requests focus to an invisible control **behind** the overlay — the overlay's highlight vanishes, the remote appears dead, and OK can activate a hidden HUD button.

## The fix

A single `inert: Boolean = false` parameter on `PlayerHud`: while set, the auto-hide timer pauses and the HUD makes **no focus requests**. The shell sets `inert = showChannelList`. This extends the same pattern as your dialog guard — dialogs own focus while open; now shell overlays do too. Default `false`, so every other call site is byte-for-byte unchanged.

15 insertions / 6 deletions across two files.

## Testing

Verified on a Fire TV Stick 4K Max: the identical steal hit an overlay drawn above the HUD in a downstream fork of this repo; with this guard the overlay holds D-pad focus indefinitely and focus hands back to the HUD when it closes. Compiles green on this repo's Android CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)