### PR TITLE
Customizable Home screen: reorder/hide rows, dwell-to-expand hero, On Now mini-guide, per-profile settings, Keep Watching filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.iml
 .gradle/
+.gradle-cache/
 .idea/
 .kotlin/
 /local.properties

--- a/app/src/main/java/tv/own/owntv/core/backup/BackupManager.kt
+++ b/app/src/main/java/tv/own/owntv/core/backup/BackupManager.kt
@@ -66,7 +66,7 @@ class BackupManager(
             val seal: ((String) -> JSONObject)? = key?.let { k -> { plain -> BackupCrypto.encrypt(k, plain) } }
 
             val root = JSONObject().apply {
-                put("version", 7) // v7: auto-refresh maps + default source (SOURCES); compat-mode pins (SETTINGS)
+                put("version", 8) // v8: home configs move with customizations; compat-mode pins (SETTINGS)
                 put("sections", JSONArray().apply { sections.forEach { put(it.name) } })
                 if (salt != null) put("crypto", BackupCrypto.cryptoBlock(salt))
                 if (Section.SOURCES in sections) {
@@ -82,6 +82,7 @@ class BackupManager(
                 }
                 if (Section.CUSTOMIZE in sections) {
                     put("customizations", JSONObject().apply { customize.exportAll().forEach { (k, v) -> put(k, v) } })
+                    put("homeConfigs", settings.exportHomeConfigs())
                 }
                 // Favorites / history / resume positions, exported with stable keys (see UserDataResolver).
                 val kinds = kindsFor(sections)
@@ -121,7 +122,10 @@ class BackupManager(
             val root = JSONObject(file.readText())
             val out = mutableSetOf<Section>()
             if (root.has("profiles") || root.has("sources")) out += Section.SOURCES
-            if (root.optJSONObject("customizations")?.keys()?.hasNext() == true) out += Section.CUSTOMIZE
+            if (
+                root.optJSONObject("customizations")?.keys()?.hasNext() == true ||
+                root.optJSONObject("homeConfigs")?.keys()?.hasNext() == true
+            ) out += Section.CUSTOMIZE
             if (root.optJSONObject("settings")?.keys()?.hasNext() == true) out += Section.SETTINGS
             root.optJSONArray("userData")?.let { arr ->
                 for (i in 0 until arr.length()) {
@@ -155,6 +159,7 @@ class BackupManager(
             val root = JSONObject(file.readText())
             val crypto = root.optJSONObject("crypto")
             val pass = backupPassword?.takeIf { it.isNotBlank() }
+            var existingProfileIds = profileDao.getAllOnce().map { it.id }.toSet()
 
             // Derive + validate the key up front, before any destructive write.
             val key = if (crypto != null && pass != null) {
@@ -191,6 +196,7 @@ class BackupManager(
                 val profileIds = profileDao.getAllOnce().map { it.id }.toSet()
                 profileIds.firstOrNull()?.let { settings.setActiveProfile(it) }
                 root.optJSONObject("startupModes")?.let { settings.importStartupModes(it, profileIds) }
+                existingProfileIds = profileIds
                 // Auto-refresh maps + default source: ids not present after restore are dropped,
                 // unknown enum values fall back to OFF. Absent keys (older backups) leave defaults.
                 val sourceIds = sourceDao.getAllOnce().map { it.id }.toSet()
@@ -207,6 +213,7 @@ class BackupManager(
                     customize.importAll(cust)
                     count += cust.size
                 }
+                root.optJSONObject("homeConfigs")?.let { settings.importHomeConfigs(it, existingProfileIds) }
             }
 
             // Favorites/history/progress: stashed as pending records — they attach automatically as

--- a/app/src/main/java/tv/own/owntv/core/database/dao/ChannelDao.kt
+++ b/app/src/main/java/tv/own/owntv/core/database/dao/ChannelDao.kt
@@ -274,4 +274,17 @@ interface ChannelDao {
             "WHERE h.profileId = :profileId ORDER BY h.watchedAt DESC LIMIT :limit",
     )
     fun recentlyWatchedWithTimestamp(profileId: Long, limit: Int): Flow<List<ChannelWithWatchedAt>>
+
+    /** Recently-watched live channels, filtered to the active playlist ids before the LIMIT is applied. */
+    @Query(
+        "SELECT c.*, h.watchedAt FROM channels c " +
+            "INNER JOIN watch_history h ON h.itemId = c.id AND h.mediaType = 'LIVE' " +
+            "WHERE h.profileId = :profileId AND c.sourceId IN (:sourceIds) " +
+            "ORDER BY h.watchedAt DESC LIMIT :limit",
+    )
+    fun recentlyWatchedWithTimestampFiltered(
+        profileId: Long,
+        sourceIds: List<Long>,
+        limit: Int,
+    ): Flow<List<ChannelWithWatchedAt>>
 }

--- a/app/src/main/java/tv/own/owntv/di/AppModule.kt
+++ b/app/src/main/java/tv/own/owntv/di/AppModule.kt
@@ -28,7 +28,7 @@ val appModule = module {
     // Merged (v4.0.0 + PR#31 Home/launcher). Koin resolves each get() by type, so only the count must match
     // each ViewModel's merged constructor.
     viewModel { ShellViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
-    viewModel { HomeViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { HomeViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { SetupViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { LiveViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { MovieViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }

--- a/app/src/main/java/tv/own/owntv/di/AppModule.kt
+++ b/app/src/main/java/tv/own/owntv/di/AppModule.kt
@@ -6,13 +6,14 @@ import org.koin.dsl.module
 import tv.own.owntv.features.customize.CustomizeViewModel
 import tv.own.owntv.features.downloads.DownloadsViewModel
 import tv.own.owntv.features.epg.EpgViewModel
-import tv.own.owntv.features.live.LiveViewModel
 import tv.own.owntv.features.home.HomeViewModel
+import tv.own.owntv.features.live.LiveViewModel
 import tv.own.owntv.features.movies.MovieViewModel
 import tv.own.owntv.features.profiles.ProfilesViewModel
 import tv.own.owntv.features.search.SearchViewModel
 import tv.own.owntv.features.series.SeriesViewModel
 import tv.own.owntv.features.settings.BackupViewModel
+import tv.own.owntv.features.settings.HomeSettingsViewModel
 import tv.own.owntv.features.settings.SettingsViewModel
 import tv.own.owntv.features.settings.data.SettingsRepository
 import tv.own.owntv.features.setup.SetupViewModel
@@ -35,6 +36,7 @@ val appModule = module {
     viewModel { SearchViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { ProfilesViewModel(get(), get(), get(), get()) }
     viewModel { SettingsViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { HomeSettingsViewModel(get()) }
     viewModel { DownloadsViewModel(get(), get(), get(), get(), get(), get(), get()) }
     viewModel { EpgViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     // settings, sourceDao, categoryDao, customizationStore

--- a/app/src/main/java/tv/own/owntv/di/AppModule.kt
+++ b/app/src/main/java/tv/own/owntv/di/AppModule.kt
@@ -30,7 +30,7 @@ val appModule = module {
     viewModel { ShellViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { HomeViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { SetupViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
-    viewModel { LiveViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { LiveViewModel(androidContext(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { MovieViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { SeriesViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { SearchViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }

--- a/app/src/main/java/tv/own/owntv/features/epg/EpgScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/epg/EpgScreen.kt
@@ -78,18 +78,15 @@ import tv.own.owntv.ui.components.roundedPanel
 import tv.own.owntv.ui.components.OwnTVSpinner
 import tv.own.owntv.ui.components.SearchBar
 import tv.own.owntv.ui.components.trapVerticalFocusExit
+import tv.own.owntv.features.epg.GuideGridDefaults
+import tv.own.owntv.features.epg.ProgrammeDetailDialog
+import tv.own.owntv.features.epg.ProgrammeStripCanvas
+import tv.own.owntv.features.epg.clock
 import tv.own.owntv.ui.theme.Dimens
 import tv.own.owntv.ui.theme.OwnTVTheme
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
-
-private val CHANNEL_COL = 176.dp
-private val ROW_HEIGHT = 64.dp
-private val PX_PER_MIN = 4.dp
-private const val SLOT_MIN = 30
-
-private fun clock(ms: Long) = SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date(ms))
 
 /**
  * The full EPG guide: a time × channel grid. Channel labels are pinned on the left; every channel row
@@ -171,8 +168,8 @@ fun EpgScreen(
     LaunchedEffect(state.windowStart, state.channels.isNotEmpty()) {
         if (state.channels.isEmpty()) return@LaunchedEffect
         val minutesBack = ((state.now - state.windowStart) / 60_000L).toInt()
-        if (minutesBack <= SLOT_MIN) return@LaunchedEffect // no real lookback → leave at the start
-        val px = with(density) { (minutesBack * PX_PER_MIN.value).dp.toPx() }.toInt()
+        if (minutesBack <= GuideGridDefaults.SlotMin) return@LaunchedEffect // no real lookback → leave at the start
+        val px = with(density) { (minutesBack * GuideGridDefaults.PxPerMin.value).dp.toPx() }.toInt()
         // Wait until the time-axis row is laid out so maxValue is known — otherwise scrollTo runs before
         // layout and clamps to 0 (a no-op), leaving the strips at the past edge (no data yet) → blank guide
         // until a later real scroll. Bounded so we never hang if the row stays unscrollable.
@@ -188,8 +185,8 @@ fun EpgScreen(
     // Keep the highlighted (cursor) programme in view while browsing a row in CELL mode.
     LaunchedEffect(cursorTime, inCellMode) {
         if (!inCellMode || state.channels.isEmpty()) return@LaunchedEffect
-        val minutes = ((cursorTime - state.windowStart) / 60_000L).toInt() - SLOT_MIN // one slot of left margin
-        val px = with(density) { (minutes.coerceAtLeast(0) * PX_PER_MIN.value).dp.toPx() }.toInt()
+        val minutes = ((cursorTime - state.windowStart) / 60_000L).toInt() - GuideGridDefaults.SlotMin // one slot of left margin
+        val px = with(density) { (minutes.coerceAtLeast(0) * GuideGridDefaults.PxPerMin.value).dp.toPx() }.toInt()
         runCatching { hScroll.scrollTo(px) }
     }
 
@@ -315,18 +312,18 @@ fun EpgScreen(
             }
             else -> {
                 // Time axis (shares hScroll with the rows below).
-                val slots = ((state.windowEnd - state.windowStart) / (SLOT_MIN * 60_000L)).toInt()
+                val slots = ((state.windowEnd - state.windowStart) / (GuideGridDefaults.SlotMin * 60_000L)).toInt()
                 Row {
-                    Spacer(Modifier.width(CHANNEL_COL))
+                    Spacer(Modifier.width(GuideGridDefaults.ChannelCol))
                     Row(Modifier.horizontalScroll(hScroll)) {
                         for (i in 0 until slots) {
-                            val slotMs = state.windowStart + i * SLOT_MIN * 60_000L
+                            val slotMs = state.windowStart + i * GuideGridDefaults.SlotMin * 60_000L
                             Text(
                                 clock(slotMs),
                                 style = MaterialTheme.typography.labelMedium,
                                 color = colors.onSurfaceVariant,
                                 fontWeight = FontWeight.SemiBold,
-                                modifier = Modifier.width((SLOT_MIN * PX_PER_MIN.value).dp).padding(start = 6.dp),
+                                modifier = Modifier.width((GuideGridDefaults.SlotMin * GuideGridDefaults.PxPerMin.value).dp).padding(start = 6.dp),
                             )
                         }
                     }
@@ -577,7 +574,7 @@ private fun GuideChannelRow(
         FocusableSurface(
             onClick = onTune,
             onLongClick = onMatchEpg,
-            modifier = Modifier.width(CHANNEL_COL).height(ROW_HEIGHT).padding(end = 6.dp)
+            modifier = Modifier.width(GuideGridDefaults.ChannelCol).height(GuideGridDefaults.RowHeight).padding(end = 6.dp)
                 .focusRequester(labelFR)
                 .then(if (labelFocus != null) Modifier.focusRequester(labelFocus) else Modifier)
                 .focusProperties { right = stripFR }
@@ -598,7 +595,7 @@ private fun GuideChannelRow(
         // the whole strip; OK enters CELL stage where Left/Right move the cursor and Up/Down jump rows.
         val rowSelected = stripFocused && !inCellMode
         Box(
-            modifier = Modifier.weight(1f).height(ROW_HEIGHT)
+            modifier = Modifier.weight(1f).height(GuideGridDefaults.RowHeight)
                 .focusRequester(stripFR)
                 .onFocusChanged { stripFocused = it.isFocused }
                 .onKeyEvent { e ->
@@ -656,118 +653,6 @@ private fun openAtCursor(progs: List<EpgProgrammeEntity>, cursorTime: Long, onOp
     p?.let(onOpen)
 }
 
-/**
- * One channel's programme strip, drawn in a SINGLE Canvas (not ~48–336 composables per row). It reads the
- * shared [hScroll] offset to translate + cull to just the visible programmes, so a 7-day window stays cheap.
- * Per the perf review: a cached [rememberTextMeasurer] and pre-computed styles/labels keep allocations out of
- * the draw loop (no GC thrash → no scroll micro-stutter).
- */
-@Composable
-private fun ProgrammeStripCanvas(
-    programmes: List<EpgProgrammeEntity>,
-    windowStart: Long,
-    windowEnd: Long,
-    now: Long,
-    highlightTime: Long?,
-    hScroll: androidx.compose.foundation.ScrollState,
-) {
-    val colors = OwnTVTheme.colors
-    val density = LocalDensity.current
-    val measurer = rememberTextMeasurer(cacheSize = 64)
-
-    // Pre-computed once — nothing here is allocated inside the draw loop.
-    val pxPerMin = with(density) { PX_PER_MIN.toPx() }
-    val gapPx = with(density) { 4.dp.toPx() }
-    val padPx = with(density) { 10.dp.toPx() }
-    val borderPx = with(density) { Dimens.FocusBorderWidth.toPx() }
-    val corner = with(density) { CornerRadius(10.dp.toPx(), 10.dp.toPx()) }
-    val titleStyle = MaterialTheme.typography.titleSmall.copy(color = colors.onSurface)
-    val titleNowStyle = MaterialTheme.typography.titleSmall.copy(color = colors.onPrimaryContainer)
-    val timeStyle = MaterialTheme.typography.labelSmall.copy(color = colors.onSurfaceVariant)
-    val timeNowStyle = MaterialTheme.typography.labelSmall.copy(color = colors.onPrimaryContainer)
-    // Time labels built once (string formatting kept out of the per-frame draw loop).
-    val labels = remember(programmes, now) {
-        programmes.map { p ->
-            val t = "${clock(p.startMs)} – ${clock(p.stopMs)}"
-            if (now in p.startMs until p.stopMs) "NOW · $t" else t
-        }
-    }
-
-    val scrollPx = hScroll.value.toFloat() // read in composable scope so Canvas redraws on scroll
-    Canvas(Modifier.fillMaxSize()) {
-        val viewW = size.width
-        val h = size.height
-        programmes.forEachIndexed { i, p ->
-            val s = p.startMs.coerceIn(windowStart, windowEnd)
-            val e = p.stopMs.coerceIn(windowStart, windowEnd)
-            if (e <= s) return@forEachIndexed
-            val x = ((s - windowStart) / 60_000f) * pxPerMin - scrollPx
-            val w = (((e - s) / 60_000f) * pxPerMin - gapPx).coerceAtLeast(0f)
-            if (x + w <= 0f || x >= viewW) return@forEachIndexed // cull off-screen programmes
-            val isNow = now in p.startMs until p.stopMs
-            val hi = highlightTime != null && highlightTime in p.startMs until p.stopMs
-            val bg = when { hi -> colors.card; isNow -> colors.primaryContainer; else -> colors.surfaceContainerHigh }
-            drawRoundRect(color = bg, topLeft = Offset(x, 0f), size = Size(w, h), cornerRadius = corner)
-            if (hi) drawRoundRect(color = colors.focusBorder, topLeft = Offset(x, 0f), size = Size(w, h), cornerRadius = corner, style = Stroke(borderPx))
-            val textW = (w - padPx * 2f).toInt()
-            if (textW > 8) {
-                val tStyle = if (isNow && !hi) titleNowStyle else titleStyle
-                val mStyle = if (isNow && !hi) timeNowStyle else timeStyle
-                val title = measurer.measure(p.title, tStyle, overflow = TextOverflow.Ellipsis, maxLines = 1, constraints = Constraints(maxWidth = textW))
-                val time = measurer.measure(labels[i], mStyle, overflow = TextOverflow.Ellipsis, maxLines = 1, constraints = Constraints(maxWidth = textW))
-                val top = (h - (title.size.height + time.size.height + 2)) / 2f
-                drawText(title, topLeft = Offset(x + padPx, top))
-                drawText(time, topLeft = Offset(x + padPx, top + title.size.height + 2))
-            }
-        }
-    }
-}
-
-@Composable
-private fun ProgrammeDetailDialog(
-    channelName: String,
-    programme: EpgProgrammeEntity,
-    loadDescription: suspend (Long) -> String?,
-    canCatchup: Boolean,
-    onWatch: () -> Unit,
-    onPlayCatchup: () -> Unit,
-    onDismiss: () -> Unit,
-) {
-    val colors = OwnTVTheme.colors
-    // The grid load drops `description` to stay under the CursorWindow limit, so fetch it on demand
-    // here (fall back to the row's own value when it was loaded by the lazy per-row path).
-    val description by produceState(programme.description, programme.id) {
-        value = programme.description ?: loadDescription(programme.id)
-    }
-    val fr = remember { FocusRequester() }
-    LaunchedEffect(Unit) { runCatching { fr.requestFocus() } }
-    BackHandler { onDismiss() }
-    Box(Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.75f)), contentAlignment = Alignment.Center) {
-        Column(Modifier.widthIn(max = 560.dp).clip(RoundedCornerShape(20.dp)).background(colors.surfaceContainerHigh).padding(28.dp)) {
-            Text(channelName.uppercase(), style = MaterialTheme.typography.labelMedium, color = colors.primary, fontWeight = FontWeight.SemiBold)
-            Spacer(Modifier.height(6.dp))
-            Text(programme.title, style = MaterialTheme.typography.headlineSmall, color = colors.onSurface)
-            Spacer(Modifier.height(8.dp))
-            Text("${clock(programme.startMs)} – ${clock(programme.stopMs)}", style = MaterialTheme.typography.titleMedium, color = colors.onSurfaceVariant)
-            if (!description.isNullOrBlank()) {
-                Spacer(Modifier.height(14.dp))
-                Text(description.orEmpty(), style = MaterialTheme.typography.bodyMedium, color = colors.onSurfaceVariant)
-            }
-            Spacer(Modifier.height(24.dp))
-            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                OwnTVButton("Close", onClick = onDismiss, style = OwnTVButtonStyle.SECONDARY)
-                Spacer(Modifier.weight(1f))
-                // Catch-up channels: replay this programme from its start (seekable archive playback).
-                if (canCatchup) {
-                    OwnTVButton("Watch from start", onClick = onPlayCatchup, icon = OwnTVIcon.PLAY, modifier = Modifier.focusRequester(fr))
-                    OwnTVButton("Watch channel", onClick = onWatch, style = OwnTVButtonStyle.SECONDARY)
-                } else {
-                    OwnTVButton("Watch channel", onClick = onWatch, icon = OwnTVIcon.PLAY, modifier = Modifier.focusRequester(fr))
-                }
-            }
-        }
-    }
-}
 
 @Composable
 private fun CenterBox(content: @Composable androidx.compose.foundation.layout.ColumnScope.() -> Unit) {

--- a/app/src/main/java/tv/own/owntv/features/epg/EpgScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/epg/EpgScreen.kt
@@ -81,7 +81,7 @@ import tv.own.owntv.ui.components.trapVerticalFocusExit
 import tv.own.owntv.features.epg.GuideGridDefaults
 import tv.own.owntv.features.epg.ProgrammeDetailDialog
 import tv.own.owntv.features.epg.ProgrammeStripCanvas
-import tv.own.owntv.features.epg.clock
+import tv.own.owntv.ui.format.rememberSystemTimeFormatter
 import tv.own.owntv.ui.theme.Dimens
 import tv.own.owntv.ui.theme.OwnTVTheme
 import java.text.SimpleDateFormat
@@ -312,6 +312,7 @@ fun EpgScreen(
             }
             else -> {
                 // Time axis (shares hScroll with the rows below).
+                val formatTime = rememberSystemTimeFormatter()
                 val slots = ((state.windowEnd - state.windowStart) / (GuideGridDefaults.SlotMin * 60_000L)).toInt()
                 Row {
                     Spacer(Modifier.width(GuideGridDefaults.ChannelCol))
@@ -319,7 +320,7 @@ fun EpgScreen(
                         for (i in 0 until slots) {
                             val slotMs = state.windowStart + i * GuideGridDefaults.SlotMin * 60_000L
                             Text(
-                                clock(slotMs),
+                                formatTime(slotMs),
                                 style = MaterialTheme.typography.labelMedium,
                                 color = colors.onSurfaceVariant,
                                 fontWeight = FontWeight.SemiBold,

--- a/app/src/main/java/tv/own/owntv/features/epg/GuideCore.kt
+++ b/app/src/main/java/tv/own/owntv/features/epg/GuideCore.kt
@@ -1,0 +1,169 @@
+package tv.own.owntv.features.epg
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import tv.own.owntv.core.database.entity.EpgProgrammeEntity
+import tv.own.owntv.ui.components.FocusableSurface
+import tv.own.owntv.ui.components.OwnTVButton
+import tv.own.owntv.ui.components.OwnTVButtonStyle
+import tv.own.owntv.ui.components.OwnTVIcon
+import tv.own.owntv.ui.theme.Dimens
+import tv.own.owntv.ui.theme.OwnTVTheme
+
+internal object GuideGridDefaults {
+    val ChannelCol = 176.dp
+    val RowHeight = 64.dp
+    val PxPerMin = 4.dp
+    const val SlotMin = 30
+}
+
+internal fun clock(ms: Long) = SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date(ms))
+
+@Composable
+internal fun ProgrammeStripCanvas(
+    programmes: List<EpgProgrammeEntity>,
+    windowStart: Long,
+    windowEnd: Long,
+    now: Long,
+    highlightTime: Long?,
+    hScroll: androidx.compose.foundation.ScrollState,
+) {
+    val colors = OwnTVTheme.colors
+    val density = androidx.compose.ui.platform.LocalDensity.current
+    val measurer = rememberTextMeasurer(cacheSize = 64)
+
+    // Pre-computed once — nothing here is allocated inside the draw loop.
+    val pxPerMin = with(density) { GuideGridDefaults.PxPerMin.toPx() }
+    val gapPx = with(density) { 4.dp.toPx() }
+    val padPx = with(density) { 10.dp.toPx() }
+    val borderPx = with(density) { Dimens.FocusBorderWidth.toPx() }
+    val corner = with(density) { CornerRadius(10.dp.toPx(), 10.dp.toPx()) }
+    val titleStyle = MaterialTheme.typography.titleSmall.copy(color = colors.onSurface)
+    val titleNowStyle = MaterialTheme.typography.titleSmall.copy(color = colors.onPrimaryContainer)
+    val timeStyle = MaterialTheme.typography.labelSmall.copy(color = colors.onSurfaceVariant)
+    val timeNowStyle = MaterialTheme.typography.labelSmall.copy(color = colors.onPrimaryContainer)
+    // Time labels built once (string formatting kept out of the per-frame draw loop).
+    val labels = remember(programmes, now) {
+        programmes.map { p ->
+            val t = "${clock(p.startMs)} – ${clock(p.stopMs)}"
+            if (now in p.startMs until p.stopMs) "NOW · $t" else t
+        }
+    }
+
+    val scrollPx = hScroll.value.toFloat() // read in composable scope so Canvas redraws on scroll
+    Canvas(Modifier.fillMaxSize()) {
+        val viewW = size.width
+        val h = size.height
+        programmes.forEachIndexed { i, p ->
+            val s = p.startMs.coerceIn(windowStart, windowEnd)
+            val e = p.stopMs.coerceIn(windowStart, windowEnd)
+            if (e <= s) return@forEachIndexed
+            val x = ((s - windowStart) / 60_000f) * pxPerMin - scrollPx
+            val w = (((e - s) / 60_000f) * pxPerMin - gapPx).coerceAtLeast(0f)
+            if (x + w <= 0f || x >= viewW) return@forEachIndexed // cull off-screen programmes
+            val isNow = now in p.startMs until p.stopMs
+            val hi = highlightTime != null && highlightTime in p.startMs until p.stopMs
+            val bg = when { hi -> colors.card; isNow -> colors.primaryContainer; else -> colors.surfaceContainerHigh }
+            drawRoundRect(color = bg, topLeft = Offset(x, 0f), size = Size(w, h), cornerRadius = corner)
+            if (hi) drawRoundRect(color = colors.focusBorder, topLeft = Offset(x, 0f), size = Size(w, h), cornerRadius = corner, style = Stroke(borderPx))
+            val textW = (w - padPx * 2f).toInt()
+            if (textW > 8) {
+                val tStyle = if (isNow && !hi) titleNowStyle else titleStyle
+                val mStyle = if (isNow && !hi) timeNowStyle else timeStyle
+                val title = measurer.measure(p.title, tStyle, overflow = TextOverflow.Ellipsis, maxLines = 1, constraints = Constraints(maxWidth = textW))
+                val time = measurer.measure(labels[i], mStyle, overflow = TextOverflow.Ellipsis, maxLines = 1, constraints = Constraints(maxWidth = textW))
+                val top = (h - (title.size.height + time.size.height + 2)) / 2f
+                drawText(title, topLeft = Offset(x + padPx, top))
+                drawText(time, topLeft = Offset(x + padPx, top + title.size.height + 2))
+            }
+        }
+    }
+}
+
+@Composable
+internal fun ProgrammeDetailDialog(
+    channelName: String,
+    programme: EpgProgrammeEntity,
+    loadDescription: suspend (Long) -> String?,
+    canCatchup: Boolean,
+    onWatch: () -> Unit,
+    onPlayCatchup: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val colors = OwnTVTheme.colors
+    // The grid load drops `description` to stay under the CursorWindow limit, so fetch it on demand
+    // here (fall back to the row's own value when it was loaded by the lazy per-row path).
+    val description by produceState(programme.description, programme.id) {
+        value = programme.description ?: loadDescription(programme.id)
+    }
+    val fr = remember { FocusRequester() }
+    LaunchedEffect(Unit) { runCatching { fr.requestFocus() } }
+    Popup(onDismissRequest = onDismiss, properties = PopupProperties(focusable = true)) {
+        BackHandler { onDismiss() }
+        Box(Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.75f)), contentAlignment = Alignment.Center) {
+            Column(Modifier.widthIn(max = 560.dp).clip(RoundedCornerShape(20.dp)).background(colors.surfaceContainerHigh).padding(28.dp)) {
+                Text(channelName.uppercase(), style = MaterialTheme.typography.labelMedium, color = colors.primary, fontWeight = FontWeight.SemiBold)
+                Spacer(Modifier.height(6.dp))
+                Text(programme.title, style = MaterialTheme.typography.headlineSmall, color = colors.onSurface)
+                Spacer(Modifier.height(8.dp))
+                Text("${clock(programme.startMs)} – ${clock(programme.stopMs)}", style = MaterialTheme.typography.titleMedium, color = colors.onSurfaceVariant)
+                if (!description.isNullOrBlank()) {
+                    Spacer(Modifier.height(14.dp))
+                    Text(description.orEmpty(), style = MaterialTheme.typography.bodyMedium, color = colors.onSurfaceVariant)
+                }
+                Spacer(Modifier.height(24.dp))
+                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    OwnTVButton("Close", onClick = onDismiss, style = OwnTVButtonStyle.SECONDARY)
+                    Spacer(Modifier.weight(1f))
+                    // Catch-up channels: replay this programme from its start (seekable archive playback).
+                    if (canCatchup) {
+                        OwnTVButton("Watch from start", onClick = onPlayCatchup, icon = OwnTVIcon.PLAY, modifier = Modifier.focusRequester(fr))
+                        OwnTVButton("Watch channel", onClick = onWatch, style = OwnTVButtonStyle.SECONDARY)
+                    } else {
+                        OwnTVButton("Watch channel", onClick = onWatch, icon = OwnTVIcon.PLAY, modifier = Modifier.focusRequester(fr))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/tv/own/owntv/features/epg/GuideCore.kt
+++ b/app/src/main/java/tv/own/owntv/features/epg/GuideCore.kt
@@ -39,14 +39,12 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 import tv.own.owntv.core.database.entity.EpgProgrammeEntity
 import tv.own.owntv.ui.components.FocusableSurface
 import tv.own.owntv.ui.components.OwnTVButton
 import tv.own.owntv.ui.components.OwnTVButtonStyle
 import tv.own.owntv.ui.components.OwnTVIcon
+import tv.own.owntv.ui.format.rememberSystemTimeFormatter
 import tv.own.owntv.ui.theme.Dimens
 import tv.own.owntv.ui.theme.OwnTVTheme
 
@@ -56,8 +54,6 @@ internal object GuideGridDefaults {
     val PxPerMin = 4.dp
     const val SlotMin = 30
 }
-
-internal fun clock(ms: Long) = SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date(ms))
 
 @Composable
 internal fun ProgrammeStripCanvas(
@@ -82,10 +78,11 @@ internal fun ProgrammeStripCanvas(
     val titleNowStyle = MaterialTheme.typography.titleSmall.copy(color = colors.onPrimaryContainer)
     val timeStyle = MaterialTheme.typography.labelSmall.copy(color = colors.onSurfaceVariant)
     val timeNowStyle = MaterialTheme.typography.labelSmall.copy(color = colors.onPrimaryContainer)
+    val formatTime = rememberSystemTimeFormatter()
     // Time labels built once (string formatting kept out of the per-frame draw loop).
-    val labels = remember(programmes, now) {
+    val labels = remember(programmes, now, formatTime) {
         programmes.map { p ->
-            val t = "${clock(p.startMs)} – ${clock(p.stopMs)}"
+            val t = "${formatTime(p.startMs)} – ${formatTime(p.stopMs)}"
             if (now in p.startMs until p.stopMs) "NOW · $t" else t
         }
     }
@@ -131,6 +128,7 @@ internal fun ProgrammeDetailDialog(
     onDismiss: () -> Unit,
 ) {
     val colors = OwnTVTheme.colors
+    val formatTime = rememberSystemTimeFormatter()
     // The grid load drops `description` to stay under the CursorWindow limit, so fetch it on demand
     // here (fall back to the row's own value when it was loaded by the lazy per-row path).
     val description by produceState(programme.description, programme.id) {
@@ -146,7 +144,7 @@ internal fun ProgrammeDetailDialog(
                 Spacer(Modifier.height(6.dp))
                 Text(programme.title, style = MaterialTheme.typography.headlineSmall, color = colors.onSurface)
                 Spacer(Modifier.height(8.dp))
-                Text("${clock(programme.startMs)} – ${clock(programme.stopMs)}", style = MaterialTheme.typography.titleMedium, color = colors.onSurfaceVariant)
+                Text("${formatTime(programme.startMs)} – ${formatTime(programme.stopMs)}", style = MaterialTheme.typography.titleMedium, color = colors.onSurfaceVariant)
                 if (!description.isNullOrBlank()) {
                     Spacer(Modifier.height(14.dp))
                     Text(description.orEmpty(), style = MaterialTheme.typography.bodyMedium, color = colors.onSurfaceVariant)

--- a/app/src/main/java/tv/own/owntv/features/home/HomeGuideSlice.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeGuideSlice.kt
@@ -1,0 +1,367 @@
+package tv.own.owntv.features.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import tv.own.owntv.core.database.entity.ChannelEntity
+import tv.own.owntv.core.database.entity.EpgProgrammeEntity
+import tv.own.owntv.features.epg.GuideGridDefaults
+import tv.own.owntv.features.epg.ProgrammeDetailDialog
+import tv.own.owntv.features.epg.ProgrammeStripCanvas
+import tv.own.owntv.features.epg.clock
+import tv.own.owntv.ui.theme.Dimens
+import tv.own.owntv.ui.components.FocusableSurface
+import tv.own.owntv.ui.components.OwnTVButton
+import tv.own.owntv.ui.components.OwnTVButtonStyle
+import tv.own.owntv.ui.components.OwnTVIcon
+import tv.own.owntv.ui.theme.OwnTVTheme
+
+@Composable
+fun HomeGuideSlice(
+    slice: GuideSliceState,
+    onTuneChannel: (ChannelEntity) -> Unit,
+    onOpenFullGuide: () -> Unit,
+    onFocus: () -> Unit,
+    firstItemFocusRequester: FocusRequester?,
+    loadDescription: suspend (Long) -> String?,
+    modifier: Modifier = Modifier,
+) {
+    val colors = OwnTVTheme.colors
+    val rows = remember(slice.channels, slice.programmes) {
+        slice.channels.filter { slice.programmes[it.id].orEmpty().isNotEmpty() }
+    }
+    val cursorTimes = remember(slice.now, rows.map { it.id }) {
+        mutableStateMapOf<Long, Long>().apply {
+            rows.forEach { put(it.id, slice.now) }
+        }
+    }
+    val labelSelected = remember(slice.now, rows.map { it.id }) {
+        mutableStateMapOf<Long, Boolean>().apply {
+            rows.forEach { put(it.id, false) }
+        }
+    }
+    val windowWidth = GuideGridDefaults.PxPerMin * (((slice.windowEnd - slice.windowStart).coerceAtLeast(0L) / 60_000f))
+    val detailFocusRow = remember { mutableStateMapOf<Long, FocusRequester>() }
+    var focusedChannelId by remember { mutableStateOf<Long?>(null) }
+
+    if (rows.isEmpty()) return
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .focusGroup(),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Dimens.HomeRowPaddingH),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "ON NOW",
+                style = MaterialTheme.typography.titleSmall,
+                color = colors.primary,
+                fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+            )
+            Spacer(Modifier.weight(1f))
+            OwnTVButton(
+                label = "View full guide",
+                onClick = onOpenFullGuide,
+                icon = OwnTVIcon.EPG,
+                style = OwnTVButtonStyle.SECONDARY,
+                modifier = Modifier.onFocusChanged {
+                    if (it.hasFocus) {
+                        focusedChannelId = null
+                        onFocus()
+                    }
+                },
+            )
+        }
+
+        Spacer(Modifier.height(10.dp))
+        GuideLiteTimeAxis(
+            windowStart = slice.windowStart,
+            windowEnd = slice.windowEnd,
+            width = windowWidth,
+        )
+        Spacer(Modifier.height(8.dp))
+
+        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            rows.forEachIndexed { index, channel ->
+                val rowFocus = detailFocusRow.getOrPut(channel.id) { FocusRequester() }
+                val rowCursor = cursorTimes[channel.id] ?: slice.now
+                val rowLabelSelected = labelSelected[channel.id] ?: false
+                val programmes = slice.programmes[channel.id].orEmpty()
+                val selectedProgramme = currentProgramme(programmes, rowCursor)
+                val highlightTime = if (focusedChannelId == channel.id && !rowLabelSelected) {
+                    selectedProgramme?.startMs ?: rowCursor
+                } else {
+                    null
+                }
+                GuideLiteRow(
+                    channel = channel,
+                    programmes = programmes,
+                    windowStart = slice.windowStart,
+                    windowEnd = slice.windowEnd,
+                    now = slice.now,
+                    cursorTime = rowCursor,
+                    highlightTime = highlightTime,
+                    labelSelected = rowLabelSelected,
+                    focusRequester = if (index == 0 && firstItemFocusRequester != null) firstItemFocusRequester else rowFocus,
+                    onCursorTimeChange = { cursorTimes[channel.id] = it },
+                    onLabelSelectedChange = { labelSelected[channel.id] = it },
+                    onTuneChannel = onTuneChannel,
+                    onFocus = {
+                        focusedChannelId = channel.id
+                        onFocus()
+                    },
+                    loadDescription = loadDescription,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GuideLiteTimeAxis(
+    windowStart: Long,
+    windowEnd: Long,
+    width: androidx.compose.ui.unit.Dp,
+) {
+    val colors = OwnTVTheme.colors
+    val slotWidth = GuideGridDefaults.PxPerMin * GuideGridDefaults.SlotMin.toFloat()
+    val slots = (((windowEnd - windowStart).coerceAtLeast(0L) / 60_000L) / GuideGridDefaults.SlotMin).toInt()
+        .coerceAtLeast(1)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = Dimens.HomeRowPaddingH),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Spacer(Modifier.width(GuideGridDefaults.ChannelCol))
+        Row(
+            modifier = Modifier.width(width),
+            horizontalArrangement = Arrangement.spacedBy(0.dp),
+        ) {
+            repeat(slots) { index ->
+                val slotStart = windowStart + index * GuideGridDefaults.SlotMin * 60_000L
+                Text(
+                    text = clock(slotStart),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = colors.onSurfaceVariant,
+                    fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold,
+                    modifier = Modifier.width(slotWidth).padding(start = 6.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GuideLiteRow(
+    channel: ChannelEntity,
+    programmes: List<EpgProgrammeEntity>,
+    windowStart: Long,
+    windowEnd: Long,
+    now: Long,
+    cursorTime: Long,
+    highlightTime: Long?,
+    labelSelected: Boolean,
+    focusRequester: FocusRequester,
+    onCursorTimeChange: (Long) -> Unit,
+    onLabelSelectedChange: (Boolean) -> Unit,
+    onTuneChannel: (ChannelEntity) -> Unit,
+    onFocus: () -> Unit,
+    loadDescription: suspend (Long) -> String?,
+    modifier: Modifier = Modifier,
+) {
+    val colors = OwnTVTheme.colors
+    var detail by remember { mutableStateOf<EpgProgrammeEntity?>(null) }
+    val useFocusRequester = focusRequester
+    var hadDialog by remember { mutableStateOf(false) }
+
+    LaunchedEffect(detail) {
+        if (detail != null) {
+            hadDialog = true
+            return@LaunchedEffect
+        }
+        if (hadDialog) {
+            hadDialog = false
+            kotlinx.coroutines.delay(40)
+            runCatching { useFocusRequester.requestFocus() }
+        }
+    }
+
+    val selectedIndex = currentProgrammeIndex(programmes, cursorTime)
+    val selectedProgramme = programmes.getOrNull(selectedIndex)
+
+    FocusableSurface(
+        onClick = {
+            if (labelSelected) {
+                onTuneChannel(channel)
+            } else {
+                val programme = selectedProgramme ?: programmes.firstOrNull()
+                if (programme != null) {
+                    detail = programme
+                } else {
+                    onTuneChannel(channel)
+                }
+            }
+        },
+        modifier = modifier
+            .height(GuideGridDefaults.RowHeight)
+            .focusRequester(useFocusRequester)
+            .onFocusChanged {
+                if (it.hasFocus) {
+                    onFocus()
+                }
+            }
+            .onKeyEvent { event ->
+                if (event.type != KeyEventType.KeyDown || programmes.isEmpty()) return@onKeyEvent false
+                val current = currentProgrammeIndex(programmes, cursorTime)
+                when (event.key) {
+                    Key.DirectionLeft -> {
+                        if (labelSelected) {
+                            false
+                        } else if (current <= 0) {
+                            onLabelSelectedChange(true)
+                            true
+                        } else {
+                            onCursorTimeChange(programmes[current - 1].startMs.coerceAtLeast(windowStart))
+                            true
+                        }
+                    }
+                    Key.DirectionRight -> {
+                        if (labelSelected) {
+                            onLabelSelectedChange(false)
+                            onCursorTimeChange(programmes.firstOrNull()?.startMs ?: now)
+                        } else if (current < programmes.lastIndex) {
+                            onCursorTimeChange(programmes[current + 1].startMs.coerceAtLeast(windowStart))
+                        }
+                        true
+                    }
+                    Key.DirectionCenter, Key.Enter -> {
+                        if (labelSelected) {
+                            onTuneChannel(channel)
+                        } else {
+                            val programme = selectedProgramme ?: programmes.firstOrNull()
+                            if (programme != null) detail = programme else onTuneChannel(channel)
+                        }
+                        true
+                    }
+                    else -> false
+                }
+            },
+        shape = RoundedCornerShape(12.dp),
+        focusedScale = 1f,
+        glowElevation = 0,
+        focusedContainerColor = colors.surfaceContainerHigh,
+        unfocusedContainerColor = colors.surfaceContainerHigh,
+        selectedContainerColor = colors.surfaceContainerHigh,
+    ) { _ ->
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Dimens.HomeRowPaddingH),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .width(GuideGridDefaults.ChannelCol)
+                    .height(GuideGridDefaults.RowHeight)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(if (labelSelected) colors.primaryContainer else colors.surfaceContainerLowest),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                Text(
+                    text = channel.number?.let { "$it  ${channel.name}" } ?: channel.name,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = if (labelSelected) colors.onPrimaryContainer else colors.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(horizontal = 12.dp),
+                )
+            }
+
+            Box(
+                modifier = Modifier
+                    .width(windowWidth(windowStart, windowEnd))
+                    .height(GuideGridDefaults.RowHeight),
+            ) {
+                ProgrammeStripCanvas(
+                    programmes = programmes,
+                    windowStart = windowStart,
+                    windowEnd = windowEnd,
+                    now = now,
+                    highlightTime = highlightTime,
+                    hScroll = rememberScrollState(),
+                )
+            }
+        }
+    }
+
+    detail?.let { programme ->
+        ProgrammeDetailDialog(
+            channelName = channel.name,
+            programme = programme,
+            loadDescription = loadDescription,
+            canCatchup = false,
+            onWatch = {
+                detail = null
+                onTuneChannel(channel)
+            },
+            onPlayCatchup = { detail = null },
+            onDismiss = { detail = null },
+        )
+    }
+}
+
+private fun currentProgrammeIndex(programmes: List<EpgProgrammeEntity>, cursorTime: Long): Int {
+    if (programmes.isEmpty()) return -1
+    val index = programmes.indexOfLast { it.startMs <= cursorTime }
+    return if (index < 0) 0 else index
+}
+
+private fun currentProgramme(programmes: List<EpgProgrammeEntity>, cursorTime: Long): EpgProgrammeEntity? {
+    if (programmes.isEmpty()) return null
+    val index = currentProgrammeIndex(programmes, cursorTime)
+    return programmes.getOrNull(index)
+}
+
+private fun windowWidth(windowStart: Long, windowEnd: Long): androidx.compose.ui.unit.Dp {
+    val minutes = ((windowEnd - windowStart).coerceAtLeast(0L) / 60_000f)
+    return GuideGridDefaults.PxPerMin * minutes
+}

--- a/app/src/main/java/tv/own/owntv/features/home/HomeGuideSlice.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeGuideSlice.kt
@@ -1,7 +1,9 @@
 package tv.own.owntv.features.home
 
+import android.text.format.DateFormat
 import coil3.compose.AsyncImage
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -29,6 +31,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
@@ -36,6 +39,7 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -45,10 +49,9 @@ import tv.own.owntv.core.database.entity.ChannelEntity
 import tv.own.owntv.core.database.entity.EpgProgrammeEntity
 import tv.own.owntv.ui.theme.Dimens
 import tv.own.owntv.ui.components.FocusableSurface
-import tv.own.owntv.ui.components.NavAccentBar
 import tv.own.owntv.ui.components.OwnTVIcon
-import tv.own.owntv.ui.format.rememberSystemTimeFormatter
 import tv.own.owntv.ui.theme.OwnTVTheme
+import java.util.Date
 
 @Composable
 fun HomeLiveRow(
@@ -59,6 +62,7 @@ fun HomeLiveRow(
     onChannelClick: (Long, List<ChannelEntity>) -> Unit,
     onFocus: () -> Unit,
     firstItemFocusRequester: FocusRequester?,
+    onContainerDown: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     when (mode) {
@@ -76,6 +80,7 @@ fun HomeLiveRow(
             onTuneChannel = { channel -> onChannelClick(channel.id, guide.channels) },
             onFocus = onFocus,
             firstItemFocusRequester = firstItemFocusRequester,
+            onContainerDown = onContainerDown,
             modifier = modifier,
         )
     }
@@ -156,10 +161,12 @@ private fun OnNowRow(
     onTuneChannel: (ChannelEntity) -> Unit,
     onFocus: () -> Unit,
     firstItemFocusRequester: FocusRequester?,
+    onContainerDown: (() -> Unit)?,
     modifier: Modifier = Modifier,
 ) {
     val colors = OwnTVTheme.colors
     val rows = guide.channels
+    val sectionShape = RoundedCornerShape(10.dp)
     var activeRowIndex by remember { mutableIntStateOf(-1) }
     var visibleStartIndex by remember { mutableIntStateOf(0) }
 
@@ -172,26 +179,29 @@ private fun OnNowRow(
     }
 
     fun handleListKey(event: KeyEvent): Boolean {
-        if (event.type != KeyEventType.KeyDown || activeRowIndex < 0) {
+        if (event.type != KeyEventType.KeyDown) {
             return false
+        }
+        if (activeRowIndex < 0) {
+            return if (event.key == Key.DirectionDown && onContainerDown != null) {
+                onContainerDown()
+                true
+            } else {
+                false
+            }
         }
         return when (event.key) {
             Key.DirectionUp -> {
-                if (activeRowIndex == 0) {
-                    activeRowIndex = -1
-                    true
-                } else {
-                    selectRow(activeRowIndex - 1)
-                    true
-                }
+                selectRow((activeRowIndex - 1).coerceAtLeast(0))
+                true
             }
             Key.DirectionDown -> {
-                if (activeRowIndex == rows.lastIndex) {
-                    false
-                } else {
-                    selectRow(activeRowIndex + 1)
-                    true
-                }
+                selectRow((activeRowIndex + 1).coerceAtMost(rows.lastIndex))
+                true
+            }
+            Key.DirectionLeft, Key.DirectionRight, Key.Back -> {
+                activeRowIndex = -1
+                true
             }
             else -> false
         }
@@ -222,22 +232,31 @@ private fun OnNowRow(
                 }
                 if (it.hasFocus) onFocus()
             },
-        shape = RoundedCornerShape(16.dp),
+        shape = sectionShape,
         focusedScale = 1f,
         glowElevation = 0,
-        focusedContainerColor = colors.surfaceContainerHigh,
-        unfocusedContainerColor = colors.surfaceContainerHigh,
-        selectedContainerColor = colors.surfaceContainerHigh,
+        showFocusBorder = false,
+        focusedContainerColor = Color.Transparent,
+        unfocusedContainerColor = Color.Transparent,
+        selectedContainerColor = Color.Transparent,
     ) { focused ->
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(vertical = 8.dp),
+                .padding(1.dp)
+                .border(
+                    width = 1.dp,
+                    color = if (focused) {
+                        colors.primary.copy(alpha = 0.42f)
+                    } else {
+                        Color.Transparent
+                    },
+                    shape = sectionShape,
+                )
+                .padding(10.dp),
         ) {
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 12.dp),
+                modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
@@ -257,12 +276,10 @@ private fun OnNowRow(
                     overflow = TextOverflow.Ellipsis,
                 )
             }
-            Spacer(Modifier.height(6.dp))
+            Spacer(Modifier.height(10.dp))
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 12.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(7.dp),
             ) {
                 rows.drop(visibleStartIndex)
                     .take(HOME_ON_NOW_VISIBLE_ROWS)
@@ -288,64 +305,73 @@ private fun OnNowChannelItem(
     focused: Boolean,
 ) {
     val colors = OwnTVTheme.colors
-    val formatTime = rememberSystemTimeFormatter()
-    val info = remember(programmes, now, formatTime) {
+    val context = LocalContext.current
+    val rowShape = RoundedCornerShape(8.dp)
+    val info = remember(programmes, now, context) {
+        val formatTime: (Long) -> String = { ms ->
+            DateFormat.getTimeFormat(context).format(Date(ms))
+        }
         val programme = currentProgramme(programmes, now) ?: programmes.firstOrNull { it.stopMs > now } ?: programmes.firstOrNull()
         OnNowProgrammeInfo(
             title = programme?.title ?: "No programme details",
             timeLabel = programme?.let { programmeTimeLabel(it, now, formatTime) } ?: "Guide data unavailable",
             progress = programmeProgress(programme, now),
             upcoming = upcomingProgrammes(programmes, programme, HOME_ON_NOW_UPCOMING_COUNT)
-                .map { "${formatTime(it.startMs)} ${it.title}" },
+                .map { programmeUpcomingLabel(it, formatTime) },
         )
     }
 
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(68.dp)
-            .clip(RoundedCornerShape(10.dp))
-            .background(colors.surfaceContainerHigh),
+            .height(82.dp)
+            .clip(rowShape)
+            .background(
+                if (focused) {
+                    colors.surfaceContainerHighest
+                } else {
+                    colors.surfaceContainerHigh.copy(alpha = 0.58f)
+                },
+            ),
     ) {
-        NavAccentBar(visible = focused, height = 36.dp)
         Row(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(start = 14.dp, end = 10.dp, top = 7.dp, bottom = 7.dp),
+                .padding(start = 14.dp, end = 12.dp, top = 9.dp, bottom = 9.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
         ) {
             ChannelLogoBadge(channel = channel, focused = focused)
-
-            Column(
-                modifier = Modifier.width(155.dp),
-                verticalArrangement = Arrangement.Center,
-            ) {
-                Text(
-                    text = channel.number?.let { "$it  ${channel.name}" } ?: channel.name,
-                    style = MaterialTheme.typography.titleSmall,
-                    color = if (focused) colors.primary else colors.onSurface,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
 
             Column(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.Center,
             ) {
                 Text(
-                    text = info.title,
-                    style = MaterialTheme.typography.titleSmall,
-                    color = colors.onSurface,
+                    text = channel.number?.let { "$it  ${channel.name}" } ?: channel.name,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = colors.onSurfaceVariant.copy(alpha = if (focused) 0.88f else 0.70f),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
-                Spacer(Modifier.height(3.dp))
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = info.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = colors.onSurface,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(2.dp))
                 Text(
                     text = info.timeLabel,
                     style = MaterialTheme.typography.labelSmall,
-                    color = colors.primary,
+                    color = if (focused) {
+                        colors.primary.copy(alpha = 0.82f)
+                    } else {
+                        colors.onSurfaceVariant.copy(alpha = 0.62f)
+                    },
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
@@ -355,19 +381,19 @@ private fun OnNowChannelItem(
 
             if (info.upcoming.isNotEmpty()) {
                 Column(
-                    modifier = Modifier.width(330.dp),
+                    modifier = Modifier.width(300.dp),
                     verticalArrangement = Arrangement.Center,
                 ) {
                     Text(
                         text = "Next",
                         style = MaterialTheme.typography.labelSmall,
-                        color = colors.onSurfaceVariant,
+                        color = colors.onSurfaceVariant.copy(alpha = 0.52f),
                         fontWeight = FontWeight.SemiBold,
                     )
                     Text(
                         text = info.upcoming.joinToString("  ·  "),
                         style = MaterialTheme.typography.bodySmall,
-                        color = colors.onSurfaceVariant,
+                        color = colors.onSurfaceVariant.copy(alpha = 0.44f),
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
@@ -384,7 +410,7 @@ private data class OnNowProgrammeInfo(
     val upcoming: List<String>,
 )
 
-private const val HOME_ON_NOW_VISIBLE_ROWS = 6
+private const val HOME_ON_NOW_VISIBLE_ROWS = 5
 private const val HOME_ON_NOW_UPCOMING_COUNT = 4
 
 private fun visibleStartFor(
@@ -488,14 +514,14 @@ private fun ProgrammeProgressBar(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(4.dp)
+            .height(2.dp)
             .clip(RoundedCornerShape(50))
             .background(colors.surfaceContainerLowest),
     ) {
         Box(
             modifier = Modifier
                 .fillMaxWidth(progress.coerceIn(0f, 1f))
-                .height(4.dp)
+                .height(2.dp)
                 .clip(RoundedCornerShape(50))
                 .background(colors.primary),
         )
@@ -534,4 +560,11 @@ private fun programmeTimeLabel(
     } else {
         "UP NEXT · $time"
     }
+}
+
+private fun programmeUpcomingLabel(
+    programme: EpgProgrammeEntity,
+    formatTime: (Long) -> String,
+): String {
+    return "${formatTime(programme.startMs)} ${programme.title}"
 }

--- a/app/src/main/java/tv/own/owntv/features/home/HomeGuideSlice.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeGuideSlice.kt
@@ -1,23 +1,26 @@
 package tv.own.owntv.features.home
 
+import coil3.compose.AsyncImage
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateMapOf
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -27,341 +30,508 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import tv.own.owntv.core.database.entity.ChannelEntity
 import tv.own.owntv.core.database.entity.EpgProgrammeEntity
-import tv.own.owntv.features.epg.GuideGridDefaults
-import tv.own.owntv.features.epg.ProgrammeDetailDialog
-import tv.own.owntv.features.epg.ProgrammeStripCanvas
-import tv.own.owntv.features.epg.clock
 import tv.own.owntv.ui.theme.Dimens
 import tv.own.owntv.ui.components.FocusableSurface
-import tv.own.owntv.ui.components.OwnTVButton
-import tv.own.owntv.ui.components.OwnTVButtonStyle
+import tv.own.owntv.ui.components.NavAccentBar
 import tv.own.owntv.ui.components.OwnTVIcon
+import tv.own.owntv.ui.format.rememberSystemTimeFormatter
 import tv.own.owntv.ui.theme.OwnTVTheme
 
 @Composable
-fun HomeGuideSlice(
-    slice: GuideSliceState,
-    onTuneChannel: (ChannelEntity) -> Unit,
-    onOpenFullGuide: () -> Unit,
+fun HomeLiveRow(
+    title: String,
+    mode: HomeLiveRowMode,
+    channels: List<ChannelEntity>,
+    guide: GuideSliceState,
+    onChannelClick: (Long, List<ChannelEntity>) -> Unit,
     onFocus: () -> Unit,
     firstItemFocusRequester: FocusRequester?,
-    loadDescription: suspend (Long) -> String?,
+    modifier: Modifier = Modifier,
+) {
+    when (mode) {
+        HomeLiveRowMode.CARDS -> ChannelCardsRow(
+            title = title,
+            channels = channels,
+            onChannelClick = { id -> onChannelClick(id, channels) },
+            onFocus = onFocus,
+            firstItemFocusRequester = firstItemFocusRequester,
+            modifier = modifier,
+        )
+        HomeLiveRowMode.ON_NOW -> OnNowRow(
+            title = title,
+            guide = guide,
+            onTuneChannel = { channel -> onChannelClick(channel.id, guide.channels) },
+            onFocus = onFocus,
+            firstItemFocusRequester = firstItemFocusRequester,
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+private fun ChannelCardsRow(
+    title: String,
+    channels: List<ChannelEntity>,
+    onChannelClick: (Long) -> Unit,
+    onFocus: () -> Unit,
+    firstItemFocusRequester: FocusRequester?,
+    modifier: Modifier = Modifier,
+) {
+    if (channels.isEmpty()) return
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = title.uppercase(),
+            style = MaterialTheme.typography.titleSmall,
+            color = OwnTVTheme.colors.primary,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(start = Dimens.HomeRowPaddingH),
+        )
+        Spacer(Modifier.height(10.dp))
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(horizontal = Dimens.HomeRowPaddingH),
+            modifier = Modifier.focusGroup(),
+        ) {
+            itemsIndexed(channels, key = { _, channel -> channel.id }) { index, channel ->
+                Box(
+                    modifier = Modifier
+                        .width(180.dp)
+                        .height(100.dp),
+                ) {
+                    FocusableSurface(
+                        onClick = { onChannelClick(channel.id) },
+                        modifier = when {
+                            firstItemFocusRequester != null && index == 0 -> Modifier.focusRequester(firstItemFocusRequester)
+                            else -> Modifier
+                        }.onFocusChanged { if (it.hasFocus) onFocus() },
+                        shape = RoundedCornerShape(14.dp),
+                        focusedScale = 1f,
+                        focusedContainerColor = OwnTVTheme.colors.surfaceContainerHigh,
+                        unfocusedContainerColor = OwnTVTheme.colors.surfaceContainerHigh,
+                        selectedContainerColor = OwnTVTheme.colors.surfaceContainerHigh,
+                    ) { focused ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(10.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            ChannelLogo(channel, size = 44)
+                            Text(
+                                text = channel.name,
+                                style = MaterialTheme.typography.titleSmall,
+                                color = if (focused) OwnTVTheme.colors.primary else OwnTVTheme.colors.onSurface,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun OnNowRow(
+    title: String,
+    guide: GuideSliceState,
+    onTuneChannel: (ChannelEntity) -> Unit,
+    onFocus: () -> Unit,
+    firstItemFocusRequester: FocusRequester?,
     modifier: Modifier = Modifier,
 ) {
     val colors = OwnTVTheme.colors
-    val rows = remember(slice.channels, slice.programmes) {
-        slice.channels.filter { slice.programmes[it.id].orEmpty().isNotEmpty() }
-    }
-    val cursorTimes = remember(slice.now, rows.map { it.id }) {
-        mutableStateMapOf<Long, Long>().apply {
-            rows.forEach { put(it.id, slice.now) }
-        }
-    }
-    val labelSelected = remember(slice.now, rows.map { it.id }) {
-        mutableStateMapOf<Long, Boolean>().apply {
-            rows.forEach { put(it.id, false) }
-        }
-    }
-    val windowWidth = GuideGridDefaults.PxPerMin * (((slice.windowEnd - slice.windowStart).coerceAtLeast(0L) / 60_000f))
-    val detailFocusRow = remember { mutableStateMapOf<Long, FocusRequester>() }
-    var focusedChannelId by remember { mutableStateOf<Long?>(null) }
+    val rows = guide.channels
+    var activeRowIndex by remember { mutableIntStateOf(-1) }
+    var visibleStartIndex by remember { mutableIntStateOf(0) }
 
     if (rows.isEmpty()) return
 
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .focusGroup(),
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = Dimens.HomeRowPaddingH),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = "ON NOW",
-                style = MaterialTheme.typography.titleSmall,
-                color = colors.primary,
-                fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
-            )
-            Spacer(Modifier.weight(1f))
-            OwnTVButton(
-                label = "View full guide",
-                onClick = onOpenFullGuide,
-                icon = OwnTVIcon.EPG,
-                style = OwnTVButtonStyle.SECONDARY,
-                modifier = Modifier.onFocusChanged {
-                    if (it.hasFocus) {
-                        focusedChannelId = null
-                        onFocus()
-                    }
-                },
-            )
+    fun selectRow(index: Int) {
+        val target = index.coerceIn(0, rows.lastIndex)
+        activeRowIndex = target
+        visibleStartIndex = visibleStartFor(target, visibleStartIndex, rows.size)
+    }
+
+    fun handleListKey(event: KeyEvent): Boolean {
+        if (event.type != KeyEventType.KeyDown || activeRowIndex < 0) {
+            return false
         }
-
-        Spacer(Modifier.height(10.dp))
-        GuideLiteTimeAxis(
-            windowStart = slice.windowStart,
-            windowEnd = slice.windowEnd,
-            width = windowWidth,
-        )
-        Spacer(Modifier.height(8.dp))
-
-        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-            rows.forEachIndexed { index, channel ->
-                val rowFocus = detailFocusRow.getOrPut(channel.id) { FocusRequester() }
-                val rowCursor = cursorTimes[channel.id] ?: slice.now
-                val rowLabelSelected = labelSelected[channel.id] ?: false
-                val programmes = slice.programmes[channel.id].orEmpty()
-                val selectedProgramme = currentProgramme(programmes, rowCursor)
-                val highlightTime = if (focusedChannelId == channel.id && !rowLabelSelected) {
-                    selectedProgramme?.startMs ?: rowCursor
+        return when (event.key) {
+            Key.DirectionUp -> {
+                if (activeRowIndex == 0) {
+                    activeRowIndex = -1
+                    true
                 } else {
-                    null
+                    selectRow(activeRowIndex - 1)
+                    true
                 }
-                GuideLiteRow(
-                    channel = channel,
-                    programmes = programmes,
-                    windowStart = slice.windowStart,
-                    windowEnd = slice.windowEnd,
-                    now = slice.now,
-                    cursorTime = rowCursor,
-                    highlightTime = highlightTime,
-                    labelSelected = rowLabelSelected,
-                    focusRequester = if (index == 0 && firstItemFocusRequester != null) firstItemFocusRequester else rowFocus,
-                    onCursorTimeChange = { cursorTimes[channel.id] = it },
-                    onLabelSelectedChange = { labelSelected[channel.id] = it },
-                    onTuneChannel = onTuneChannel,
-                    onFocus = {
-                        focusedChannelId = channel.id
-                        onFocus()
-                    },
-                    loadDescription = loadDescription,
-                    modifier = Modifier.fillMaxWidth(),
-                )
             }
-        }
-    }
-}
-
-@Composable
-private fun GuideLiteTimeAxis(
-    windowStart: Long,
-    windowEnd: Long,
-    width: androidx.compose.ui.unit.Dp,
-) {
-    val colors = OwnTVTheme.colors
-    val slotWidth = GuideGridDefaults.PxPerMin * GuideGridDefaults.SlotMin.toFloat()
-    val slots = (((windowEnd - windowStart).coerceAtLeast(0L) / 60_000L) / GuideGridDefaults.SlotMin).toInt()
-        .coerceAtLeast(1)
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(start = Dimens.HomeRowPaddingH),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Spacer(Modifier.width(GuideGridDefaults.ChannelCol))
-        Row(
-            modifier = Modifier.width(width),
-            horizontalArrangement = Arrangement.spacedBy(0.dp),
-        ) {
-            repeat(slots) { index ->
-                val slotStart = windowStart + index * GuideGridDefaults.SlotMin * 60_000L
-                Text(
-                    text = clock(slotStart),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = colors.onSurfaceVariant,
-                    fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold,
-                    modifier = Modifier.width(slotWidth).padding(start = 6.dp),
-                )
+            Key.DirectionDown -> {
+                if (activeRowIndex == rows.lastIndex) {
+                    false
+                } else {
+                    selectRow(activeRowIndex + 1)
+                    true
+                }
             }
+            else -> false
         }
     }
-}
-
-@Composable
-private fun GuideLiteRow(
-    channel: ChannelEntity,
-    programmes: List<EpgProgrammeEntity>,
-    windowStart: Long,
-    windowEnd: Long,
-    now: Long,
-    cursorTime: Long,
-    highlightTime: Long?,
-    labelSelected: Boolean,
-    focusRequester: FocusRequester,
-    onCursorTimeChange: (Long) -> Unit,
-    onLabelSelectedChange: (Boolean) -> Unit,
-    onTuneChannel: (ChannelEntity) -> Unit,
-    onFocus: () -> Unit,
-    loadDescription: suspend (Long) -> String?,
-    modifier: Modifier = Modifier,
-) {
-    val colors = OwnTVTheme.colors
-    var detail by remember { mutableStateOf<EpgProgrammeEntity?>(null) }
-    val useFocusRequester = focusRequester
-    var hadDialog by remember { mutableStateOf(false) }
-
-    LaunchedEffect(detail) {
-        if (detail != null) {
-            hadDialog = true
-            return@LaunchedEffect
-        }
-        if (hadDialog) {
-            hadDialog = false
-            kotlinx.coroutines.delay(40)
-            runCatching { useFocusRequester.requestFocus() }
-        }
-    }
-
-    val selectedIndex = currentProgrammeIndex(programmes, cursorTime)
-    val selectedProgramme = programmes.getOrNull(selectedIndex)
 
     FocusableSurface(
         onClick = {
-            if (labelSelected) {
-                onTuneChannel(channel)
+            if (activeRowIndex < 0) {
+                selectRow(visibleStartIndex.coerceAtMost(rows.lastIndex))
             } else {
-                val programme = selectedProgramme ?: programmes.firstOrNull()
-                if (programme != null) {
-                    detail = programme
-                } else {
-                    onTuneChannel(channel)
-                }
+                rows.getOrNull(activeRowIndex)?.let(onTuneChannel)
             }
         },
         modifier = modifier
-            .height(GuideGridDefaults.RowHeight)
-            .focusRequester(useFocusRequester)
+            .fillMaxWidth()
+            .padding(horizontal = Dimens.HomeRowPaddingH)
+            .then(
+                if (firstItemFocusRequester != null) {
+                    Modifier.focusRequester(firstItemFocusRequester)
+                } else {
+                    Modifier
+                },
+            )
+            .onPreviewKeyEvent(::handleListKey)
             .onFocusChanged {
-                if (it.hasFocus) {
-                    onFocus()
+                if (!it.hasFocus) {
+                    activeRowIndex = -1
                 }
-            }
-            .onKeyEvent { event ->
-                if (event.type != KeyEventType.KeyDown || programmes.isEmpty()) return@onKeyEvent false
-                val current = currentProgrammeIndex(programmes, cursorTime)
-                when (event.key) {
-                    Key.DirectionLeft -> {
-                        if (labelSelected) {
-                            false
-                        } else if (current <= 0) {
-                            onLabelSelectedChange(true)
-                            true
-                        } else {
-                            onCursorTimeChange(programmes[current - 1].startMs.coerceAtLeast(windowStart))
-                            true
-                        }
-                    }
-                    Key.DirectionRight -> {
-                        if (labelSelected) {
-                            onLabelSelectedChange(false)
-                            onCursorTimeChange(programmes.firstOrNull()?.startMs ?: now)
-                        } else if (current < programmes.lastIndex) {
-                            onCursorTimeChange(programmes[current + 1].startMs.coerceAtLeast(windowStart))
-                        }
-                        true
-                    }
-                    Key.DirectionCenter, Key.Enter -> {
-                        if (labelSelected) {
-                            onTuneChannel(channel)
-                        } else {
-                            val programme = selectedProgramme ?: programmes.firstOrNull()
-                            if (programme != null) detail = programme else onTuneChannel(channel)
-                        }
-                        true
-                    }
-                    else -> false
-                }
+                if (it.hasFocus) onFocus()
             },
-        shape = RoundedCornerShape(12.dp),
+        shape = RoundedCornerShape(16.dp),
         focusedScale = 1f,
         glowElevation = 0,
         focusedContainerColor = colors.surfaceContainerHigh,
         unfocusedContainerColor = colors.surfaceContainerHigh,
         selectedContainerColor = colors.surfaceContainerHigh,
-    ) { _ ->
-        Row(
+    ) { focused ->
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = Dimens.HomeRowPaddingH),
-            verticalAlignment = Alignment.CenterVertically,
+                .padding(vertical = 8.dp),
         ) {
-            Box(
+            Row(
                 modifier = Modifier
-                    .width(GuideGridDefaults.ChannelCol)
-                    .height(GuideGridDefaults.RowHeight)
-                    .clip(RoundedCornerShape(10.dp))
-                    .background(if (labelSelected) colors.primaryContainer else colors.surfaceContainerLowest),
-                contentAlignment = Alignment.CenterStart,
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "${title.uppercase()} · ON NOW",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = colors.primary,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.weight(1f))
+                Text(
+                    text = if (focused && activeRowIndex >= 0) "OK to watch" else if (focused) "OK to browse" else "${rows.size} channels",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = colors.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Spacer(Modifier.height(6.dp))
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                rows.drop(visibleStartIndex)
+                    .take(HOME_ON_NOW_VISIBLE_ROWS)
+                    .forEachIndexed { visibleIndex, channel ->
+                        val index = visibleStartIndex + visibleIndex
+                        OnNowChannelItem(
+                            channel = channel,
+                            programmes = guide.programmes[channel.id].orEmpty(),
+                            now = guide.now,
+                            focused = focused && activeRowIndex == index,
+                        )
+                    }
+            }
+        }
+    }
+}
+
+@Composable
+private fun OnNowChannelItem(
+    channel: ChannelEntity,
+    programmes: List<EpgProgrammeEntity>,
+    now: Long,
+    focused: Boolean,
+) {
+    val colors = OwnTVTheme.colors
+    val formatTime = rememberSystemTimeFormatter()
+    val info = remember(programmes, now, formatTime) {
+        val programme = currentProgramme(programmes, now) ?: programmes.firstOrNull { it.stopMs > now } ?: programmes.firstOrNull()
+        OnNowProgrammeInfo(
+            title = programme?.title ?: "No programme details",
+            timeLabel = programme?.let { programmeTimeLabel(it, now, formatTime) } ?: "Guide data unavailable",
+            progress = programmeProgress(programme, now),
+            upcoming = upcomingProgrammes(programmes, programme, HOME_ON_NOW_UPCOMING_COUNT)
+                .map { "${formatTime(it.startMs)} ${it.title}" },
+        )
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(68.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(colors.surfaceContainerHigh),
+    ) {
+        NavAccentBar(visible = focused, height = 36.dp)
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(start = 14.dp, end = 10.dp, top = 7.dp, bottom = 7.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            ChannelLogoBadge(channel = channel, focused = focused)
+
+            Column(
+                modifier = Modifier.width(155.dp),
+                verticalArrangement = Arrangement.Center,
             ) {
                 Text(
                     text = channel.number?.let { "$it  ${channel.name}" } ?: channel.name,
                     style = MaterialTheme.typography.titleSmall,
-                    color = if (labelSelected) colors.onPrimaryContainer else colors.onSurface,
+                    color = if (focused) colors.primary else colors.onSurface,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.padding(horizontal = 12.dp),
                 )
             }
 
-            Box(
-                modifier = Modifier
-                    .width(windowWidth(windowStart, windowEnd))
-                    .height(GuideGridDefaults.RowHeight),
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.Center,
             ) {
-                ProgrammeStripCanvas(
-                    programmes = programmes,
-                    windowStart = windowStart,
-                    windowEnd = windowEnd,
-                    now = now,
-                    highlightTime = highlightTime,
-                    hScroll = rememberScrollState(),
+                Text(
+                    text = info.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = colors.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
+                Spacer(Modifier.height(3.dp))
+                Text(
+                    text = info.timeLabel,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = colors.primary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(5.dp))
+                ProgrammeProgressBar(progress = info.progress)
+            }
+
+            if (info.upcoming.isNotEmpty()) {
+                Column(
+                    modifier = Modifier.width(330.dp),
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    Text(
+                        text = "Next",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = colors.onSurfaceVariant,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Text(
+                        text = info.upcoming.joinToString("  ·  "),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = colors.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
             }
         }
     }
+}
 
-    detail?.let { programme ->
-        ProgrammeDetailDialog(
-            channelName = channel.name,
-            programme = programme,
-            loadDescription = loadDescription,
-            canCatchup = false,
-            onWatch = {
-                detail = null
-                onTuneChannel(channel)
-            },
-            onPlayCatchup = { detail = null },
-            onDismiss = { detail = null },
+private data class OnNowProgrammeInfo(
+    val title: String,
+    val timeLabel: String,
+    val progress: Float,
+    val upcoming: List<String>,
+)
+
+private const val HOME_ON_NOW_VISIBLE_ROWS = 6
+private const val HOME_ON_NOW_UPCOMING_COUNT = 4
+
+private fun visibleStartFor(
+    activeIndex: Int,
+    currentStart: Int,
+    rowCount: Int,
+): Int {
+    val maxStart = (rowCount - HOME_ON_NOW_VISIBLE_ROWS).coerceAtLeast(0)
+    return when {
+        activeIndex < currentStart -> activeIndex
+        activeIndex >= currentStart + HOME_ON_NOW_VISIBLE_ROWS -> activeIndex - HOME_ON_NOW_VISIBLE_ROWS + 1
+        else -> currentStart
+    }.coerceIn(0, maxStart)
+}
+
+@Composable
+private fun ChannelTextBadge(
+    channel: ChannelEntity,
+    focused: Boolean,
+) {
+    val colors = OwnTVTheme.colors
+    val text = channel.number?.toString() ?: channel.name.firstOrNull()?.uppercase().orEmpty()
+    Box(
+        modifier = Modifier
+            .size(46.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(if (focused) colors.primaryContainer else colors.surfaceContainerLowest),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelLarge,
+            color = if (focused) colors.onPrimaryContainer else colors.onSurfaceVariant,
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
     }
 }
 
-private fun currentProgrammeIndex(programmes: List<EpgProgrammeEntity>, cursorTime: Long): Int {
-    if (programmes.isEmpty()) return -1
-    val index = programmes.indexOfLast { it.startMs <= cursorTime }
-    return if (index < 0) 0 else index
+@Composable
+private fun ChannelLogoBadge(
+    channel: ChannelEntity,
+    focused: Boolean,
+) {
+    val colors = OwnTVTheme.colors
+    Box(
+        modifier = Modifier
+            .size(46.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(if (focused) colors.primaryContainer else colors.surfaceContainerLowest),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (!channel.logoUrl.isNullOrBlank()) {
+            AsyncImage(
+                model = channel.logoUrl,
+                contentDescription = null,
+                modifier = Modifier.size(40.dp),
+                contentScale = ContentScale.Fit,
+            )
+        } else {
+            ChannelTextBadge(channel = channel, focused = focused)
+        }
+    }
 }
 
-private fun currentProgramme(programmes: List<EpgProgrammeEntity>, cursorTime: Long): EpgProgrammeEntity? {
-    if (programmes.isEmpty()) return null
-    val index = currentProgrammeIndex(programmes, cursorTime)
-    return programmes.getOrNull(index)
+@Composable
+private fun ChannelLogo(
+    channel: ChannelEntity,
+    size: Int,
+) {
+    Box(
+        modifier = Modifier
+            .size(size.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(OwnTVTheme.colors.surfaceContainerLowest),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (!channel.logoUrl.isNullOrBlank()) {
+            AsyncImage(
+                model = channel.logoUrl,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Fit,
+            )
+        } else {
+            OwnTVIcon(
+                OwnTVIcon.LIVE_TV,
+                tint = OwnTVTheme.colors.onSurfaceVariant,
+                modifier = Modifier.size((size / 2).dp),
+            )
+        }
+    }
 }
 
-private fun windowWidth(windowStart: Long, windowEnd: Long): androidx.compose.ui.unit.Dp {
-    val minutes = ((windowEnd - windowStart).coerceAtLeast(0L) / 60_000f)
-    return GuideGridDefaults.PxPerMin * minutes
+@Composable
+private fun ProgrammeProgressBar(
+    progress: Float,
+) {
+    val colors = OwnTVTheme.colors
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(4.dp)
+            .clip(RoundedCornerShape(50))
+            .background(colors.surfaceContainerLowest),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(progress.coerceIn(0f, 1f))
+                .height(4.dp)
+                .clip(RoundedCornerShape(50))
+                .background(colors.primary),
+        )
+    }
+}
+
+private fun currentProgramme(programmes: List<EpgProgrammeEntity>, now: Long): EpgProgrammeEntity? {
+    return programmes.firstOrNull { now in it.startMs until it.stopMs }
+}
+
+private fun upcomingProgrammes(
+    programmes: List<EpgProgrammeEntity>,
+    current: EpgProgrammeEntity?,
+    limit: Int,
+): List<EpgProgrammeEntity> {
+    if (current == null) return programmes.take(limit)
+    val currentIndex = programmes.indexOfFirst { it.id == current.id }
+    if (currentIndex < 0) return programmes.take(limit)
+    return programmes.drop(currentIndex + 1).take(limit)
+}
+
+private fun programmeProgress(programme: EpgProgrammeEntity?, now: Long): Float {
+    if (programme == null || now !in programme.startMs until programme.stopMs) return 0f
+    val duration = (programme.stopMs - programme.startMs).coerceAtLeast(1L)
+    return (now - programme.startMs).toFloat() / duration.toFloat()
+}
+
+private fun programmeTimeLabel(
+    programme: EpgProgrammeEntity,
+    now: Long,
+    formatTime: (Long) -> String,
+): String {
+    val time = "${formatTime(programme.startMs)}-${formatTime(programme.stopMs)}"
+    return if (now in programme.startMs until programme.stopMs) {
+        "NOW · $time"
+    } else {
+        "UP NEXT · $time"
+    }
 }

--- a/app/src/main/java/tv/own/owntv/features/home/HomeRow.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeRow.kt
@@ -9,7 +9,7 @@ enum class HomeRow(
     val implemented: Boolean = true,
 ) {
     HERO("Keep Watching", "The large preview row at the top"),
-    RECENT_CHANNELS("Recently Watched TV", "Live channels you tuned recently"),
+    RECENT_CHANNELS("Recent Channels", "Live channels you tuned recently"),
     FAVORITE_CHANNELS("Favourite Channels", "Your favourited live channels"),
     CONTINUE_MOVIES("Continue Watching Movies", "Movies with a saved position"),
     CONTINUE_SERIES("Continue Watching Series", "Episodes to resume or play next"),
@@ -33,7 +33,7 @@ enum class HeroKind {
 
 data class HomeConfig(
     val order: List<HomeRow> = HomeRow.entries.toList(),
-    val hidden: Set<HomeRow> = emptySet(),
+    val hidden: Set<HomeRow> = setOf(HomeRow.RECENT_CHANNELS),
     val heroIncludeLive: Boolean = true,
     val heroIncludeMovies: Boolean = true,
     val heroIncludeSeries: Boolean = true,
@@ -61,9 +61,8 @@ data class HomeConfig(
             if (raw.isNullOrBlank()) return HomeConfig()
             val obj = runCatching { JSONObject(raw) }.getOrNull() ?: return HomeConfig()
             val storedOrder = obj.optJSONArray("order").toHomeRows()
-            val hidden = obj.optJSONArray("hidden")
-                .toHomeRows()
-                .toSet()
+            val hidden = if (obj.has("hidden")) obj.optJSONArray("hidden").toHomeRows().toSet()
+                else HomeConfig().hidden
             return HomeConfig(
                 order = mergeOrder(storedOrder),
                 hidden = hidden,

--- a/app/src/main/java/tv/own/owntv/features/home/HomeRow.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeRow.kt
@@ -1,0 +1,92 @@
+package tv.own.owntv.features.home
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+enum class HomeRow(
+    val title: String,
+    val settingsDesc: String,
+    val implemented: Boolean = true,
+) {
+    HERO("Keep Watching", "The large preview row at the top"),
+    RECENT_CHANNELS("Recently Watched TV", "Live channels you tuned recently"),
+    FAVORITE_CHANNELS("Favourite Channels", "Your favourited live channels"),
+    CONTINUE_MOVIES("Continue Watching Movies", "Movies with a saved position"),
+    CONTINUE_SERIES("Continue Watching Series", "Episodes to resume or play next"),
+    GUIDE_SLICE("On Now", "A mini TV Guide for your recent channels"),
+}
+
+enum class HeroKind {
+    LIVE, MOVIES, SERIES,
+}
+
+data class HomeConfig(
+    val order: List<HomeRow> = HomeRow.entries.toList(),
+    val hidden: Set<HomeRow> = emptySet(),
+    val heroIncludeLive: Boolean = true,
+    val heroIncludeMovies: Boolean = true,
+    val heroIncludeSeries: Boolean = true,
+) {
+    val visibleOrder: List<HomeRow>
+        get() = order.filter { it.implemented && it !in hidden }
+
+    val settingsRows: List<HomeRow>
+        get() = order.filter { it.implemented }
+
+    fun toJson(): JSONObject = JSONObject().apply {
+        put("order", JSONArray(order.map { it.name }))
+        put("hidden", JSONArray(hidden.map { it.name }))
+        put("heroLive", heroIncludeLive)
+        put("heroMovies", heroIncludeMovies)
+        put("heroSeries", heroIncludeSeries)
+    }
+
+    companion object {
+        fun fromJson(raw: String?): HomeConfig {
+            if (raw.isNullOrBlank()) return HomeConfig()
+            val obj = runCatching { JSONObject(raw) }.getOrNull() ?: return HomeConfig()
+            val storedOrder = obj.optJSONArray("order").toHomeRows()
+            val hidden = obj.optJSONArray("hidden")
+                .toHomeRows()
+                .toSet()
+            return HomeConfig(
+                order = mergeOrder(storedOrder),
+                hidden = hidden,
+                heroIncludeLive = readBool(obj, "heroLive", "heroIncludeLive", default = true),
+                heroIncludeMovies = readBool(obj, "heroMovies", "heroIncludeMovies", default = true),
+                heroIncludeSeries = readBool(obj, "heroSeries", "heroIncludeSeries", default = true),
+            )
+        }
+
+        private fun readBool(obj: JSONObject, primary: String, fallback: String, default: Boolean): Boolean =
+            when {
+                obj.has(primary) -> obj.optBoolean(primary, default)
+                obj.has(fallback) -> obj.optBoolean(fallback, default)
+                else -> default
+            }
+    }
+}
+
+fun mergeOrder(stored: List<HomeRow>): List<HomeRow> {
+    val result = LinkedHashSet<HomeRow>()
+    stored.forEach { result += it }
+    HomeRow.entries.forEachIndexed { index, row ->
+        if (row !in result) {
+            val current = result.toMutableList()
+            current.add(index.coerceAtMost(current.size), row)
+            result.clear()
+            result += current
+        }
+    }
+    return result.toList()
+}
+
+private fun JSONArray?.toHomeRows(): List<HomeRow> {
+    if (this == null) return emptyList()
+    val out = ArrayList<HomeRow>(length())
+    for (i in 0 until length()) {
+        val row = runCatching { HomeRow.valueOf(optString(i)) }.getOrNull() ?: continue
+        if (row !in out) out += row
+    }
+    return out
+}

--- a/app/src/main/java/tv/own/owntv/features/home/HomeRow.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeRow.kt
@@ -13,7 +13,18 @@ enum class HomeRow(
     FAVORITE_CHANNELS("Favourite Channels", "Your favourited live channels"),
     CONTINUE_MOVIES("Continue Watching Movies", "Movies with a saved position"),
     CONTINUE_SERIES("Continue Watching Series", "Episodes to resume or play next"),
-    GUIDE_SLICE("On Now", "A mini TV Guide for your recent channels"),
+}
+
+enum class HomeLiveRowMode(
+    val label: String,
+) {
+    CARDS("Cards"),
+    ON_NOW("On Now");
+
+    fun toggled(): HomeLiveRowMode = when (this) {
+        CARDS -> ON_NOW
+        ON_NOW -> CARDS
+    }
 }
 
 enum class HeroKind {
@@ -26,6 +37,8 @@ data class HomeConfig(
     val heroIncludeLive: Boolean = true,
     val heroIncludeMovies: Boolean = true,
     val heroIncludeSeries: Boolean = true,
+    val recentLiveMode: HomeLiveRowMode = HomeLiveRowMode.CARDS,
+    val favoriteLiveMode: HomeLiveRowMode = HomeLiveRowMode.ON_NOW,
 ) {
     val visibleOrder: List<HomeRow>
         get() = order.filter { it.implemented && it !in hidden }
@@ -39,6 +52,8 @@ data class HomeConfig(
         put("heroLive", heroIncludeLive)
         put("heroMovies", heroIncludeMovies)
         put("heroSeries", heroIncludeSeries)
+        put("recentLiveMode", recentLiveMode.name)
+        put("favoriteLiveMode", favoriteLiveMode.name)
     }
 
     companion object {
@@ -55,6 +70,8 @@ data class HomeConfig(
                 heroIncludeLive = readBool(obj, "heroLive", "heroIncludeLive", default = true),
                 heroIncludeMovies = readBool(obj, "heroMovies", "heroIncludeMovies", default = true),
                 heroIncludeSeries = readBool(obj, "heroSeries", "heroIncludeSeries", default = true),
+                recentLiveMode = readLiveMode(obj, "recentLiveMode", HomeLiveRowMode.CARDS),
+                favoriteLiveMode = readLiveMode(obj, "favoriteLiveMode", HomeLiveRowMode.ON_NOW),
             )
         }
 
@@ -64,6 +81,9 @@ data class HomeConfig(
                 obj.has(fallback) -> obj.optBoolean(fallback, default)
                 else -> default
             }
+
+        private fun readLiveMode(obj: JSONObject, key: String, default: HomeLiveRowMode): HomeLiveRowMode =
+            runCatching { HomeLiveRowMode.valueOf(obj.optString(key)) }.getOrDefault(default)
     }
 }
 

--- a/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
@@ -25,6 +25,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -33,6 +35,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -67,6 +70,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
+import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import tv.own.owntv.core.database.entity.ChannelEntity
 import tv.own.owntv.core.launcher.LauncherContinuationItem
@@ -112,16 +116,16 @@ fun HomeScreen(
     val heroFocus = remember { FocusRequester() }
     val fallbackFocus = remember { FocusRequester() }
     val firstRowFocus = remember { FocusRequester() }
-    // The SELECTED hero is always shown wide (with its poster) — default the first one, even before the row
-    // is focused. Video only plays once the row is focused (see the preview effect below). Expansion is
-    // decoupled from playback, so the wide card never collapses just because the video hasn't started.
-    var expandedHeroIndex by remember { mutableStateOf(0) }
+    // Nothing starts expanded: a hero card earns its wide (16:9) state only after 3s of continuous focus
+    // (see the dwell effect below). Moving focus — to another card or out of the row — collapses it again.
+    var expandedHeroIndex by remember { mutableStateOf(-1) }
     var focusedHeroIndex by remember { mutableStateOf(-1) }
 
     val onNonHeroFocused = remember(vm, heroPreviewEngine) {
         {
             vm.setHeroFocused(false)
-            heroPreviewEngine.stop() // stop the video, but keep the selected hero expanded (poster)
+            heroPreviewEngine.stop()
+            expandedHeroIndex = -1
             onChildFocused()
         }
     }
@@ -133,7 +137,17 @@ fun HomeScreen(
         kotlinx.coroutines.delay(40L)
         if (focusedHeroIndex != -1) return@LaunchedEffect
         vm.setHeroFocused(false)
-        heroPreviewEngine.stop() // keep the selected hero expanded (poster); just stop the video
+        heroPreviewEngine.stop()
+        expandedHeroIndex = -1
+    }
+
+    // Dwell-to-expand: a card widens only after 3s of uninterrupted focus. Navigating away cancels the
+    // timer (this effect restarts), so quick D-pad sweeps never expand anything.
+    LaunchedEffect(focusedHeroIndex) {
+        val index = focusedHeroIndex
+        if (index < 0) return@LaunchedEffect
+        kotlinx.coroutines.delay(3_000L)
+        if (focusedHeroIndex == index) expandedHeroIndex = index
     }
 
     LaunchedEffect(previewEnabled) {
@@ -216,8 +230,8 @@ fun HomeScreen(
                         if (hasFocus) {
                             if (expandedHeroIndex != index) {
                                 heroPreviewEngine.stop() // stop the previous hero's video before switching
+                                expandedHeroIndex = -1 // collapse immediately; the dwell timer re-expands after 3s
                             }
-                            expandedHeroIndex = index // expand the focused hero immediately (poster shows first)
                             focusedHeroIndex = index
                             vm.onHeroUserNavigate(index)
                             vm.setHeroFocused(true)
@@ -329,10 +343,24 @@ private fun HeroRowSection(
     var previewRectInRowPx by remember { mutableStateOf<Rect?>(null) }
     var localFocusedIndex by remember { mutableStateOf(-1) }
     var rowWidthDp by remember { mutableStateOf(0.dp) }
+    // Set when a focus move collapses the previously expanded card ("collapse handoff"): scroll-to-start
+    // would fight the collapse animation and shove the newly focused card around, so that one move uses
+    // minimal bring-into-view scrolling instead.
+    var skipScrollToStart by remember { mutableStateOf(false) }
     val heroRowState = rememberLazyListState()
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(expandedIndex) {
+        // The rect is only ever written by the expanded card's onGloballyPositioned; drop it on collapse
+        // so the next expansion can't flash its overlay at the previous card's stale position.
+        if (expandedIndex < 0) previewRectInRowPx = null
+    }
 
     LaunchedEffect(localFocusedIndex) {
-        if (localFocusedIndex >= 0) {
+        if (localFocusedIndex < 0) return@LaunchedEffect
+        if (skipScrollToStart) {
+            skipScrollToStart = false
+        } else {
             heroRowState.animateScrollToItem(localFocusedIndex)
         }
     }
@@ -388,11 +416,21 @@ private fun HeroRowSection(
                         is HeroItem.LiveHero -> item.channel.logoUrl
                     }
 
+                    val bringIntoView = remember { BringIntoViewRequester() }
+                    LaunchedEffect(isExpanded) {
+                        if (isExpanded) {
+                            // Wait out the 500ms width tween so bringIntoView measures the final wide bounds.
+                            kotlinx.coroutines.delay(520L)
+                            bringIntoView.bringIntoView()
+                        }
+                    }
+
                     val heroGlowColor = colors.focusGlow
                     Box(
                         modifier = Modifier
                             .height(cardHeight)
                             .width(width)
+                            .bringIntoViewRequester(bringIntoView)
                             .then(if (isExpanded) Modifier.zIndex(1f) else Modifier)
                             .then(
                                 if (isExpanded) Modifier.onGloballyPositioned { coords ->
@@ -414,7 +452,15 @@ private fun HeroRowSection(
                                 .height(cardHeight)
                                 .then(if (index == 0) Modifier.focusRequester(heroFocusRequester) else Modifier)
                                 .onFocusChanged { fs ->
-                                    if (fs.hasFocus) localFocusedIndex = index
+                                    if (fs.hasFocus) {
+                                        // expandedIndex still holds the pre-collapse value here: a focus
+                                        // move off an expanded card is the collapse handoff.
+                                        if (expandedIndex >= 0 && expandedIndex != index) {
+                                            skipScrollToStart = true
+                                            scope.launch { bringIntoView.bringIntoView() }
+                                        }
+                                        localFocusedIndex = index
+                                    }
                                     onHeroFocusChanged(index, fs.hasFocus)
                                 }
                                 .then(

--- a/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -140,6 +141,11 @@ fun HomeScreen(
         if (!previewEnabled) {
             vm.stopPreview() // keep the hero expanded (poster); just stop the video
         }
+    }
+
+    // The engine is an app-scoped singleton; make sure the preview can't outlive the Home screen.
+    DisposableEffect(heroPreviewEngine) {
+        onDispose { heroPreviewEngine.stop() }
     }
 
     LaunchedEffect(state.heroItems, state.continueMovies, state.continueSeries, state.favoriteLive, restoreFocus) {
@@ -437,6 +443,9 @@ private fun HeroRowSection(
                             contentAlignment = Alignment.Center,
                         ) { focused ->
                             if (isExpanded) {
+                                // No blurred backdrop here: the preview overlay covers this card as soon
+                                // as previewRectInRowPx is known and renders the blur itself — doubling the
+                                // blur underneath just costs frames on TV hardware.
                                 Box(Modifier.fillMaxSize().background(Color.Black)) {
                                     if (!imageUrl.isNullOrBlank()) {
                                         AsyncImage(
@@ -567,12 +576,24 @@ private fun HeroRowSection(
                                 modifier = Modifier.fillMaxSize(),
                             )
                             if (engineState != HeroPreviewEngine.State.PLAYING) {
+                                // Opaque cover: the SurfaceView below holds the previous preview's last
+                                // frame after stop(), and the parent's black background is punched out by
+                                // the SurfaceView. Everything above (loading images, translucent blur,
+                                // transparent logos, bare fallback icon) relies on this layer to hide it.
+                                Box(Modifier.fillMaxSize().background(Color.Black))
                                 val artUrl = when (expandedItem) {
                                     is HeroItem.MovieHero -> expandedItem.movie.posterUrl
                                     is HeroItem.SeriesHero -> expandedItem.series.posterUrl
                                     is HeroItem.LiveHero -> expandedItem.channel.logoUrl
                                 }
                                 if (!artUrl.isNullOrBlank()) {
+                                    AsyncImage(
+                                        model = artUrl,
+                                        contentDescription = null,
+                                        modifier = Modifier.fillMaxSize().blur(20.dp),
+                                        contentScale = ContentScale.Crop,
+                                        alpha = 0.5f,
+                                    )
                                     AsyncImage(
                                         model = artUrl,
                                         contentDescription = null,

--- a/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
@@ -25,8 +25,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.relocation.BringIntoViewRequester
-import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -399,10 +397,6 @@ private fun HeroRowSection(
     var localFocusedIndex by remember { mutableStateOf(-1) }
     var rowWidthDp by remember { mutableStateOf(0.dp) }
     var alignToActiveHeroKey by remember { mutableStateOf<String?>(null) }
-    // Set when a focus move collapses the previously expanded card ("collapse handoff"): scroll-to-start
-    // would fight the collapse animation and shove the newly focused card around, so that one move uses
-    // minimal bring-into-view scrolling instead.
-    var skipScrollToStart by remember { mutableStateOf(false) }
     val heroRowState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     val itemsSignature = remember(items) { items.joinToString(separator = "|") { it.heroKey() } }
@@ -412,7 +406,6 @@ private fun HeroRowSection(
         if (activeHeroIndex !in items.indices) return@LaunchedEffect
 
         alignToActiveHeroKey = activeHeroKey
-        skipScrollToStart = false
         heroRowState.scrollToItem(activeHeroIndex)
 
         if (activeHeroIndex == 0 && localFocusedIndex >= 0 && localFocusedIndex != activeHeroIndex) {
@@ -433,11 +426,7 @@ private fun HeroRowSection(
 
     LaunchedEffect(localFocusedIndex) {
         if (localFocusedIndex < 0) return@LaunchedEffect
-        if (skipScrollToStart) {
-            skipScrollToStart = false
-        } else {
-            heroRowState.animateScrollToItem(localFocusedIndex)
-        }
+        heroRowState.animateScrollToItem(localFocusedIndex)
     }
 
     val endPadding = (rowWidthDp - Dimens.HeroBaseWidth - Dimens.HomeRowPaddingH).coerceAtLeast(Dimens.HomeRowPaddingH)
@@ -485,14 +474,11 @@ private fun HeroRowSection(
                         is HeroItem.LiveHero -> item.channel.logoUrl
                     }
 
-                    val bringIntoView = remember { BringIntoViewRequester() }
-
                     val heroGlowColor = colors.focusGlow
                     Box(
                         modifier = Modifier
                             .height(cardHeight)
                             .width(width)
-                            .bringIntoViewRequester(bringIntoView)
                             .then(if (isExpanded) Modifier.zIndex(1f) else Modifier)
                             .then(
                                 if (isExpanded) Modifier.onGloballyPositioned { coords ->
@@ -526,12 +512,6 @@ private fun HeroRowSection(
                                             }
                                         } else {
                                             alignToActiveHeroKey = null
-                                            // expandedIndex still holds the pre-collapse value here: a focus
-                                            // move off an expanded card is the collapse handoff.
-                                            if (expandedIndex >= 0 && expandedIndex != index) {
-                                                skipScrollToStart = true
-                                                scope.launch { bringIntoView.bringIntoView() }
-                                            }
                                             localFocusedIndex = index
                                         }
                                     }

--- a/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
@@ -293,20 +293,22 @@ fun HomeScreen(
         }
     }
 
-    // Video preview: only the EXPANSION is immediate (on navigation, above) — the muted video starts a
-    // moment later, on top of the already-wide card's poster, and only while the row is focused.
-    LaunchedEffect(isPreviewActive, hero, lastInteractionMs) {
-        if (!isPreviewActive || hero == null) {
+    // Video preview starts after the expanded card has settled, so 4K decoder setup does not compete with
+    // the width animation. Until then the expanded card stays on the poster.
+    LaunchedEffect(isPreviewActive, hero, expandedHeroIndex, focusedHeroIndex, lastInteractionMs) {
+        if (!isPreviewActive || hero == null || expandedHeroIndex < 0 || focusedHeroIndex != expandedHeroIndex) {
             heroPreviewEngine.stop()
             return@LaunchedEffect
         }
 
+        val scheduledIndex = expandedHeroIndex
         val scheduledHero = hero
         val interactionStamp = lastInteractionMs
 
         heroPreviewEngine.stop()
-        kotlinx.coroutines.delay(3_000L)
+        kotlinx.coroutines.delay(520L)
         if (!isPreviewActive || interactionStamp != lastInteractionMs) return@LaunchedEffect
+        if (focusedHeroIndex != scheduledIndex || expandedHeroIndex != scheduledIndex) return@LaunchedEffect
         if (scheduledHero != state.heroItems.getOrNull(state.activeHeroIndex)) return@LaunchedEffect
 
         heroPreviewEngine.play(scheduledHero.streamUrl, scheduledHero.seekToMs)

--- a/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
@@ -110,9 +111,12 @@ fun HomeScreen(
     val isPreviewActive by vm.isPreviewActive.collectAsStateWithLifecycle()
     val lastInteractionMs by vm.lastHeroInteractionMs.collectAsStateWithLifecycle()
     val listState = androidx.compose.foundation.lazy.rememberLazyListState()
+    val homeScope = rememberCoroutineScope()
     val heroFocus = remember { FocusRequester() }
     val fallbackFocus = remember { FocusRequester() }
-    val firstRowFocus = remember { FocusRequester() }
+    val rowFirstFocusRequesters = remember {
+        HomeRow.entries.associateWith { FocusRequester() }
+    }
     // Nothing starts expanded: a hero card earns its wide (16:9) state only after 3s of continuous focus
     // (see the dwell effect below). Moving focus — to another card or out of the row — collapses it again.
     var expandedHeroIndex by remember { mutableStateOf(-1) }
@@ -125,6 +129,16 @@ fun HomeScreen(
     val firstDataRow = renderRows.firstOrNull { it != HomeRow.HERO && rowHasData(it, state) }
     val showAllHiddenState = orderedRows.isEmpty()
     val showEmptyState = orderedRows.isNotEmpty() && renderRows.isEmpty()
+    val rowFocusRequester: (HomeRow) -> FocusRequester? = { row ->
+        when (row) {
+            HomeRow.HERO -> when {
+                state.heroItems.isNotEmpty() -> heroFocus
+                showHeroFallback -> fallbackFocus
+                else -> null
+            }
+            else -> rowFirstFocusRequesters[row]
+        }
+    }
 
     val onNonHeroFocused = remember(vm, heroPreviewEngine) {
         {
@@ -189,7 +203,7 @@ fun HomeScreen(
             val focusTarget = when {
                 heroVisible && state.heroItems.isNotEmpty() -> heroFocus
                 showHeroFallback -> fallbackFocus
-                firstDataRow != null -> firstRowFocus
+                firstDataRow != null -> rowFocusRequester(firstDataRow)
                 else -> null
             }
             if (focusTarget != null) runCatching { focusTarget.requestFocus() }
@@ -227,7 +241,26 @@ fun HomeScreen(
         contentPadding = PaddingValues(vertical = Dimens.ScreenPaddingV),
         verticalArrangement = Arrangement.spacedBy(Dimens.GapLarge),
     ) {
-        itemsIndexed(renderRows, key = { _, row -> row.name }) { _, row ->
+        itemsIndexed(renderRows, key = { _, row -> row.name }) { index, row ->
+            val firstItemFocusRequester = rowFocusRequester(row)
+            val nextRowIndex = renderRows
+                .drop(index + 1)
+                .indexOfFirst { rowFocusRequester(it) != null }
+                .takeIf { it >= 0 }
+                ?.let { index + 1 + it }
+            val onMoveToNextRow: (() -> Unit)? = nextRowIndex?.let { targetIndex ->
+                val targetFocusRequester = rowFocusRequester(renderRows[targetIndex]) ?: return@let null
+                {
+                    homeScope.launch {
+                        val targetIsVisible = listState.layoutInfo.visibleItemsInfo.any { it.index == targetIndex }
+                        if (!targetIsVisible) {
+                            listState.scrollToItem(targetIndex)
+                            kotlinx.coroutines.delay(50)
+                        }
+                        runCatching { targetFocusRequester.requestFocus() }
+                    }
+                }
+            }
             when (row) {
                 HomeRow.HERO -> {
                     if (state.heroItems.isNotEmpty()) {
@@ -278,7 +311,8 @@ fun HomeScreen(
                         guide = state.recentGuide,
                         onChannelClick = onPlayChannel,
                         onFocus = onNonHeroFocused,
-                        firstItemFocusRequester = if (row == firstDataRow) firstRowFocus else null,
+                        firstItemFocusRequester = firstItemFocusRequester,
+                        onContainerDown = onMoveToNextRow,
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }
@@ -291,7 +325,8 @@ fun HomeScreen(
                         guide = state.favoriteGuide,
                         onChannelClick = onPlayChannel,
                         onFocus = onNonHeroFocused,
-                        firstItemFocusRequester = if (row == firstDataRow) firstRowFocus else null,
+                        firstItemFocusRequester = firstItemFocusRequester,
+                        onContainerDown = onMoveToNextRow,
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }
@@ -302,7 +337,7 @@ fun HomeScreen(
                         items = state.continueMovies,
                         onItemClick = { onPlayMovie(it.sourceItemId, it.positionMs) },
                         onFocus = onNonHeroFocused,
-                        firstItemFocusRequester = if (row == firstDataRow) firstRowFocus else null,
+                        firstItemFocusRequester = firstItemFocusRequester,
                     )
                 }
 
@@ -312,7 +347,7 @@ fun HomeScreen(
                         items = state.continueSeries,
                         onItemClick = { onPlayEpisode(0L, it.targetItemId, it.positionMs) },
                         onFocus = onNonHeroFocused,
-                        firstItemFocusRequester = if (row == firstDataRow) firstRowFocus else null,
+                        firstItemFocusRequester = firstItemFocusRequester,
                     )
                 }
             }
@@ -454,7 +489,22 @@ private fun HeroRowSection(
                 state = heroRowState,
                 horizontalArrangement = Arrangement.spacedBy(Dimens.HeroGap),
                 contentPadding = PaddingValues(start = Dimens.HomeRowPaddingH, end = endPadding),
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .focusProperties {
+                        onEnter = {
+                            if (
+                                requestedFocusDirection == FocusDirection.Down ||
+                                requestedFocusDirection == FocusDirection.Up
+                            ) {
+                                scope.launch {
+                                    heroRowState.scrollToItem(0)
+                                    runCatching { heroFocusRequester.requestFocus() }
+                                }
+                                cancelFocusChange()
+                            }
+                        }
+                    },
             ) {
                 itemsIndexed(
                     items,

--- a/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
@@ -101,6 +101,7 @@ fun HomeScreen(
     onPlayMovie: (movieId: Long, positionMs: Long) -> Unit,
     onPlayEpisode: (seriesId: Long, episodeId: Long, positionMs: Long) -> Unit,
     onPlayChannel: (channelId: Long, zapChannels: List<ChannelEntity>) -> Unit,
+    onOpenGuide: () -> Unit,
     onChildFocused: () -> Unit,
     restoreFocus: Boolean = false,
     onRestored: () -> Unit = {},
@@ -120,6 +121,14 @@ fun HomeScreen(
     // (see the dwell effect below). Moving focus — to another card or out of the row — collapses it again.
     var expandedHeroIndex by remember { mutableStateOf(-1) }
     var focusedHeroIndex by remember { mutableStateOf(-1) }
+    val orderedRows = state.config.visibleOrder
+    val heroVisible = HomeRow.HERO in orderedRows
+    val hasNonHeroContent = orderedRows.any { it != HomeRow.HERO && rowHasData(it, state) }
+    val showHeroFallback = heroVisible && state.heroItems.isEmpty() && !hasNonHeroContent
+    val renderRows = orderedRows.filter { rowCanRender(it, state, showHeroFallback) }
+    val firstDataRow = renderRows.firstOrNull { it != HomeRow.HERO && rowHasData(it, state) }
+    val showAllHiddenState = orderedRows.isEmpty()
+    val showEmptyState = orderedRows.isNotEmpty() && renderRows.isEmpty()
 
     val onNonHeroFocused = remember(vm, heroPreviewEngine) {
         {
@@ -162,21 +171,32 @@ fun HomeScreen(
         onDispose { heroPreviewEngine.stop() }
     }
 
-    LaunchedEffect(state.heroItems, state.continueMovies, state.continueSeries, state.favoriteLive, restoreFocus) {
-        if (state.isEmpty) {
+    LaunchedEffect(orderedRows, state.heroItems, state.recentLive, state.favoriteLive, state.continueMovies, state.continueSeries, state.guideSlice, restoreFocus) {
+        if (orderedRows.isEmpty()) {
             if (restoreFocus) onRestored()
             return@LaunchedEffect
         }
-        runCatching { listState.scrollToItem(0) }
+
+        val targetRow = when {
+            restoreFocus && heroVisible && state.heroItems.isNotEmpty() -> HomeRow.HERO
+            restoreFocus && showHeroFallback -> HomeRow.HERO
+            restoreFocus -> firstDataRow
+            else -> null
+        }
+        val targetIndex = targetRow?.let { renderRows.indexOf(it) } ?: 0
+        runCatching { listState.scrollToItem(targetIndex.coerceAtLeast(0)) }
+
         // Only pull focus INTO the Home content when returning from the player (restoreFocus). On a cold
         // start or a tab switch, leave focus on the sidebar's Home item so the nav is immediately navigable.
         if (restoreFocus) {
             kotlinx.coroutines.delay(60)
-            if (state.heroItems.isNotEmpty()) {
-                runCatching { heroFocus.requestFocus() }
-            } else {
-                runCatching { fallbackFocus.requestFocus() }
+            val focusTarget = when {
+                heroVisible && state.heroItems.isNotEmpty() -> heroFocus
+                showHeroFallback -> fallbackFocus
+                firstDataRow != null -> firstRowFocus
+                else -> null
             }
+            if (focusTarget != null) runCatching { focusTarget.requestFocus() }
             onRestored()
         }
     }
@@ -190,23 +210,16 @@ fun HomeScreen(
         HomeSkeleton(modifier = modifier.fillMaxSize())
         return
     }
-    if (state.isEmpty) {
-        EmptyHomeState(
-            modifier = modifier.fillMaxSize(),
-        )
+    if (showAllHiddenState) {
+        AllRowsHiddenState(modifier = modifier.fillMaxSize())
+        return
+    }
+    if (showEmptyState) {
+        EmptyHomeState(modifier = modifier.fillMaxSize())
         return
     }
 
     val hero = state.heroItems.getOrNull(state.activeHeroIndex)
-    val hasMovies = state.continueMovies.isNotEmpty()
-    val hasSeries = state.continueSeries.isNotEmpty()
-    val hasFavorites = state.favoriteLive.isNotEmpty()
-    val firstRowKind = when {
-        hasFavorites -> RowKind.FAVORITES
-        hasMovies -> RowKind.MOVIES
-        hasSeries -> RowKind.SERIES
-        else -> null
-    }
 
     LazyColumn(
         modifier = modifier
@@ -218,77 +231,99 @@ fun HomeScreen(
         contentPadding = PaddingValues(vertical = Dimens.ScreenPaddingV),
         verticalArrangement = Arrangement.spacedBy(Dimens.GapLarge),
     ) {
-        item {
-            if (state.heroItems.isNotEmpty()) {
-                HeroRowSection(
-                    items = state.heroItems,
-                    expandedIndex = expandedHeroIndex,
-                    heroPreviewEngine = heroPreviewEngine,
-                    engineState = engineState,
-                    heroFocusRequester = heroFocus,
-                    onHeroFocusChanged = { index, hasFocus ->
-                        if (hasFocus) {
-                            if (expandedHeroIndex != index) {
-                                heroPreviewEngine.stop() // stop the previous hero's video before switching
-                                expandedHeroIndex = -1 // collapse immediately; the dwell timer re-expands after 3s
-                            }
-                            focusedHeroIndex = index
-                            vm.onHeroUserNavigate(index)
-                            vm.setHeroFocused(true)
-                            onChildFocused()
-                        } else if (focusedHeroIndex == index) {
-                            focusedHeroIndex = -1
-                        }
-                    },
-                    onPlay = { item ->
-                        when (item) {
-                            is HeroItem.MovieHero -> onPlayMovie(item.movie.id, item.positionMs)
-                            is HeroItem.SeriesHero -> onPlayEpisode(item.series.id, item.episode.id, item.positionMs)
-                            is HeroItem.LiveHero -> onPlayChannel(item.channel.id, state.recentLive)
-                        }
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            } else {
-                HeroFallbackPane(
-                    modifier = Modifier.fillMaxWidth(),
-                    focusRequester = fallbackFocus,
-                    onChildFocused = onNonHeroFocused,
-                )
-            }
-        }
+        itemsIndexed(renderRows, key = { _, row -> row.name }) { _, row ->
+            when (row) {
+                HomeRow.HERO -> {
+                    if (state.heroItems.isNotEmpty()) {
+                        HeroRowSection(
+                            items = state.heroItems,
+                            expandedIndex = expandedHeroIndex,
+                            heroPreviewEngine = heroPreviewEngine,
+                            engineState = engineState,
+                            heroFocusRequester = heroFocus,
+                            onHeroFocusChanged = { index, hasFocus ->
+                                if (hasFocus) {
+                                    if (expandedHeroIndex != index) {
+                                        heroPreviewEngine.stop() // stop the previous hero's video before switching
+                                        expandedHeroIndex = -1 // collapse immediately; the dwell timer re-expands after 3s
+                                    }
+                                    focusedHeroIndex = index
+                                    vm.onHeroUserNavigate(index)
+                                    vm.setHeroFocused(true)
+                                    onChildFocused()
+                                } else if (focusedHeroIndex == index) {
+                                    focusedHeroIndex = -1
+                                }
+                            },
+                            onPlay = { item ->
+                                when (item) {
+                                    is HeroItem.MovieHero -> onPlayMovie(item.movie.id, item.positionMs)
+                                    is HeroItem.SeriesHero -> onPlayEpisode(item.series.id, item.episode.id, item.positionMs)
+                                    is HeroItem.LiveHero -> onPlayChannel(item.channel.id, state.recentLive)
+                                }
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    } else {
+                        HeroFallbackPane(
+                            modifier = Modifier.fillMaxWidth(),
+                            focusRequester = fallbackFocus,
+                            onChildFocused = onNonHeroFocused,
+                        )
+                    }
+                }
 
-        if (hasFavorites) {
-            item {
-                ChannelRailRow(
-                    title = "Favourite Channels",
-                    channels = state.favoriteLive,
-                    onChannelClick = { id -> onPlayChannel(id, state.favoriteLive) },
-                    onFocus = onNonHeroFocused,
-                    firstItemFocusRequester = if (firstRowKind == RowKind.FAVORITES) firstRowFocus else null,
-                )
-            }
-        }
-        if (hasMovies) {
-            item {
-                ContinueWatchingRow(
-                    title = "Continue Watching Movies",
-                    items = state.continueMovies,
-                    onItemClick = { onPlayMovie(it.sourceItemId, it.positionMs) },
-                    onFocus = onNonHeroFocused,
-                    firstItemFocusRequester = if (firstRowKind == RowKind.MOVIES) firstRowFocus else null,
-                )
-            }
-        }
-        if (hasSeries) {
-            item {
-                ContinueWatchingRow(
-                    title = "Continue Watching Series",
-                    items = state.continueSeries,
-                    onItemClick = { onPlayEpisode(0L, it.targetItemId, it.positionMs) },
-                    onFocus = onNonHeroFocused,
-                    firstItemFocusRequester = if (firstRowKind == RowKind.SERIES) firstRowFocus else null,
-                )
+                HomeRow.RECENT_CHANNELS -> if (state.recentLive.isNotEmpty()) {
+                    ChannelRailRow(
+                        title = row.title,
+                        channels = state.recentLive,
+                        onChannelClick = { id -> onPlayChannel(id, state.recentLive) },
+                        onFocus = onNonHeroFocused,
+                        firstItemFocusRequester = if (row == firstDataRow) firstRowFocus else null,
+                    )
+                }
+
+                HomeRow.FAVORITE_CHANNELS -> if (state.favoriteLive.isNotEmpty()) {
+                    ChannelRailRow(
+                        title = row.title,
+                        channels = state.favoriteLive,
+                        onChannelClick = { id -> onPlayChannel(id, state.favoriteLive) },
+                        onFocus = onNonHeroFocused,
+                        firstItemFocusRequester = if (row == firstDataRow) firstRowFocus else null,
+                    )
+                }
+
+                HomeRow.CONTINUE_MOVIES -> if (state.continueMovies.isNotEmpty()) {
+                    ContinueWatchingRow(
+                        title = row.title,
+                        items = state.continueMovies,
+                        onItemClick = { onPlayMovie(it.sourceItemId, it.positionMs) },
+                        onFocus = onNonHeroFocused,
+                        firstItemFocusRequester = if (row == firstDataRow) firstRowFocus else null,
+                    )
+                }
+
+                HomeRow.CONTINUE_SERIES -> if (state.continueSeries.isNotEmpty()) {
+                    ContinueWatchingRow(
+                        title = row.title,
+                        items = state.continueSeries,
+                        onItemClick = { onPlayEpisode(0L, it.targetItemId, it.positionMs) },
+                        onFocus = onNonHeroFocused,
+                        firstItemFocusRequester = if (row == firstDataRow) firstRowFocus else null,
+                    )
+                }
+
+                HomeRow.GUIDE_SLICE -> if (state.guideSlice.hasContent) {
+                    HomeGuideSlice(
+                        slice = state.guideSlice,
+                        onTuneChannel = { ch -> onPlayChannel(ch.id, state.guideSlice.channels) },
+                        onOpenFullGuide = onOpenGuide,
+                        onFocus = onNonHeroFocused,
+                        firstItemFocusRequester = if (row == firstDataRow) firstRowFocus else null,
+                        loadDescription = vm::programmeDescription,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
             }
         }
     }
@@ -315,7 +350,20 @@ fun HomeScreen(
     }
 }
 
-private enum class RowKind { FAVORITES, MOVIES, SERIES }
+private fun rowHasData(row: HomeRow, state: HomeUiState): Boolean = when (row) {
+    HomeRow.HERO -> state.heroItems.isNotEmpty()
+    HomeRow.RECENT_CHANNELS -> state.recentLive.isNotEmpty()
+    HomeRow.FAVORITE_CHANNELS -> state.favoriteLive.isNotEmpty()
+    HomeRow.CONTINUE_MOVIES -> state.continueMovies.isNotEmpty()
+    HomeRow.CONTINUE_SERIES -> state.continueSeries.isNotEmpty()
+    HomeRow.GUIDE_SLICE -> state.guideSlice.hasContent
+}
+
+private fun rowCanRender(row: HomeRow, state: HomeUiState, showHeroFallback: Boolean): Boolean =
+    when (row) {
+        HomeRow.HERO -> state.heroItems.isNotEmpty() || showHeroFallback
+        else -> rowHasData(row, state)
+    }
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -1039,6 +1087,38 @@ private fun EmptyHomeState(
             Spacer(Modifier.height(8.dp))
             Text(
                 text = "Continue watching will show up on Home once you have playback history.",
+                style = MaterialTheme.typography.bodyLarge,
+                color = colors.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AllRowsHiddenState(
+    modifier: Modifier = Modifier,
+) {
+    val colors = OwnTVTheme.colors
+    Box(
+        modifier = modifier
+            .focusProperties { canFocus = false }
+            .background(colors.surface),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            BrandLockup(markSize = 84, textSize = 48)
+            Spacer(Modifier.height(16.dp))
+            Text(
+                text = "All Home rows are hidden.",
+                style = MaterialTheme.typography.titleLarge,
+                color = colors.onSurface,
+                maxLines = 1,
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = "Turn rows back on in Settings → Home screen.",
                 style = MaterialTheme.typography.bodyLarge,
                 color = colors.onSurfaceVariant,
                 maxLines = 2,

--- a/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
@@ -85,15 +85,13 @@ import tv.own.owntv.ui.components.OwnTVSpinner
 import tv.own.owntv.ui.components.PosterCard
 import tv.own.owntv.ui.components.ContentPanelFill
 import tv.own.owntv.ui.components.roundedPanel
+import tv.own.owntv.ui.format.formatSystemTime
 import tv.own.owntv.ui.theme.Dimens
 import tv.own.owntv.ui.theme.OwnTVTheme
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import androidx.compose.foundation.layout.widthIn
-import java.text.SimpleDateFormat
 import java.util.Calendar
-import java.util.Date
-import java.util.Locale
 
 @Composable
 fun HomeScreen(
@@ -171,7 +169,7 @@ fun HomeScreen(
         onDispose { heroPreviewEngine.stop() }
     }
 
-    LaunchedEffect(orderedRows, state.heroItems, state.recentLive, state.favoriteLive, state.continueMovies, state.continueSeries, state.guideSlice, restoreFocus) {
+    LaunchedEffect(orderedRows, state.heroItems, state.recentLive, state.favoriteLive, state.recentGuide, state.favoriteGuide, state.continueMovies, state.continueSeries, restoreFocus) {
         if (orderedRows.isEmpty()) {
             if (restoreFocus) onRestored()
             return@LaunchedEffect
@@ -274,22 +272,28 @@ fun HomeScreen(
                 }
 
                 HomeRow.RECENT_CHANNELS -> if (state.recentLive.isNotEmpty()) {
-                    ChannelRailRow(
+                    HomeLiveRow(
                         title = row.title,
+                        mode = state.config.recentLiveMode,
                         channels = state.recentLive,
-                        onChannelClick = { id -> onPlayChannel(id, state.recentLive) },
+                        guide = state.recentGuide,
+                        onChannelClick = onPlayChannel,
                         onFocus = onNonHeroFocused,
                         firstItemFocusRequester = if (row == firstDataRow) firstRowFocus else null,
+                        modifier = Modifier.fillMaxWidth(),
                     )
                 }
 
                 HomeRow.FAVORITE_CHANNELS -> if (state.favoriteLive.isNotEmpty()) {
-                    ChannelRailRow(
+                    HomeLiveRow(
                         title = row.title,
+                        mode = state.config.favoriteLiveMode,
                         channels = state.favoriteLive,
-                        onChannelClick = { id -> onPlayChannel(id, state.favoriteLive) },
+                        guide = state.favoriteGuide,
+                        onChannelClick = onPlayChannel,
                         onFocus = onNonHeroFocused,
                         firstItemFocusRequester = if (row == firstDataRow) firstRowFocus else null,
+                        modifier = Modifier.fillMaxWidth(),
                     )
                 }
 
@@ -310,18 +314,6 @@ fun HomeScreen(
                         onItemClick = { onPlayEpisode(0L, it.targetItemId, it.positionMs) },
                         onFocus = onNonHeroFocused,
                         firstItemFocusRequester = if (row == firstDataRow) firstRowFocus else null,
-                    )
-                }
-
-                HomeRow.GUIDE_SLICE -> if (state.guideSlice.hasContent) {
-                    HomeGuideSlice(
-                        slice = state.guideSlice,
-                        onTuneChannel = { ch -> onPlayChannel(ch.id, state.guideSlice.channels) },
-                        onOpenFullGuide = onOpenGuide,
-                        onFocus = onNonHeroFocused,
-                        firstItemFocusRequester = if (row == firstDataRow) firstRowFocus else null,
-                        loadDescription = vm::programmeDescription,
-                        modifier = Modifier.fillMaxWidth(),
                     )
                 }
             }
@@ -352,11 +344,16 @@ fun HomeScreen(
 
 private fun rowHasData(row: HomeRow, state: HomeUiState): Boolean = when (row) {
     HomeRow.HERO -> state.heroItems.isNotEmpty()
-    HomeRow.RECENT_CHANNELS -> state.recentLive.isNotEmpty()
-    HomeRow.FAVORITE_CHANNELS -> state.favoriteLive.isNotEmpty()
+    HomeRow.RECENT_CHANNELS -> when (state.config.recentLiveMode) {
+        HomeLiveRowMode.CARDS -> state.recentLive.isNotEmpty()
+        HomeLiveRowMode.ON_NOW -> state.recentGuide.hasContent
+    }
+    HomeRow.FAVORITE_CHANNELS -> when (state.config.favoriteLiveMode) {
+        HomeLiveRowMode.CARDS -> state.favoriteLive.isNotEmpty()
+        HomeLiveRowMode.ON_NOW -> state.favoriteGuide.hasContent
+    }
     HomeRow.CONTINUE_MOVIES -> state.continueMovies.isNotEmpty()
     HomeRow.CONTINUE_SERIES -> state.continueSeries.isNotEmpty()
-    HomeRow.GUIDE_SLICE -> state.guideSlice.hasContent
 }
 
 private fun rowCanRender(row: HomeRow, state: HomeUiState, showHeroFallback: Boolean): Boolean =
@@ -541,12 +538,30 @@ private fun HeroRowSection(
                                 // blur underneath just costs frames on TV hardware.
                                 Box(Modifier.fillMaxSize().background(Color.Black)) {
                                     if (!imageUrl.isNullOrBlank()) {
-                                        AsyncImage(
-                                            model = imageUrl,
-                                            contentDescription = null,
-                                            contentScale = ContentScale.Fit,
-                                            modifier = Modifier.fillMaxSize(),
-                                        )
+                                        if (item is HeroItem.LiveHero) {
+                                            AsyncImage(
+                                                model = imageUrl,
+                                                contentDescription = null,
+                                                modifier = Modifier.fillMaxSize().blur(20.dp),
+                                                contentScale = ContentScale.Crop,
+                                                alpha = 0.5f,
+                                            )
+                                            AsyncImage(
+                                                model = imageUrl,
+                                                contentDescription = null,
+                                                contentScale = ContentScale.Fit,
+                                                modifier = Modifier
+                                                    .align(Alignment.Center)
+                                                    .size(80.dp),
+                                            )
+                                        } else {
+                                            AsyncImage(
+                                                model = imageUrl,
+                                                contentDescription = null,
+                                                contentScale = ContentScale.Fit,
+                                                modifier = Modifier.fillMaxSize(),
+                                            )
+                                        }
                                     } else {
                                         Box(
                                             Modifier.fillMaxSize(),
@@ -680,19 +695,35 @@ private fun HeroRowSection(
                                     is HeroItem.LiveHero -> expandedItem.channel.logoUrl
                                 }
                                 if (!artUrl.isNullOrBlank()) {
-                                    AsyncImage(
-                                        model = artUrl,
-                                        contentDescription = null,
-                                        modifier = Modifier.fillMaxSize().blur(20.dp),
-                                        contentScale = ContentScale.Crop,
-                                        alpha = 0.5f,
-                                    )
-                                    AsyncImage(
-                                        model = artUrl,
-                                        contentDescription = null,
-                                        contentScale = ContentScale.Fit,
-                                        modifier = Modifier.fillMaxSize(),
-                                    )
+                                    if (expandedItem is HeroItem.LiveHero) {
+                                        AsyncImage(
+                                            model = artUrl,
+                                            contentDescription = null,
+                                            modifier = Modifier.fillMaxSize().blur(20.dp),
+                                            contentScale = ContentScale.Crop,
+                                            alpha = 0.5f,
+                                        )
+                                        AsyncImage(
+                                            model = artUrl,
+                                            contentDescription = null,
+                                            contentScale = ContentScale.Fit,
+                                            modifier = Modifier.size(80.dp),
+                                        )
+                                    } else {
+                                        AsyncImage(
+                                            model = artUrl,
+                                            contentDescription = null,
+                                            modifier = Modifier.fillMaxSize().blur(20.dp),
+                                            contentScale = ContentScale.Crop,
+                                            alpha = 0.5f,
+                                        )
+                                        AsyncImage(
+                                            model = artUrl,
+                                            contentDescription = null,
+                                            contentScale = ContentScale.Fit,
+                                            modifier = Modifier.fillMaxSize(),
+                                        )
+                                    }
                                 } else {
                                     val fallback = when (expandedItem) {
                                         is HeroItem.MovieHero -> OwnTVIcon.MOVIES
@@ -831,8 +862,7 @@ private fun finishByLabel(context: Context, positionMs: Long, durationMs: Long, 
     if (remainingMs <= 0L) return null
 
     val finishMs = roundUpToNextQuarterHour(nowMs + remainingMs)
-    val pattern = if (android.text.format.DateFormat.is24HourFormat(context)) "H:mm" else "h:mm a"
-    val time = SimpleDateFormat(pattern, Locale.getDefault()).format(Date(finishMs))
+    val time = formatSystemTime(context, finishMs)
     return "Finish by $time"
 }
 
@@ -935,89 +965,6 @@ private fun ContinueWatchingRow(
                         onFocus = onFocus,
                         onClick = { onItemClick(item) },
                     )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun ChannelRailRow(
-    title: String,
-    channels: List<ChannelEntity>,
-    onChannelClick: (Long) -> Unit,
-    onFocus: () -> Unit,
-    firstItemFocusRequester: FocusRequester? = null,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier = modifier.fillMaxWidth(),
-    ) {
-        Text(
-            text = title.uppercase(),
-            style = MaterialTheme.typography.titleSmall,
-            color = OwnTVTheme.colors.primary,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(start = Dimens.HomeRowPaddingH),
-        )
-        Spacer(Modifier.height(10.dp))
-        LazyRow(
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            contentPadding = PaddingValues(horizontal = Dimens.HomeRowPaddingH),
-            modifier = Modifier.focusGroup(),
-        ) {
-            itemsIndexed(channels, key = { _, channel -> channel.id }) { index, channel ->
-                Box(
-                    modifier = Modifier
-                        .width(180.dp)
-                        .height(100.dp),
-                ) {
-                    FocusableSurface(
-                        onClick = { onChannelClick(channel.id) },
-                        modifier = when {
-                            firstItemFocusRequester != null && index == 0 -> Modifier.focusRequester(firstItemFocusRequester)
-                            else -> Modifier
-                        }.onFocusChanged { if (it.hasFocus) onFocus() },
-                        shape = RoundedCornerShape(14.dp),
-                        focusedScale = 1f,
-                        focusedContainerColor = OwnTVTheme.colors.surfaceContainerHigh,
-                        unfocusedContainerColor = OwnTVTheme.colors.surfaceContainerHigh,
-                        selectedContainerColor = OwnTVTheme.colors.surfaceContainerHigh,
-                    ) { focused ->
-                        Row(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(10.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        ) {
-                            Box(
-                                modifier = Modifier
-                                    .size(44.dp)
-                                    .clip(RoundedCornerShape(10.dp))
-                                    .background(OwnTVTheme.colors.surfaceContainerLowest),
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                if (!channel.logoUrl.isNullOrBlank()) {
-                                    AsyncImage(
-                                        model = channel.logoUrl,
-                                        contentDescription = null,
-                                        modifier = Modifier.fillMaxSize(),
-                                        contentScale = ContentScale.Crop,
-                                    )
-                                } else {
-                                    OwnTVIcon(OwnTVIcon.LIVE_TV, tint = OwnTVTheme.colors.onSurfaceVariant, modifier = Modifier.size(22.dp))
-                                }
-                            }
-                            Text(
-                                text = channel.name,
-                                style = MaterialTheme.typography.titleSmall,
-                                color = if (focused) OwnTVTheme.colors.primary else OwnTVTheme.colors.onSurface,
-                                maxLines = 2,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                        }
-                    }
                 }
             }
         }

--- a/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
@@ -235,6 +235,7 @@ fun HomeScreen(
                     if (state.heroItems.isNotEmpty()) {
                         HeroRowSection(
                             items = state.heroItems,
+                            activeHeroIndex = state.activeHeroIndex,
                             expandedIndex = expandedHeroIndex,
                             heroPreviewEngine = heroPreviewEngine,
                             engineState = engineState,
@@ -362,10 +363,17 @@ private fun rowCanRender(row: HomeRow, state: HomeUiState, showHeroFallback: Boo
         else -> rowHasData(row, state)
     }
 
+private fun HeroItem.heroKey(): String = when (this) {
+    is HeroItem.MovieHero -> "movie:${movie.id}"
+    is HeroItem.SeriesHero -> "episode:${episode.id}"
+    is HeroItem.LiveHero -> "live:${channel.id}"
+}
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun HeroRowSection(
     items: List<HeroItem>,
+    activeHeroIndex: Int,
     expandedIndex: Int,
     heroPreviewEngine: HeroPreviewEngine,
     engineState: HeroPreviewEngine.State,
@@ -390,12 +398,28 @@ private fun HeroRowSection(
     var previewRectInRowPx by remember { mutableStateOf<Rect?>(null) }
     var localFocusedIndex by remember { mutableStateOf(-1) }
     var rowWidthDp by remember { mutableStateOf(0.dp) }
+    var alignToActiveHeroKey by remember { mutableStateOf<String?>(null) }
     // Set when a focus move collapses the previously expanded card ("collapse handoff"): scroll-to-start
     // would fight the collapse animation and shove the newly focused card around, so that one move uses
     // minimal bring-into-view scrolling instead.
     var skipScrollToStart by remember { mutableStateOf(false) }
     val heroRowState = rememberLazyListState()
     val scope = rememberCoroutineScope()
+    val itemsSignature = remember(items) { items.joinToString(separator = "|") { it.heroKey() } }
+    val activeHeroKey = items.getOrNull(activeHeroIndex)?.heroKey()
+
+    LaunchedEffect(itemsSignature) {
+        if (activeHeroIndex !in items.indices) return@LaunchedEffect
+
+        alignToActiveHeroKey = activeHeroKey
+        skipScrollToStart = false
+        heroRowState.scrollToItem(activeHeroIndex)
+
+        if (activeHeroIndex == 0 && localFocusedIndex >= 0 && localFocusedIndex != activeHeroIndex) {
+            localFocusedIndex = activeHeroIndex
+            runCatching { heroFocusRequester.requestFocus() }
+        }
+    }
 
     LaunchedEffect(expandedIndex, items.size) {
         // The rect is only ever written by the expanded card's onGloballyPositioned; drop it on collapse
@@ -445,13 +469,7 @@ private fun HeroRowSection(
             ) {
                 itemsIndexed(
                     items,
-                    key = { _, item ->
-                        when (item) {
-                            is HeroItem.MovieHero -> "movie:${item.movie.id}"
-                            is HeroItem.SeriesHero -> "episode:${item.episode.id}"
-                            is HeroItem.LiveHero -> "live:${item.channel.id}"
-                        }
-                    },
+                    key = { _, item -> item.heroKey() },
                 ) { index, item ->
                     val isExpanded = index == expandedIndex
                     val targetWidth = if (isExpanded) expandedWidth else Dimens.HeroBaseWidth
@@ -496,16 +514,28 @@ private fun HeroRowSection(
                                 .height(cardHeight)
                                 .then(if (index == 0) Modifier.focusRequester(heroFocusRequester) else Modifier)
                                 .onFocusChanged { fs ->
+                                    val redirectToActiveHero = fs.hasFocus &&
+                                        activeHeroIndex == 0 &&
+                                        index != activeHeroIndex &&
+                                        alignToActiveHeroKey == activeHeroKey
                                     if (fs.hasFocus) {
-                                        // expandedIndex still holds the pre-collapse value here: a focus
-                                        // move off an expanded card is the collapse handoff.
-                                        if (expandedIndex >= 0 && expandedIndex != index) {
-                                            skipScrollToStart = true
-                                            scope.launch { bringIntoView.bringIntoView() }
+                                        if (redirectToActiveHero) {
+                                            scope.launch {
+                                                heroRowState.scrollToItem(activeHeroIndex)
+                                                runCatching { heroFocusRequester.requestFocus() }
+                                            }
+                                        } else {
+                                            alignToActiveHeroKey = null
+                                            // expandedIndex still holds the pre-collapse value here: a focus
+                                            // move off an expanded card is the collapse handoff.
+                                            if (expandedIndex >= 0 && expandedIndex != index) {
+                                                skipScrollToStart = true
+                                                scope.launch { bringIntoView.bringIntoView() }
+                                            }
+                                            localFocusedIndex = index
                                         }
-                                        localFocusedIndex = index
                                     }
-                                    onHeroFocusChanged(index, fs.hasFocus)
+                                    if (!redirectToActiveHero) onHeroFocusChanged(index, fs.hasFocus)
                                 }
                                 .then(
                                     if (isExpanded) Modifier.drawBehind {

--- a/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
@@ -352,10 +352,14 @@ private fun HeroRowSection(
     val heroRowState = rememberLazyListState()
     val scope = rememberCoroutineScope()
 
-    LaunchedEffect(expandedIndex) {
+    LaunchedEffect(expandedIndex, items.size) {
         // The rect is only ever written by the expanded card's onGloballyPositioned; drop it on collapse
         // so the next expansion can't flash its overlay at the previous card's stale position.
-        if (expandedIndex < 0) previewRectInRowPx = null
+        if (expandedIndex < 0) {
+            previewRectInRowPx = null
+        } else if (expandedIndex < items.size) {
+            heroRowState.animateScrollToItem(expandedIndex)
+        }
     }
 
     LaunchedEffect(localFocusedIndex) {
@@ -419,13 +423,6 @@ private fun HeroRowSection(
                     }
 
                     val bringIntoView = remember { BringIntoViewRequester() }
-                    LaunchedEffect(isExpanded) {
-                        if (isExpanded) {
-                            // Wait out the 500ms width tween so bringIntoView measures the final wide bounds.
-                            kotlinx.coroutines.delay(520L)
-                            bringIntoView.bringIntoView()
-                        }
-                    }
 
                     val heroGlowColor = colors.focusGlow
                     Box(

--- a/app/src/main/java/tv/own/owntv/features/home/HomeViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeViewModel.kt
@@ -18,6 +18,7 @@ import tv.own.owntv.core.customize.SectionCustomizations
 import tv.own.owntv.core.database.dao.CategoryDao
 import tv.own.owntv.core.database.dao.ChannelDao
 import tv.own.owntv.core.database.dao.ChannelWithWatchedAt
+import tv.own.owntv.core.database.dao.EpgDao
 import tv.own.owntv.core.database.dao.MovieDao
 import tv.own.owntv.core.database.dao.ProfileDao
 import tv.own.owntv.core.database.dao.SeriesDao
@@ -25,6 +26,7 @@ import tv.own.owntv.core.database.dao.SourceDao
 import tv.own.owntv.core.database.dao.resolveExistingProfileId
 import tv.own.owntv.core.database.entity.ChannelEntity
 import tv.own.owntv.core.database.entity.EpisodeEntity
+import tv.own.owntv.core.database.entity.EpgProgrammeEntity
 import tv.own.owntv.core.database.entity.MovieEntity
 import tv.own.owntv.core.database.entity.SeriesEntity
 import tv.own.owntv.core.launcher.LauncherContinuationItem
@@ -32,6 +34,7 @@ import tv.own.owntv.core.launcher.LauncherContinuationKind
 import tv.own.owntv.core.launcher.LauncherRecommendationPlanner
 import tv.own.owntv.core.launcher.LauncherWatchNextType
 import tv.own.owntv.core.model.MediaType
+import tv.own.owntv.core.epg.EpgSourceStore
 import tv.own.owntv.core.repository.activeSourceIds
 import tv.own.owntv.features.settings.data.SettingsRepository
 import tv.own.owntv.player.HeroPreviewEngine
@@ -93,7 +96,8 @@ data class HomeUiState(
     val continueSeries: List<LauncherContinuationItem> = emptyList(),
     val recentLive: List<ChannelEntity> = emptyList(),
     val favoriteLive: List<ChannelEntity> = emptyList(),
-    val isEmpty: Boolean = true,
+    val config: HomeConfig = HomeConfig(),
+    val guideSlice: GuideSliceState = GuideSliceState(),
     /**
      * True until the first [HomeViewModel.loadHomeData] completes. Home's queries are profile-scoped and
      * already indexed, but on a cold boot their first reads come off slow eMMC (pages not yet in the OS
@@ -104,6 +108,22 @@ data class HomeUiState(
      */
     val isLoading: Boolean = true,
 )
+
+data class GuideSliceState(
+    val channels: List<ChannelEntity> = emptyList(),
+    val programmes: Map<Long, List<EpgProgrammeEntity>> = emptyMap(),
+    val windowStart: Long = 0L,
+    val windowEnd: Long = 0L,
+    val now: Long = 0L,
+) {
+    val hasContent: Boolean
+        get() = channels.isNotEmpty() && programmes.values.any { it.isNotEmpty() }
+}
+
+private const val SLICE_WINDOW_MS = 150 * 60_000L
+private const val RECENT_LIVE_LIMIT = 10
+private const val GUIDE_SLICE_CANDIDATE_LIMIT = 50
+private const val GUIDE_SLICE_CHANNEL_LIMIT = 5
 
 class HomeViewModel(
     private val planner: LauncherRecommendationPlanner,
@@ -116,6 +136,8 @@ class HomeViewModel(
     private val settings: SettingsRepository,
     private val profileDao: ProfileDao,
     private val heroPreviewEngine: HeroPreviewEngine,
+    private val epgSourceStore: EpgSourceStore,
+    private val epgDao: EpgDao,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(HomeUiState())
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
@@ -162,6 +184,7 @@ class HomeViewModel(
 
     private suspend fun loadHomeData(profileId: Long) {
         val state = withContext(Dispatchers.IO) {
+            val config = settings.homeConfig(profileId).first()
             // Active-playlist filter: when a "Default" playlist is chosen, the home rails narrow to it too
             // (Continue Watching / Recent / Favorites). No default → activeIds == all profile ids → no-op.
             val activeIds = activeSourceIds(settings, sourceDao, profileId).toSet()
@@ -176,14 +199,20 @@ class HomeViewModel(
                 .filterNot { isContinuationHidden(it, hidden) }
             val movies = items.filter { it.kind == LauncherContinuationKind.MOVIE }
             val series = items.filter { it.kind == LauncherContinuationKind.EPISODE }
-            val liveWithTs = channelDao.recentlyWatchedWithTimestamp(profileId, 10).first()
-                .let { if (!filtering) it else it.filter { w -> w.channel.sourceId in activeIds } }
+            val liveWithTs = recentlyWatchedLive(profileId, activeIds, filtering, RECENT_LIVE_LIMIT)
                 .filterNot { isChannelHidden(it.channel, hidden) }
             val live = liveWithTs.map { it.channel }
             val favLive = channelDao.favoritesListAlpha(profileId, 50).first()
                 .let { if (!filtering) it else it.filter { c -> c.sourceId in activeIds } }
                 .filterNot { isChannelHidden(it, hidden) }
-            val heroItems = buildHeroItems(items, liveWithTs)
+            val heroItems = buildHeroItems(items, liveWithTs, config)
+            val guideSlice = if (HomeRow.GUIDE_SLICE in config.visibleOrder) {
+                val guideCandidates = recentlyWatchedLive(profileId, activeIds, filtering, GUIDE_SLICE_CANDIDATE_LIMIT)
+                    .filterNot { isChannelHidden(it.channel, hidden) }
+                buildGuideSlice(profileId, activeIds, guideCandidates)
+            } else {
+                GuideSliceState()
+            }
 
             HomeUiState(
                 heroItems = heroItems,
@@ -192,7 +221,8 @@ class HomeViewModel(
                 continueSeries = series,
                 recentLive = live,
                 favoriteLive = favLive,
-                isEmpty = movies.isEmpty() && series.isEmpty() && live.isEmpty() && favLive.isEmpty(),
+                config = config,
+                guideSlice = guideSlice,
                 isLoading = false,
             )
         }
@@ -262,31 +292,36 @@ class HomeViewModel(
     private suspend fun buildHeroItems(
         continuationItems: List<LauncherContinuationItem>,
         liveChannels: List<ChannelWithWatchedAt>,
+        config: HomeConfig,
     ): List<HeroItem> {
         data class Candidate(val engagedAt: Long, val resolve: suspend () -> HeroItem?)
 
         val candidates = mutableListOf<Candidate>()
 
         continuationItems.forEach { item ->
-            candidates += Candidate(item.lastEngagementAt) {
-                when (item.kind) {
-                    LauncherContinuationKind.MOVIE -> {
+            when (item.kind) {
+                LauncherContinuationKind.MOVIE -> if (config.heroIncludeMovies) {
+                    candidates += Candidate(item.lastEngagementAt) {
                         val movie = movieDao.getById(item.sourceItemId) ?: return@Candidate null
                         HeroItem.MovieHero(movie, item)
                     }
-                    LauncherContinuationKind.EPISODE -> {
+                }
+                LauncherContinuationKind.EPISODE -> if (config.heroIncludeSeries) {
+                    candidates += Candidate(item.lastEngagementAt) {
                         val episode = seriesDao.getEpisodeById(item.targetItemId) ?: return@Candidate null
                         val series = seriesDao.getSeriesById(episode.seriesId) ?: return@Candidate null
                         HeroItem.SeriesHero(series, episode, item)
                     }
-                    LauncherContinuationKind.LIVE -> null
                 }
+                LauncherContinuationKind.LIVE -> Unit
             }
         }
 
-        liveChannels.forEach { watched ->
-            candidates += Candidate(watched.watchedAt) {
-                HeroItem.LiveHero(watched.channel, watched.watchedAt)
+        if (config.heroIncludeLive) {
+            liveChannels.forEach { watched ->
+                candidates += Candidate(watched.watchedAt) {
+                    HeroItem.LiveHero(watched.channel, watched.watchedAt)
+                }
             }
         }
 
@@ -297,6 +332,66 @@ class HomeViewModel(
         }
         return result
     }
+
+    private suspend fun recentlyWatchedLive(
+        profileId: Long,
+        activeIds: Set<Long>,
+        filtering: Boolean,
+        limit: Int,
+    ): List<ChannelWithWatchedAt> =
+        if (filtering) {
+            channelDao.recentlyWatchedWithTimestampFiltered(profileId, activeIds.toList(), limit).first()
+        } else {
+            channelDao.recentlyWatchedWithTimestamp(profileId, limit).first()
+        }
+
+    private suspend fun buildGuideSlice(
+        profileId: Long,
+        activeIds: Set<Long>,
+        liveWithTs: List<ChannelWithWatchedAt>,
+    ): GuideSliceState = withContext(Dispatchers.IO) {
+        val now = System.currentTimeMillis()
+        val windowStart = floorToHalfHour(now)
+        val windowEnd = windowStart + SLICE_WINDOW_MS
+        if (liveWithTs.isEmpty()) return@withContext GuideSliceState(now = now, windowStart = windowStart, windowEnd = windowEnd)
+
+        val epgIds = epgSourceStore.getAll().map { it.id }
+        val sourceIds = (activeIds.toList() + epgIds).distinct()
+        val customizations = customize.observe(profileId, tv.own.owntv.core.model.MediaType.LIVE).first()
+        val channels = mutableListOf<ChannelEntity>()
+        val programmes = linkedMapOf<Long, List<EpgProgrammeEntity>>()
+
+        for (watched in liveWithTs) {
+            if (channels.size >= GUIDE_SLICE_CHANNEL_LIMIT) break
+            val channel = watched.channel
+            val key = customizations.epgMatches[CustomizeKeys.channel(channel)]
+                ?: channel.epgChannelId
+            val epgKey = key?.trim()?.lowercase().orEmpty()
+            if (epgKey.isBlank()) continue
+
+            val rows = epgDao.programmeSummariesForChannel(sourceIds, epgKey, windowStart, windowEnd)
+            if (rows.isNotEmpty()) {
+                channels += channel
+                programmes[channel.id] = rows
+            }
+        }
+
+        GuideSliceState(
+            channels = channels,
+            programmes = programmes,
+            windowStart = windowStart,
+            windowEnd = windowEnd,
+            now = now,
+        )
+    }
+
+    private fun floorToHalfHour(ms: Long): Long {
+        val halfHourMs = 30 * 60_000L
+        return ms / halfHourMs * halfHourMs
+    }
+
+    suspend fun programmeDescription(programmeId: Long): String? =
+        runCatching { epgDao.programmeDescription(programmeId) }.getOrNull()
 
     private suspend fun currentProfileId(): Long? {
         val preferred = settings.activeProfileId.first()

--- a/app/src/main/java/tv/own/owntv/features/home/HomeViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeViewModel.kt
@@ -97,7 +97,8 @@ data class HomeUiState(
     val recentLive: List<ChannelEntity> = emptyList(),
     val favoriteLive: List<ChannelEntity> = emptyList(),
     val config: HomeConfig = HomeConfig(),
-    val guideSlice: GuideSliceState = GuideSliceState(),
+    val recentGuide: GuideSliceState = GuideSliceState(),
+    val favoriteGuide: GuideSliceState = GuideSliceState(),
     /**
      * True until the first [HomeViewModel.loadHomeData] completes. Home's queries are profile-scoped and
      * already indexed, but on a cold boot their first reads come off slow eMMC (pages not yet in the OS
@@ -117,13 +118,12 @@ data class GuideSliceState(
     val now: Long = 0L,
 ) {
     val hasContent: Boolean
-        get() = channels.isNotEmpty() && programmes.values.any { it.isNotEmpty() }
+        get() = channels.isNotEmpty()
 }
 
-private const val SLICE_WINDOW_MS = 150 * 60_000L
-private const val RECENT_LIVE_LIMIT = 10
-private const val GUIDE_SLICE_CANDIDATE_LIMIT = 50
-private const val GUIDE_SLICE_CHANNEL_LIMIT = 5
+private const val SLICE_WINDOW_MS = 360 * 60_000L
+private const val LIVE_ROW_CHANNEL_LIMIT = 20
+private const val LIVE_ROW_EPG_LIMIT = 10
 
 class HomeViewModel(
     private val planner: LauncherRecommendationPlanner,
@@ -199,17 +199,21 @@ class HomeViewModel(
                 .filterNot { isContinuationHidden(it, hidden) }
             val movies = items.filter { it.kind == LauncherContinuationKind.MOVIE }
             val series = items.filter { it.kind == LauncherContinuationKind.EPISODE }
-            val liveWithTs = recentlyWatchedLive(profileId, activeIds, filtering, RECENT_LIVE_LIMIT)
+            val liveWithTs = recentlyWatchedLive(profileId, activeIds, filtering, LIVE_ROW_CHANNEL_LIMIT)
                 .filterNot { isChannelHidden(it.channel, hidden) }
             val live = liveWithTs.map { it.channel }
             val favLive = channelDao.favoritesListAlpha(profileId, 50).first()
                 .let { if (!filtering) it else it.filter { c -> c.sourceId in activeIds } }
                 .filterNot { isChannelHidden(it, hidden) }
+                .take(LIVE_ROW_CHANNEL_LIMIT)
             val heroItems = buildHeroItems(items, liveWithTs, config)
-            val guideSlice = if (HomeRow.GUIDE_SLICE in config.visibleOrder) {
-                val guideCandidates = recentlyWatchedLive(profileId, activeIds, filtering, GUIDE_SLICE_CANDIDATE_LIMIT)
-                    .filterNot { isChannelHidden(it.channel, hidden) }
-                buildGuideSlice(profileId, activeIds, guideCandidates)
+            val recentGuide = if (HomeRow.RECENT_CHANNELS in config.visibleOrder && config.recentLiveMode == HomeLiveRowMode.ON_NOW) {
+                buildLiveGuide(profileId, activeIds, live)
+            } else {
+                GuideSliceState()
+            }
+            val favoriteGuide = if (HomeRow.FAVORITE_CHANNELS in config.visibleOrder && config.favoriteLiveMode == HomeLiveRowMode.ON_NOW) {
+                buildLiveGuide(profileId, activeIds, favLive)
             } else {
                 GuideSliceState()
             }
@@ -222,7 +226,8 @@ class HomeViewModel(
                 recentLive = live,
                 favoriteLive = favLive,
                 config = config,
-                guideSlice = guideSlice,
+                recentGuide = recentGuide,
+                favoriteGuide = favoriteGuide,
                 isLoading = false,
             )
         }
@@ -345,25 +350,23 @@ class HomeViewModel(
             channelDao.recentlyWatchedWithTimestamp(profileId, limit).first()
         }
 
-    private suspend fun buildGuideSlice(
+    private suspend fun buildLiveGuide(
         profileId: Long,
         activeIds: Set<Long>,
-        liveWithTs: List<ChannelWithWatchedAt>,
+        candidates: List<ChannelEntity>,
     ): GuideSliceState = withContext(Dispatchers.IO) {
         val now = System.currentTimeMillis()
         val windowStart = floorToHalfHour(now)
         val windowEnd = windowStart + SLICE_WINDOW_MS
-        if (liveWithTs.isEmpty()) return@withContext GuideSliceState(now = now, windowStart = windowStart, windowEnd = windowEnd)
+        val channels = candidates.take(LIVE_ROW_CHANNEL_LIMIT)
+        if (channels.isEmpty()) return@withContext GuideSliceState(now = now, windowStart = windowStart, windowEnd = windowEnd)
 
         val epgIds = epgSourceStore.getAll().map { it.id }
         val sourceIds = (activeIds.toList() + epgIds).distinct()
         val customizations = customize.observe(profileId, tv.own.owntv.core.model.MediaType.LIVE).first()
-        val channels = mutableListOf<ChannelEntity>()
         val programmes = linkedMapOf<Long, List<EpgProgrammeEntity>>()
 
-        for (watched in liveWithTs) {
-            if (channels.size >= GUIDE_SLICE_CHANNEL_LIMIT) break
-            val channel = watched.channel
+        for (channel in channels.take(LIVE_ROW_EPG_LIMIT)) {
             val key = customizations.epgMatches[CustomizeKeys.channel(channel)]
                 ?: channel.epgChannelId
             val epgKey = key?.trim()?.lowercase().orEmpty()
@@ -371,7 +374,6 @@ class HomeViewModel(
 
             val rows = epgDao.programmeSummariesForChannel(sourceIds, epgKey, windowStart, windowEnd)
             if (rows.isNotEmpty()) {
-                channels += channel
                 programmes[channel.id] = rows
             }
         }
@@ -389,9 +391,6 @@ class HomeViewModel(
         val halfHourMs = 30 * 60_000L
         return ms / halfHourMs * halfHourMs
     }
-
-    suspend fun programmeDescription(programmeId: Long): String? =
-        runCatching { epgDao.programmeDescription(programmeId) }.getOrNull()
 
     private suspend fun currentProfileId(): Long? {
         val preferred = settings.activeProfileId.first()

--- a/app/src/main/java/tv/own/owntv/features/live/LiveScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/live/LiveScreen.kt
@@ -66,6 +66,7 @@ import tv.own.owntv.ui.components.formatCount
 import tv.own.owntv.ui.components.ContentPanelFill
 import tv.own.owntv.ui.components.PreviewPanelFill
 import tv.own.owntv.ui.components.roundedPanel
+import tv.own.owntv.ui.format.rememberSystemTimeFormatter
 import tv.own.owntv.ui.theme.Dimens
 import tv.own.owntv.ui.theme.OwnTVTheme
 
@@ -554,6 +555,7 @@ private fun LivePreviewPane(
 @Composable
 private fun EpgSection(nowNext: EpgNowNext?) {
     val colors = OwnTVTheme.colors
+    val formatTime = rememberSystemTimeFormatter()
     val now = nowNext?.now
     val next = nowNext?.next
     if (now == null && next == null) return
@@ -577,14 +579,14 @@ private fun EpgSection(nowNext: EpgNowNext?) {
                 Box(Modifier.fillMaxWidth(progress).height(4.dp).clip(RoundedCornerShape(2.dp)).background(colors.primary))
             }
             Text(
-                "${formatClock(now.startMs)} – ${formatClock(now.stopMs)}",
+                "${formatTime(now.startMs)} – ${formatTime(now.stopMs)}",
                 style = MaterialTheme.typography.labelSmall,
                 color = colors.onSurfaceVariant,
             )
         }
         if (next != null) {
             Spacer(Modifier.height(2.dp))
-            Text("NEXT  ·  ${formatClock(next.startMs)}", style = MaterialTheme.typography.labelSmall, color = colors.onSurfaceVariant, fontWeight = FontWeight.Bold)
+            Text("NEXT  ·  ${formatTime(next.startMs)}", style = MaterialTheme.typography.labelSmall, color = colors.onSurfaceVariant, fontWeight = FontWeight.Bold)
             Text(
                 next.title,
                 style = MaterialTheme.typography.bodyMedium,
@@ -600,7 +602,7 @@ private fun EpgSection(nowNext: EpgNowNext?) {
             Text("LATER", style = MaterialTheme.typography.labelSmall, color = colors.onSurfaceVariant, fontWeight = FontWeight.Bold)
             later.forEach { p ->
                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                    Text(formatClock(p.startMs), style = MaterialTheme.typography.labelSmall, color = colors.primary)
+                    Text(formatTime(p.startMs), style = MaterialTheme.typography.labelSmall, color = colors.primary)
                     Text(p.title, style = MaterialTheme.typography.bodySmall, color = colors.onSurfaceVariant, maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }
@@ -608,12 +610,14 @@ private fun EpgSection(nowNext: EpgNowNext?) {
     }
 }
 
-private val clockFormat = java.text.SimpleDateFormat("HH:mm", java.util.Locale.getDefault())
-private fun formatClock(ms: Long): String = clockFormat.format(java.util.Date(ms))
-
-private val catchupDayTimeFormat = java.text.SimpleDateFormat("EEE HH:mm", java.util.Locale.getDefault())
-private fun formatCatchupTime(startMs: Long, stopMs: Long): String =
-    "${catchupDayTimeFormat.format(java.util.Date(startMs))} – ${clockFormat.format(java.util.Date(stopMs))}"
+private fun formatCatchupTime(
+    startMs: Long,
+    stopMs: Long,
+    formatTime: (Long) -> String,
+): String {
+    val day = java.text.SimpleDateFormat("EEE", java.util.Locale.getDefault()).format(java.util.Date(startMs))
+    return "$day ${formatTime(startMs)} – ${formatTime(stopMs)}"
+}
 
 /** Live TV catch-up: pick a recent (already-aired) programme on a catch-up channel to replay from start. */
 @Composable
@@ -624,6 +628,7 @@ private fun CatchupDialog(
     onDismiss: () -> Unit,
 ) {
     val colors = OwnTVTheme.colors
+    val formatTime = rememberSystemTimeFormatter()
     val list by androidx.compose.runtime.produceState<List<tv.own.owntv.core.database.entity.EpgProgrammeEntity>?>(initialValue = null) {
         value = runCatching { loadProgrammes() }.getOrDefault(emptyList())
     }
@@ -660,7 +665,7 @@ private fun CatchupDialog(
                             ) { _ ->
                                 Column(Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 10.dp)) {
                                     Text(p.title, style = MaterialTheme.typography.titleMedium, color = colors.onSurface, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                                    Text(formatCatchupTime(p.startMs, p.stopMs), style = MaterialTheme.typography.bodySmall, color = colors.onSurfaceVariant)
+                                    Text(formatCatchupTime(p.startMs, p.stopMs, formatTime), style = MaterialTheme.typography.bodySmall, color = colors.onSurfaceVariant)
                                 }
                             }
                         }

--- a/app/src/main/java/tv/own/owntv/features/live/LiveViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/live/LiveViewModel.kt
@@ -2,6 +2,7 @@
 
 package tv.own.owntv.features.live
 
+import android.content.Context
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -62,6 +63,7 @@ import tv.own.owntv.core.repository.activeProfileSources
 import tv.own.owntv.features.settings.data.SettingsRepository
 import tv.own.owntv.player.OwnTVPlayer
 import tv.own.owntv.ui.components.OwnTVIcon
+import tv.own.owntv.ui.format.formatSystemTime
 
 /** Layer-2 rail selection for Live TV. */
 sealed interface LiveKey {
@@ -78,6 +80,7 @@ data class LiveRailItem(val key: LiveKey, val abbr: String, val title: String, v
 data class EpgNowNext(val now: XtEpgEntry?, val next: XtEpgEntry?, val upcoming: List<XtEpgEntry> = emptyList())
 
 class LiveViewModel(
+    private val appContext: Context,
     private val channelDao: ChannelDao,
     private val categoryDao: CategoryDao,
     private val favoriteDao: FavoriteDao,
@@ -665,8 +668,7 @@ class LiveViewModel(
             } ?: return@launch
             if (_timeshiftOffsetSec.value == null) return@launch // user jumped back to live meanwhile
             // Show the clock time being watched (handy for the user; no credentials in logs).
-            val localLabel = java.text.SimpleDateFormat("HH:mm", java.util.Locale.getDefault())
-                .apply { timeZone = java.util.TimeZone.getDefault() }.format(java.util.Date(startMs))
+            val localLabel = formatSystemTime(appContext, startMs)
             _previewChannel.value = ch
             clearLiveOnExo() // archive plays as a VOD-style mpv stream, not the live ExoPlayer channel
             player.play(url, title = ch.name, subtitle = "Rewind · $localLabel", logoUrl = ch.logoUrl, isLive = false, preferSoftware = true, userAgent = sourceUa)

--- a/app/src/main/java/tv/own/owntv/features/settings/HomeSettingsScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/settings/HomeSettingsScreen.kt
@@ -96,10 +96,10 @@ fun HomeSettingsScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             item {
-                Text("Rows", style = MaterialTheme.typography.titleLarge, color = colors.onSurface)
+                Text("Sections", style = MaterialTheme.typography.titleLarge, color = colors.onSurface)
                 Spacer(Modifier.height(4.dp))
                 Text(
-                    "Hidden rows stay listed so you can turn them back on.",
+                    "Hidden sections stay listed so you can turn them back on.",
                     style = MaterialTheme.typography.bodyMedium,
                     color = colors.onSurfaceVariant,
                 )

--- a/app/src/main/java/tv/own/owntv/features/settings/HomeSettingsScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/settings/HomeSettingsScreen.kt
@@ -1,0 +1,283 @@
+package tv.own.owntv.features.settings
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import org.koin.androidx.compose.koinViewModel
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import tv.own.owntv.features.home.HeroKind
+import tv.own.owntv.features.home.HomeRow
+import tv.own.owntv.features.settings.data.StartupMode
+import tv.own.owntv.ui.components.OwnTVButton
+import tv.own.owntv.ui.components.OwnTVButtonStyle
+import tv.own.owntv.ui.components.OwnTVIcon
+import tv.own.owntv.ui.components.roundedPanel
+import tv.own.owntv.ui.theme.OwnTVTheme
+
+@Composable
+fun HomeSettingsScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
+    val vm: HomeSettingsViewModel = koinViewModel()
+    val settingsVm: SettingsViewModel = koinViewModel()
+    val config by vm.config.collectAsStateWithLifecycle()
+    val startupMode by settingsVm.startupMode.collectAsStateWithLifecycle()
+    val androidTvHomeEnabled by settingsVm.androidTvHomeEnabled.collectAsStateWithLifecycle()
+    val tvHomeRefresh by settingsVm.tvHomeRefresh.collectAsStateWithLifecycle()
+    val colors = OwnTVTheme.colors
+
+    var showStartup by remember { mutableStateOf(false) }
+    val firstFocus = remember { FocusRequester() }
+    val startupFocus = remember { FocusRequester() }
+    var dialogReturn by remember { mutableStateOf<FocusRequester?>(null) }
+
+    LaunchedEffect(showStartup) {
+        if (!showStartup) {
+            dialogReturn?.let { row ->
+                kotlinx.coroutines.delay(80)
+                runCatching { row.requestFocus() }
+            }
+        }
+    }
+
+    BackHandler { onBack() }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .roundedPanel()
+            .focusProperties {
+                onEnter = {
+                    val target = dialogReturn ?: firstFocus
+                    dialogReturn = null
+                    runCatching { target.requestFocus() }
+                }
+            }
+            .focusGroup()
+            .padding(horizontal = 40.dp, vertical = 28.dp),
+    ) {
+        Text("Home screen", style = MaterialTheme.typography.headlineLarge, color = colors.onSurface)
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "Hide, reorder and filter rows on Home for this profile.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = colors.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(16.dp))
+
+        LazyColumn(
+            modifier = Modifier.weight(1f).fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            item {
+                Text("Rows", style = MaterialTheme.typography.titleLarge, color = colors.onSurface)
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    "Hidden rows stay listed so you can turn them back on.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = colors.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(4.dp))
+            }
+
+            itemsIndexed(config.settingsRows, key = { _, row -> row.name }) { index, row ->
+                HomeRowCard(
+                    row = row,
+                    hidden = row in config.hidden,
+                    canMoveUp = index > 0,
+                    canMoveDown = index < config.settingsRows.lastIndex,
+                    onMoveUp = { vm.move(row, up = true) },
+                    onMoveDown = { vm.move(row, up = false) },
+                    onMoveTop = { vm.moveToEdge(row, top = true) },
+                    onMoveBottom = { vm.moveToEdge(row, top = false) },
+                    onToggleHidden = { vm.setRowHidden(row, row !in config.hidden) },
+                    firstButtonModifier = if (index == 0) Modifier.focusRequester(firstFocus) else Modifier,
+                )
+            }
+
+            item {
+                Spacer(Modifier.height(14.dp))
+                GroupLabel("Keep Watching")
+            }
+
+            item {
+                Row2(
+                    icon = OwnTVIcon.LIVE_TV,
+                    title = "Live channels in Keep Watching",
+                    desc = "Show recently watched live channels in the hero row.",
+                    chip = if (config.heroIncludeLive) "On" else "Off",
+                    primaryChip = config.heroIncludeLive,
+                    onClick = { vm.setHeroInclude(HeroKind.LIVE, !config.heroIncludeLive) },
+                )
+            }
+            item {
+                Row2(
+                    icon = OwnTVIcon.MOVIES,
+                    title = "Movies in Keep Watching",
+                    desc = "Show movie resume cards in the hero row.",
+                    chip = if (config.heroIncludeMovies) "On" else "Off",
+                    primaryChip = config.heroIncludeMovies,
+                    onClick = { vm.setHeroInclude(HeroKind.MOVIES, !config.heroIncludeMovies) },
+                )
+            }
+            item {
+                Row2(
+                    icon = OwnTVIcon.SERIES,
+                    title = "Series in Keep Watching",
+                    desc = "Show episode resume cards in the hero row.",
+                    chip = if (config.heroIncludeSeries) "On" else "Off",
+                    primaryChip = config.heroIncludeSeries,
+                    onClick = { vm.setHeroInclude(HeroKind.SERIES, !config.heroIncludeSeries) },
+                )
+            }
+
+            item {
+                Spacer(Modifier.height(6.dp))
+                GroupLabel("Startup")
+            }
+            item {
+                Row2(
+                    icon = OwnTVIcon.HOME,
+                    title = "Startup",
+                    desc = "Where this profile opens: Home, the last live channel you watched, or Live TV on Favorites.",
+                    chip = startupMode.label,
+                    chevron = true,
+                    modifier = Modifier.focusRequester(startupFocus),
+                    onClick = {
+                        dialogReturn = startupFocus
+                        showStartup = true
+                    },
+                )
+            }
+
+            item {
+                Spacer(Modifier.height(6.dp))
+                GroupLabel("Android TV home")
+            }
+            item {
+                Row2(
+                    icon = OwnTVIcon.HISTORY,
+                    title = "Android TV home",
+                    desc = "Show Continue Watching and recent live channels on the TV home screen.",
+                    chip = if (androidTvHomeEnabled) "On" else "Off",
+                    primaryChip = androidTvHomeEnabled,
+                    onClick = { settingsVm.setAndroidTvHomeEnabled(!androidTvHomeEnabled) },
+                )
+            }
+            if (androidTvHomeEnabled) {
+                item {
+                    Row2(
+                        icon = OwnTVIcon.SHARE,
+                        title = "Refresh now",
+                        desc = "Rebuild the Continue Watching / recent cards on the Android TV home.",
+                        chip = when (tvHomeRefresh) {
+                            SettingsViewModel.TvHomeRefresh.REFRESHING -> "Rebuilding…"
+                            SettingsViewModel.TvHomeRefresh.DONE -> "Done ✓"
+                            else -> null
+                        },
+                        onClick = {
+                            if (tvHomeRefresh == SettingsViewModel.TvHomeRefresh.IDLE) {
+                                settingsVm.refreshAndroidTvHome()
+                            }
+                        },
+                    )
+                }
+            }
+        }
+    }
+
+    if (showStartup) {
+        PickerDialog(
+            title = "Startup",
+            options = StartupMode.entries.map { it.name to it.label },
+            selected = startupMode.name,
+            onSelect = {
+                settingsVm.setStartupMode(StartupMode.valueOf(it))
+                showStartup = false
+            },
+            onDismiss = { showStartup = false },
+        )
+    }
+}
+
+@Composable
+private fun HomeRowCard(
+    row: HomeRow,
+    hidden: Boolean,
+    canMoveUp: Boolean,
+    canMoveDown: Boolean,
+    onMoveUp: () -> Unit,
+    onMoveDown: () -> Unit,
+    onMoveTop: () -> Unit,
+    onMoveBottom: () -> Unit,
+    onToggleHidden: () -> Unit,
+    firstButtonModifier: Modifier = Modifier,
+) {
+    val colors = OwnTVTheme.colors
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(colors.surfaceContainerHigh)
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                row.title,
+                style = MaterialTheme.typography.titleSmall,
+                color = if (hidden) colors.onSurfaceVariant else colors.onSurface,
+                maxLines = 1,
+            )
+            if (hidden) {
+                Text(
+                    "Hidden",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = colors.onSurfaceVariant,
+                    maxLines = 1,
+                )
+            }
+        }
+        Spacer(Modifier.width(10.dp))
+        OwnTVButton("⤒", onClick = onMoveTop, style = OwnTVButtonStyle.SECONDARY, enabled = canMoveUp)
+        Spacer(Modifier.width(6.dp))
+        OwnTVButton("↑", onClick = onMoveUp, style = OwnTVButtonStyle.SECONDARY, enabled = canMoveUp)
+        Spacer(Modifier.width(6.dp))
+        OwnTVButton("↓", onClick = onMoveDown, style = OwnTVButtonStyle.SECONDARY, enabled = canMoveDown)
+        Spacer(Modifier.width(6.dp))
+        OwnTVButton("⤓", onClick = onMoveBottom, style = OwnTVButtonStyle.SECONDARY, enabled = canMoveDown)
+        Spacer(Modifier.width(6.dp))
+        OwnTVButton(
+            label = if (hidden) "Show" else "Hide",
+            onClick = onToggleHidden,
+            modifier = firstButtonModifier,
+            style = OwnTVButtonStyle.SECONDARY,
+        )
+    }
+}

--- a/app/src/main/java/tv/own/owntv/features/settings/HomeSettingsScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/settings/HomeSettingsScreen.kt
@@ -33,6 +33,7 @@ import org.koin.androidx.compose.koinViewModel
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import tv.own.owntv.features.home.HeroKind
+import tv.own.owntv.features.home.HomeLiveRowMode
 import tv.own.owntv.features.home.HomeRow
 import tv.own.owntv.features.settings.data.StartupMode
 import tv.own.owntv.ui.components.OwnTVButton
@@ -116,6 +117,12 @@ fun HomeSettingsScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
                     onMoveTop = { vm.moveToEdge(row, top = true) },
                     onMoveBottom = { vm.moveToEdge(row, top = false) },
                     onToggleHidden = { vm.setRowHidden(row, row !in config.hidden) },
+                    liveMode = when (row) {
+                        HomeRow.RECENT_CHANNELS -> config.recentLiveMode
+                        HomeRow.FAVORITE_CHANNELS -> config.favoriteLiveMode
+                        else -> null
+                    },
+                    onToggleLiveMode = { mode -> vm.setLiveRowMode(row, mode.toggled()) },
                     firstButtonModifier = if (index == 0) Modifier.focusRequester(firstFocus) else Modifier,
                 )
             }
@@ -236,6 +243,8 @@ private fun HomeRowCard(
     onMoveTop: () -> Unit,
     onMoveBottom: () -> Unit,
     onToggleHidden: () -> Unit,
+    liveMode: HomeLiveRowMode?,
+    onToggleLiveMode: (HomeLiveRowMode) -> Unit,
     firstButtonModifier: Modifier = Modifier,
 ) {
     val colors = OwnTVTheme.colors
@@ -265,6 +274,14 @@ private fun HomeRowCard(
             }
         }
         Spacer(Modifier.width(10.dp))
+        if (liveMode != null) {
+            OwnTVButton(
+                label = "Mode: ${liveMode.label}",
+                onClick = { onToggleLiveMode(liveMode) },
+                style = OwnTVButtonStyle.SECONDARY,
+            )
+            Spacer(Modifier.width(6.dp))
+        }
         OwnTVButton("⤒", onClick = onMoveTop, style = OwnTVButtonStyle.SECONDARY, enabled = canMoveUp)
         Spacer(Modifier.width(6.dp))
         OwnTVButton("↑", onClick = onMoveUp, style = OwnTVButtonStyle.SECONDARY, enabled = canMoveUp)

--- a/app/src/main/java/tv/own/owntv/features/settings/HomeSettingsViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/settings/HomeSettingsViewModel.kt
@@ -1,0 +1,83 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package tv.own.owntv.features.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import tv.own.owntv.features.home.HeroKind
+import tv.own.owntv.features.home.HomeConfig
+import tv.own.owntv.features.home.HomeRow
+import tv.own.owntv.features.settings.data.SettingsRepository
+
+class HomeSettingsViewModel(
+    private val settings: SettingsRepository,
+) : ViewModel() {
+    val config: StateFlow<HomeConfig> = settings.activeProfileId
+        .flatMapLatest { pid -> if (pid < 0) flowOf(HomeConfig()) else settings.homeConfig(pid) }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, HomeConfig())
+
+    fun setRowHidden(row: HomeRow, hidden: Boolean) {
+        updateConfig { config -> config.copy(hidden = if (hidden) config.hidden + row else config.hidden - row) }
+    }
+
+    fun move(row: HomeRow, up: Boolean) {
+        updateConfig { config ->
+            val rows = config.settingsRows.toMutableList()
+            val from = rows.indexOf(row)
+            if (from < 0) {
+                config
+            } else {
+                val to = if (up) from - 1 else from + 1
+                if (to !in rows.indices) {
+                    config
+                } else {
+                    rows.add(to, rows.removeAt(from))
+                    config.copy(order = rows + config.order.filterNot { it.implemented })
+                }
+            }
+        }
+    }
+
+    fun moveToEdge(row: HomeRow, top: Boolean) {
+        updateConfig { config ->
+            val rows = config.settingsRows.toMutableList()
+            val from = rows.indexOf(row)
+            if (from < 0) {
+                config
+            } else {
+                val to = if (top) 0 else rows.lastIndex
+                if (to == from) {
+                    config
+                } else {
+                    rows.add(to, rows.removeAt(from))
+                    config.copy(order = rows + config.order.filterNot { it.implemented })
+                }
+            }
+        }
+    }
+
+    fun setHeroInclude(kind: HeroKind, included: Boolean) {
+        updateConfig { config ->
+            when (kind) {
+                HeroKind.LIVE -> config.copy(heroIncludeLive = included)
+                HeroKind.MOVIES -> config.copy(heroIncludeMovies = included)
+                HeroKind.SERIES -> config.copy(heroIncludeSeries = included)
+            }
+        }
+    }
+
+    private fun updateConfig(transform: (HomeConfig) -> HomeConfig) {
+        viewModelScope.launch {
+            val pid = settings.activeProfileId.first()
+            if (pid < 0) return@launch
+            settings.updateHomeConfig(pid) { current -> transform(current) }
+        }
+    }
+}

--- a/app/src/main/java/tv/own/owntv/features/settings/HomeSettingsViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/settings/HomeSettingsViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import tv.own.owntv.features.home.HeroKind
 import tv.own.owntv.features.home.HomeConfig
+import tv.own.owntv.features.home.HomeLiveRowMode
 import tv.own.owntv.features.home.HomeRow
 import tv.own.owntv.features.settings.data.SettingsRepository
 
@@ -69,6 +70,16 @@ class HomeSettingsViewModel(
                 HeroKind.LIVE -> config.copy(heroIncludeLive = included)
                 HeroKind.MOVIES -> config.copy(heroIncludeMovies = included)
                 HeroKind.SERIES -> config.copy(heroIncludeSeries = included)
+            }
+        }
+    }
+
+    fun setLiveRowMode(row: HomeRow, mode: HomeLiveRowMode) {
+        updateConfig { config ->
+            when (row) {
+                HomeRow.RECENT_CHANNELS -> config.copy(recentLiveMode = mode)
+                HomeRow.FAVORITE_CHANNELS -> config.copy(favoriteLiveMode = mode)
+                else -> config
             }
         }
     }

--- a/app/src/main/java/tv/own/owntv/features/settings/data/SettingsRepository.kt
+++ b/app/src/main/java/tv/own/owntv/features/settings/data/SettingsRepository.kt
@@ -14,6 +14,7 @@ import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import tv.own.owntv.features.home.HomeConfig
 import tv.own.owntv.ui.theme.AccentColor
 import tv.own.owntv.ui.theme.ThemeMode
 import tv.own.owntv.ui.theme.UiZoom
@@ -153,6 +154,21 @@ class SettingsRepository(private val context: Context) {
         context.dataStore.edit { prefs ->
             val k = stringPreferencesKey("customize_pin_$profileId")
             if (pin.isNullOrBlank()) prefs.remove(k) else prefs[k] = pin.trim()
+        }
+    }
+
+    // --- Home: per-profile row order / visibility / hero filters. ---
+    private fun homeConfigKey(profileId: Long) = stringPreferencesKey("home_config_$profileId")
+
+    fun homeConfig(profileId: Long): Flow<HomeConfig> = context.dataStore.data.map { prefs ->
+        HomeConfig.fromJson(prefs[homeConfigKey(profileId)])
+    }
+
+    suspend fun updateHomeConfig(profileId: Long, transform: (HomeConfig) -> HomeConfig) {
+        context.dataStore.edit { prefs ->
+            val key = homeConfigKey(profileId)
+            val next = transform(HomeConfig.fromJson(prefs[key]))
+            if (next == HomeConfig()) prefs.remove(key) else prefs[key] = next.toJson().toString()
         }
     }
 
@@ -689,6 +705,19 @@ class SettingsRepository(private val context: Context) {
         return out
     }
 
+    /** Exports all per-profile Home config blobs as { "<profileId>": { ... } }. */
+    suspend fun exportHomeConfigs(): org.json.JSONObject {
+        val prefix = "home_config_"
+        val out = org.json.JSONObject()
+        context.dataStore.data.first().asMap().forEach { (k, v) ->
+            if (k.name.startsWith(prefix) && v is String) {
+                val blob = runCatching { org.json.JSONObject(v) }.getOrNull() ?: return@forEach
+                out.put(k.name.removePrefix(prefix), blob)
+            }
+        }
+        return out
+    }
+
     /** Restores startup modes only for profile ids in [existingProfileIds] (others are dropped safely). */
     suspend fun importStartupModes(o: org.json.JSONObject, existingProfileIds: Set<Long>) {
         context.dataStore.edit { prefs ->
@@ -699,6 +728,18 @@ class SettingsRepository(private val context: Context) {
                 if (runCatching { StartupMode.valueOf(mode) }.isSuccess) {
                     prefs[stringPreferencesKey("startup_mode_$pid")] = mode
                 }
+            }
+        }
+    }
+
+    /** Restores Home configs only for profile ids in [existingProfileIds] (others are dropped safely). */
+    suspend fun importHomeConfigs(o: org.json.JSONObject, existingProfileIds: Set<Long>) {
+        context.dataStore.edit { prefs ->
+            o.keys().forEach { key ->
+                val pid = key.toLongOrNull() ?: return@forEach
+                if (pid !in existingProfileIds) return@forEach
+                val blob = o.optJSONObject(key) ?: return@forEach
+                prefs[homeConfigKey(pid)] = blob.toString()
             }
         }
     }

--- a/app/src/main/java/tv/own/owntv/features/shell/OwnTVShell.kt
+++ b/app/src/main/java/tv/own/owntv/features/shell/OwnTVShell.kt
@@ -344,6 +344,7 @@ fun OwnTVShell(
                             onPlayMovie = { id, pos -> scope.launch { if (movieVm.playByIdAsync(id, pos)) openFullscreen(MainSection.MOVIES) } },
                             onPlayEpisode = { seriesId, epId, pos -> scope.launch { if (seriesVm.playFromHomeAsync(seriesId, epId, pos)) openFullscreen(MainSection.SERIES) } },
                             onPlayChannel = { id, zap -> scope.launch { if (liveVm.ensurePlayingByIdAsync(id, zap)) openFullscreen(MainSection.LIVE_TV) } },
+                            onOpenGuide = { onSelectSection(MainSection.EPG) },
                             onChildFocused = { focusedLayer = ShellLayer.CONTENT },
                             restoreFocus = restoreFocus,
                             onRestored = { restoreFocus = false },

--- a/app/src/main/java/tv/own/owntv/features/shell/components/SettingsScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/shell/components/SettingsScreen.kt
@@ -44,6 +44,7 @@ import org.koin.androidx.compose.koinViewModel
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import tv.own.owntv.features.customize.CustomizeScreen
+import tv.own.owntv.features.settings.HomeSettingsScreen
 import tv.own.owntv.features.settings.data.SettingsRepository
 import tv.own.owntv.features.update.UpdateDialog
 import tv.own.owntv.features.settings.BackupScreen
@@ -69,7 +70,7 @@ import tv.own.owntv.ui.theme.UiZoom
 
 private enum class TileTone { PRIMARY, SECONDARY, TERTIARY }
 
-private enum class SettingsTab { ROOT, SOURCES, EPG, PROFILES, BACKUP, VIDEO, CUSTOMIZE, NETWORK, METADATA }
+private enum class SettingsTab { ROOT, SOURCES, EPG, PROFILES, BACKUP, VIDEO, CUSTOMIZE, HOME, NETWORK, METADATA }
 
 /**
  * The MD3 Settings screen (shown when [MainSection.SETTINGS] is active): grouped sections, each row
@@ -98,7 +99,6 @@ fun SettingsScreen(
     var showCatchupTime by remember { mutableStateOf(false) }
     var showClearHistory by remember { mutableStateOf(false) }
     var showAnimations by remember { mutableStateOf(false) }
-    var showStartup by remember { mutableStateOf(false) }
     var showWeatherLocation by remember { mutableStateOf(false) }
 
     // Dialog-close focus return: closing a dialog/picker refocuses the row that opened it (focus
@@ -112,13 +112,12 @@ fun SettingsScreen(
     val catchupRowFocus = remember { FocusRequester() }
     val clearHistoryRowFocus = remember { FocusRequester() }
     val animationsRowFocus = remember { FocusRequester() }
-    val startupRowFocus = remember { FocusRequester() }
     // NOTE: this restore request crosses INTO the root focus group from outside (the dialog), so
     // the group's onEnter intercepts it — onEnter must consult dialogReturn first (it does, below)
     // or it would hijack the restore to its own default target. dialogReturn is cleared by onEnter.
     var dialogReturn by remember { mutableStateOf<FocusRequester?>(null) }
-    LaunchedEffect(showZoom, showTheme, showAccent, showFolderPicker, showUpdate, showAbout, showCatchupTime, showClearHistory, showAnimations, showStartup) {
-        if (!showZoom && !showTheme && !showAccent && !showFolderPicker && !showUpdate && !showAbout && !showCatchupTime && !showClearHistory && !showAnimations && !showStartup) {
+    LaunchedEffect(showZoom, showTheme, showAccent, showFolderPicker, showUpdate, showAbout, showCatchupTime, showClearHistory, showAnimations) {
+        if (!showZoom && !showTheme && !showAccent && !showFolderPicker && !showUpdate && !showAbout && !showCatchupTime && !showClearHistory && !showAnimations) {
             dialogReturn?.let { row ->
                 kotlinx.coroutines.delay(80)
                 runCatching { row.requestFocus() }
@@ -132,10 +131,7 @@ fun SettingsScreen(
     val hdr by settingsVm.hdrEnabled.collectAsStateWithLifecycle()
     val surroundSound by settingsVm.surroundSound.collectAsStateWithLifecycle()
     val autoPlayNext by settingsVm.autoPlayNext.collectAsStateWithLifecycle()
-    val androidTvHomeEnabled by settingsVm.androidTvHomeEnabled.collectAsStateWithLifecycle()
     val updateCheckOnStart by settingsVm.updateCheckOnStart.collectAsStateWithLifecycle()
-    val resumeLastChannel by settingsVm.resumeLastChannel.collectAsStateWithLifecycle()
-    val startupMode by settingsVm.startupMode.collectAsStateWithLifecycle()
     val catchupTz by settingsVm.catchupTimezone.collectAsStateWithLifecycle()
     val catchupOffset by settingsVm.catchupOffsetMinutes.collectAsStateWithLifecycle()
     val catchupChannels by settingsVm.catchupChannelCount.collectAsStateWithLifecycle()
@@ -154,6 +150,7 @@ fun SettingsScreen(
         SettingsTab.BACKUP to FocusRequester(),
         SettingsTab.VIDEO to FocusRequester(),
         SettingsTab.CUSTOMIZE to FocusRequester(),
+        SettingsTab.HOME to FocusRequester(),
         SettingsTab.NETWORK to FocusRequester(),
         SettingsTab.METADATA to FocusRequester(),
     ) }
@@ -175,6 +172,7 @@ fun SettingsScreen(
         SettingsTab.BACKUP -> { BackupScreen(onBack = { tab = SettingsTab.ROOT }, modifier = modifier); return }
         SettingsTab.VIDEO -> { VideoPlayerSettingsScreen(onBack = { tab = SettingsTab.ROOT }, modifier = modifier); return }
         SettingsTab.CUSTOMIZE -> { CustomizeScreen(onBack = { tab = SettingsTab.ROOT }, modifier = modifier); return }
+        SettingsTab.HOME -> { HomeSettingsScreen(onBack = { tab = SettingsTab.ROOT }, modifier = modifier); return }
         SettingsTab.NETWORK -> { tv.own.owntv.features.settings.NetworkSettingsScreen(onBack = { tab = SettingsTab.ROOT }, modifier = modifier); return }
         SettingsTab.METADATA -> { tv.own.owntv.features.settings.MetadataSettingsScreen(onBack = { tab = SettingsTab.ROOT }, modifier = modifier); return }
         SettingsTab.ROOT -> Unit
@@ -226,6 +224,12 @@ fun SettingsScreen(
             title = "Customize & Hidden Items", desc = "Hide & unhide items, rename & reorder categories",
             onClick = { open(SettingsTab.CUSTOMIZE) }, showChevron = true,
             modifier = Modifier.focusRequester(rowFocus.getValue(SettingsTab.CUSTOMIZE)),
+        )
+        SettingsRow(
+            tone = TileTone.SECONDARY, icon = OwnTVIcon.HOME,
+            title = "Home screen", desc = "Choose, reorder & filter the rows on Home",
+            onClick = { open(SettingsTab.HOME) }, showChevron = true,
+            modifier = Modifier.focusRequester(rowFocus.getValue(SettingsTab.HOME)),
         )
         SettingsRow(
             tone = TileTone.PRIMARY, icon = OwnTVIcon.VIDEO,
@@ -341,14 +345,6 @@ fun SettingsScreen(
             onClick = { settingsVm.setSurroundSound(!surroundSound) },
         )
         SettingsRow(
-            tone = TileTone.SECONDARY, icon = OwnTVIcon.LIVE_TV,
-            title = "Startup",
-            desc = "Where this profile opens: Home, the last live channel you watched, or Live TV on Favorites.",
-            chip = startupMode.label, chipTone = TileTone.SECONDARY,
-            onClick = { dialogReturn = startupRowFocus; showStartup = true }, showChevron = true,
-            modifier = Modifier.focusRequester(startupRowFocus),
-        )
-        SettingsRow(
             tone = TileTone.SECONDARY, icon = OwnTVIcon.SKIP_NEXT,
             title = "Auto-play next episode",
             desc = "When an episode ends, automatically start the next one — and roll into the next season.",
@@ -369,31 +365,6 @@ fun SettingsScreen(
             onClick = { dialogReturn = catchupRowFocus; showCatchupTime = true }, showChevron = true,
             modifier = Modifier.focusRequester(catchupRowFocus),
         )
-        SettingsRow(
-            tone = TileTone.SECONDARY, icon = OwnTVIcon.HISTORY,
-            title = "Android TV home", desc = "Show Continue Watching and recent live channels on the TV home screen",
-            chip = if (androidTvHomeEnabled) "On" else "Off",
-            chipTone = if (androidTvHomeEnabled) TileTone.PRIMARY else TileTone.SECONDARY,
-            onClick = { settingsVm.setAndroidTvHomeEnabled(!androidTvHomeEnabled) },
-        )
-        if (androidTvHomeEnabled) {
-            val tvHomeRefresh by settingsVm.tvHomeRefresh.collectAsStateWithLifecycle()
-            SettingsRow(
-                tone = TileTone.TERTIARY, icon = OwnTVIcon.SHARE,
-                title = "Refresh now", desc = "Rebuild the Continue Watching / recent cards on the Android TV home",
-                chip = when (tvHomeRefresh) {
-                    tv.own.owntv.features.settings.SettingsViewModel.TvHomeRefresh.REFRESHING -> "Rebuilding…"
-                    tv.own.owntv.features.settings.SettingsViewModel.TvHomeRefresh.DONE -> "Done ✓"
-                    else -> null
-                },
-                chipTone = TileTone.PRIMARY,
-                onClick = {
-                    if (tvHomeRefresh == tv.own.owntv.features.settings.SettingsViewModel.TvHomeRefresh.IDLE) {
-                        settingsVm.refreshAndroidTvHome()
-                    }
-                },
-            )
-        }
         SettingsRow(
             tone = TileTone.TERTIARY, icon = OwnTVIcon.VIDEO,
             title = "Video Player Settings", desc = "Decoder, subtitles, sync",
@@ -472,15 +443,6 @@ fun SettingsScreen(
             selected = animationLevel.name,
             onSelect = { settingsVm.setAnimationLevel(tv.own.owntv.ui.theme.AnimationLevel.valueOf(it)); showAnimations = false },
             onDismiss = { showAnimations = false },
-        )
-    }
-    if (showStartup) {
-        tv.own.owntv.features.settings.PickerDialog(
-            title = "Startup",
-            options = tv.own.owntv.features.settings.data.StartupMode.entries.map { it.name to it.label },
-            selected = startupMode.name,
-            onSelect = { settingsVm.setStartupMode(tv.own.owntv.features.settings.data.StartupMode.valueOf(it)); showStartup = false },
-            onDismiss = { showStartup = false },
         )
     }
     if (showWeatherLocation) {

--- a/app/src/main/java/tv/own/owntv/ui/format/TimeFormat.kt
+++ b/app/src/main/java/tv/own/owntv/ui/format/TimeFormat.kt
@@ -1,0 +1,30 @@
+package tv.own.owntv.ui.format
+
+import android.content.Context
+import android.text.format.DateFormat
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import java.util.Date
+
+@Composable
+fun rememberSystemTimeFormatter(): (Long) -> String {
+    val context = LocalContext.current
+    val configuration = LocalConfiguration.current
+    val formatter = remember(context, configuration) {
+        DateFormat.getTimeFormat(context)
+    }
+    return remember(formatter) {
+        val date = Date(0L)
+        val format: (Long) -> String = { ms ->
+            date.time = ms
+            formatter.format(date)
+        }
+        format
+    }
+}
+
+fun formatSystemTime(context: Context, ms: Long): String {
+    return DateFormat.getTimeFormat(context).format(Date(ms))
+}


### PR DESCRIPTION
## Before you open this PR (required)
- [x] I read the **[User Guide](https://github.com/ahXN00/OwnTV/blob/main/extras/USER_GUIDE.md)** and checked the app's **Settings** and existing **functions** — this change isn't already possible in the app.
- [x] I searched existing issues/PRs and this isn't a duplicate.

## What does this PR do?

Major Home screen overhaul: every row is now customizable (hide, reorder, filter), the hero preview is redesigned with dwell-to-expand, live-channel rows gain an inline "On Now" mini-guide mode, and all Home-related settings move to a dedicated per-profile settings page. 12 commits, 18 files changed.

### Customizable Home screen (Settings → Home screen)

- **Reorder and show/hide every Home row** — five rows (Keep Watching hero, Recent Channels, Favourite Channels, Continue Watching Movies, Continue Watching Series) can each be toggled on/off and moved up/down/top/bottom via the new **Settings → Home screen** page. Configuration is stored per-profile as a JSON blob in DataStore and survives app restarts.
- **Filter the Keep Watching hero row** — three independent toggles let you include/exclude live channels, movies, and series from the hero strip. For example, disable live channels so the hero only shows movie and series resume cards — no more channel-surfing clutter mixing with your VOD content.
- **Two live-channel row display modes** — Recent Channels and Favourite Channels rows can each display as **Cards** (compact logo + name tiles) or **On Now** (an inline mini-guide showing currently-airing programmes, progress bars, channel logos, and the upcoming schedule). Favourite Channels defaults to On Now; Recent Channels defaults to Cards. Mode is toggled per-row from the Home settings page.
- **Recent Channels row** — new row surfacing recently tuned live channels (filtered to the active playlist), backed by a new `ChannelDao` query with configurable limit. Hidden by default to keep Home clean for new users; easily enabled from Settings → Home screen.
- **Startup & Android TV home settings relocated** — the Startup picker (Home / Last channel / Live TV Favorites) and the Android TV home toggle + refresh button moved from the main Settings list into the Home screen settings page, grouping all Home-related controls together.
- **Empty and all-hidden states** — when every row is hidden, Home shows "All rows are hidden — open Settings → Home screen" instead of a blank screen. When rows are enabled but have no data, the existing empty state still appears.
- **Backup/restore support** — Home configs ride with the CUSTOMIZE backup section (backup format bumped to v8). Older backups without Home configs restore cleanly using defaults; configs are scoped to existing profile IDs so a restore never creates orphan data.

### Redesigned hero row (Keep Watching)

- **Dwell-to-expand (3s)** — hero cards no longer expand the instant you navigate to them. A card stays compact until it holds focus for 3 uninterrupted seconds, then smoothly widens to 16:9 preview size. Quick D-pad sweeps never trigger expansion, so browsing the row is snappier and the layout doesn't jump. Moving focus away collapses the card immediately.
- **Video preview delayed until expansion settles** — the muted video preview now starts only *after* the card finishes expanding, so 4K decoder setup doesn't compete with the width animation. On lower-end devices this prevents the stutter that occurred when both ran simultaneously.
- **Blurred artwork backdrop** — expanded hero cards reuse the Live-card treatment: a blurred crop backdrop behind centered artwork, with an opaque overlay below so the previous preview's last frame never bleeds through the SurfaceView while loading.
- **Left-aligned expansion** — expanded hero cards stay left-aligned (instead of centering), matching standard TV UI patterns.
- **Anchored across data refreshes** — when Home data reloads (e.g. returning from the player), the active hero index is preserved and the row scrolls back to it instead of jumping to the first item.
- **Preview cleanup on exit** — the hero preview engine is stopped via `DisposableEffect` when Home leaves composition, preventing an off-screen video from playing in the background.

### On Now mini-guide on Home

- **Inline EPG on Home** — when a live-channel row is set to "On Now" mode, each channel shows a horizontal programme timeline with: channel logo, channel name, the currently-airing programme highlighted with a live progress bar, upcoming programmes for the next 6 hours, and time labels respecting the device's 12h/24h setting.
- **D-pad navigation** — Up/Down selects channels, Left/Right scrolls the programme timeline, Enter tunes to the selected channel. The focused channel row auto-scrolls to keep the current programme visible.
- **Shared EPG rendering (GuideCore.kt)** — programme-strip rendering logic (time slots, progress bars, now-marker, text measuring via `ProgrammeStripCanvas`) is extracted from the full EPG screen into a shared module, so both the EPG and the Home guide slice use identical rendering.
- **Device time format everywhere** — a new `rememberSystemTimeFormatter()` composable reads the device's 12h/24h preference and is now used across Home, Live TV preview, EPG, and the catch-up dialog, replacing scattered `SimpleDateFormat("HH:mm")` calls that always forced 24h format.

### Settings reorganization

- **New "Home screen" entry in Settings** — opens the per-profile Home settings page described above.
- **Startup mode, Android TV home toggle, and TV home refresh** are removed from the main Settings list and relocated to the Home settings page.
- **Settings root is cleaner** — fewer rows in the main list; Home-related concerns are no longer scattered across the general settings.

## Which issue / improvement does it address?

Addresses **#43** — the first row no longer mixes TV channels, movies, and series by default:
- Users can filter what appears in the Keep Watching hero row (disable live channels to keep it VOD-only, or disable movies/series to keep it live-only).
- The new Favourite Channels row (with On Now mode by default) gives quick access to favorited live channels directly from Home, exactly as requested.
- Continue Watching Movies and Continue Watching Series remain as separate dedicated rows.
- All rows can be reordered to the user's preferred layout, e.g. Favourite Channels → Continue Watching Movies → Continue Watching Series → Keep Watching (or any order).
- Recent Channels is hidden by default to avoid clutter from channel surfing.

Addresses **#49** — the hero row no longer shows oversized channel logos on initial focus:
- Cards now stay compact (small logo with blurred backdrop) until a 3-second dwell triggers expansion. Which lets user to see all the recent items in the row.
- So currently selected card is properly visible with focus border
- The expanded card uses a blurred artwork backdrop instead of stretching the channel logo.
- Video preview only starts after expansion completes, so the transition is smooth.
- Quick navigation never expands cards at all, so low-res logos are never scaled up during browsing.

## How was it tested?

- **Device(s) tested on:** TCL C6K Google TV
- **What you exercised:**
  - Full Home settings page: reordered all 5 rows, hid/showed each one, verified order persists across app restarts
  - Hero row: verified 3s dwell-to-expand timing, quick D-pad sweep doesn't expand, expansion left-aligns, video preview starts only after expansion, preview stops when leaving Home
  - Hero filters: disabled live channels in hero → verified only movies/series appear; disabled all three → hero row empty; re-enabled → items return
  - Recent Channels row in Cards mode: shows recently watched channels with logo + name tiles
  - Favourite Channels row in On Now mode: shows programme guide with progress bars, correct 12h time format, D-pad scroll through timeline
  - Toggled modes (Cards ↔ On Now) for both live rows, verified correct rendering
  - All-rows-hidden state: hid every row → "All rows hidden" message appears → showed one row → Home renders correctly
  - Startup picker and Android TV home toggle work from the new Home settings page
  - Backup/restore: exported with Home config, restored on fresh install → row order and settings preserved
  - Returning from player → hero row anchored on the previously active item, not reset to first
  - D-pad navigation between Home rows (hero → live rows → continue watching rows), focus handoff works

## Checklist
- [x] Builds locally (`./gradlew assembleDebug`) and CI is green
- [x] **Tested on a real Android TV — D-pad/remote navigation works
- [x] No user data is wiped (Room migrations stay additive)
- [x] Keeps OwnTV player-only (no bundled channels/content)
- [x] Commit messages are clear (they become the release notes)