### PR TITLE
Polish Home On Now and artwork

### DIFF
--- a/app/schemas/tv.own.owntv.core.database.OwnTVDatabase/13.json
+++ b/app/schemas/tv.own.owntv.core.database.OwnTVDatabase/13.json
@@ -1,0 +1,2188 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 13,
+    "identityHash": "dde0682ffeb2bcd5437fa88316e28c52",
+    "entities": [
+      {
+        "tableName": "profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `avatarColor` INTEGER NOT NULL, `avatarId` INTEGER NOT NULL, `isKids` INTEGER NOT NULL, `pinHash` TEXT, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarColor",
+            "columnName": "avatarColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarId",
+            "columnName": "avatarId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isKids",
+            "columnName": "isKids",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinHash",
+            "columnName": "pinHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `url` TEXT NOT NULL, `username` TEXT, `password` TEXT, `userAgent` TEXT, `epgUrl` TEXT, `createdAt` INTEGER NOT NULL, `lastSyncAt` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userAgent",
+            "columnName": "userAgent",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "epgUrl",
+            "columnName": "epgUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncAt",
+            "columnName": "lastSyncAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sources_type",
+            "unique": false,
+            "columnNames": [
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sources_type` ON `${TABLE_NAME}` (`type`)"
+          }
+        ]
+      },
+      {
+        "tableName": "profile_source",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`profileId` INTEGER NOT NULL, `sourceId` INTEGER NOT NULL, PRIMARY KEY(`profileId`, `sourceId`), FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "profileId",
+            "sourceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_profile_source_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_profile_source_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `name` TEXT NOT NULL, `remoteId` TEXT, `sortOrder` INTEGER NOT NULL, FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_categories_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_categories_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_categories_sourceId_mediaType",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "mediaType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_categories_sourceId_mediaType` ON `${TABLE_NAME}` (`sourceId`, `mediaType`)"
+          },
+          {
+            "name": "index_categories_sourceId_mediaType_remoteId",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "mediaType",
+              "remoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_categories_sourceId_mediaType_remoteId` ON `${TABLE_NAME}` (`sourceId`, `mediaType`, `remoteId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "channels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `categoryId` INTEGER, `name` TEXT NOT NULL, `logoUrl` TEXT, `streamUrl` TEXT NOT NULL, `epgChannelId` TEXT, `number` INTEGER, `remoteId` TEXT, `sortOrder` INTEGER NOT NULL, `catchup` INTEGER NOT NULL, `catchupDays` INTEGER NOT NULL, `catchupSource` TEXT, `contentHash` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`categoryId`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoUrl",
+            "columnName": "logoUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epgChannelId",
+            "columnName": "epgChannelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catchup",
+            "columnName": "catchup",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catchupDays",
+            "columnName": "catchupDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catchupSource",
+            "columnName": "catchupSource",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_channels_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_channels_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          },
+          {
+            "name": "index_channels_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_channels_epgChannelId",
+            "unique": false,
+            "columnNames": [
+              "epgChannelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_epgChannelId` ON `${TABLE_NAME}` (`epgChannelId`)"
+          },
+          {
+            "name": "index_channels_sourceId_remoteId",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "remoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_channels_sourceId_remoteId` ON `${TABLE_NAME}` (`sourceId`, `remoteId`)"
+          },
+          {
+            "name": "index_channels_sourceId_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_sourceId_name` ON `${TABLE_NAME}` (`sourceId`, `name`)"
+          },
+          {
+            "name": "index_channels_categoryId_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_categoryId_name` ON `${TABLE_NAME}` (`categoryId`, `name`)"
+          },
+          {
+            "name": "index_channels_sourceId_sortOrder_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "sortOrder",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_sourceId_sortOrder_name` ON `${TABLE_NAME}` (`sourceId`, `sortOrder`, `name`)"
+          },
+          {
+            "name": "index_channels_categoryId_sortOrder_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "sortOrder",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_categoryId_sortOrder_name` ON `${TABLE_NAME}` (`categoryId`, `sortOrder`, `name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "categories",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "categoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "movies",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `categoryId` INTEGER, `name` TEXT NOT NULL, `posterUrl` TEXT, `backdropUrl` TEXT, `year` INTEGER, `rating` REAL, `durationSecs` INTEGER, `plot` TEXT, `streamUrl` TEXT NOT NULL, `containerExt` TEXT, `remoteId` TEXT, `addedAt` INTEGER, `sortOrder` INTEGER NOT NULL, `contentHash` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`categoryId`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "posterUrl",
+            "columnName": "posterUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "backdropUrl",
+            "columnName": "backdropUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "durationSecs",
+            "columnName": "durationSecs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "plot",
+            "columnName": "plot",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "containerExt",
+            "columnName": "containerExt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_movies_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_movies_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          },
+          {
+            "name": "index_movies_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_movies_sourceId_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_sourceId_name` ON `${TABLE_NAME}` (`sourceId`, `name`)"
+          },
+          {
+            "name": "index_movies_categoryId_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_categoryId_name` ON `${TABLE_NAME}` (`categoryId`, `name`)"
+          },
+          {
+            "name": "index_movies_sourceId_sortOrder_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "sortOrder",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_sourceId_sortOrder_name` ON `${TABLE_NAME}` (`sourceId`, `sortOrder`, `name`)"
+          },
+          {
+            "name": "index_movies_categoryId_sortOrder_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "sortOrder",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_categoryId_sortOrder_name` ON `${TABLE_NAME}` (`categoryId`, `sortOrder`, `name`)"
+          },
+          {
+            "name": "index_movies_sourceId_remoteId",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "remoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_movies_sourceId_remoteId` ON `${TABLE_NAME}` (`sourceId`, `remoteId`)"
+          },
+          {
+            "name": "index_movies_sourceId_rating_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "rating",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_sourceId_rating_name` ON `${TABLE_NAME}` (`sourceId`, `rating`, `name`)"
+          },
+          {
+            "name": "index_movies_categoryId_rating_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "rating",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_categoryId_rating_name` ON `${TABLE_NAME}` (`categoryId`, `rating`, `name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "categories",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "categoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `categoryId` INTEGER, `name` TEXT NOT NULL, `posterUrl` TEXT, `backdropUrl` TEXT, `year` INTEGER, `rating` REAL, `plot` TEXT, `remoteId` TEXT, `sortOrder` INTEGER NOT NULL, `contentHash` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`categoryId`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "posterUrl",
+            "columnName": "posterUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "backdropUrl",
+            "columnName": "backdropUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "plot",
+            "columnName": "plot",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_series_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_series_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          },
+          {
+            "name": "index_series_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_series_sourceId_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_sourceId_name` ON `${TABLE_NAME}` (`sourceId`, `name`)"
+          },
+          {
+            "name": "index_series_categoryId_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_categoryId_name` ON `${TABLE_NAME}` (`categoryId`, `name`)"
+          },
+          {
+            "name": "index_series_sourceId_sortOrder_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "sortOrder",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_sourceId_sortOrder_name` ON `${TABLE_NAME}` (`sourceId`, `sortOrder`, `name`)"
+          },
+          {
+            "name": "index_series_categoryId_sortOrder_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "sortOrder",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_categoryId_sortOrder_name` ON `${TABLE_NAME}` (`categoryId`, `sortOrder`, `name`)"
+          },
+          {
+            "name": "index_series_sourceId_remoteId",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "remoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_series_sourceId_remoteId` ON `${TABLE_NAME}` (`sourceId`, `remoteId`)"
+          },
+          {
+            "name": "index_series_sourceId_rating_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "rating",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_sourceId_rating_name` ON `${TABLE_NAME}` (`sourceId`, `rating`, `name`)"
+          },
+          {
+            "name": "index_series_categoryId_rating_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "rating",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_categoryId_rating_name` ON `${TABLE_NAME}` (`categoryId`, `rating`, `name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "categories",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "categoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "seasons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `seriesId` INTEGER NOT NULL, `seasonNumber` INTEGER NOT NULL, `name` TEXT, `remoteId` TEXT, FOREIGN KEY(`seriesId`) REFERENCES `series`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seasonNumber",
+            "columnName": "seasonNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_seasons_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_seasons_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "series",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "seriesId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `seriesId` INTEGER NOT NULL, `seasonId` INTEGER, `seasonNumber` INTEGER NOT NULL, `episodeNumber` INTEGER NOT NULL, `name` TEXT NOT NULL, `plot` TEXT, `streamUrl` TEXT NOT NULL, `durationSecs` INTEGER, `containerExt` TEXT, `remoteId` TEXT, FOREIGN KEY(`seriesId`) REFERENCES `series`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`seasonId`) REFERENCES `seasons`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seasonId",
+            "columnName": "seasonId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seasonNumber",
+            "columnName": "seasonNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeNumber",
+            "columnName": "episodeNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "plot",
+            "columnName": "plot",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationSecs",
+            "columnName": "durationSecs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "containerExt",
+            "columnName": "containerExt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodes_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_episodes_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          },
+          {
+            "name": "index_episodes_seasonId",
+            "unique": false,
+            "columnNames": [
+              "seasonId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_episodes_seasonId` ON `${TABLE_NAME}` (`seasonId`)"
+          },
+          {
+            "name": "index_episodes_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_episodes_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_episodes_seriesId_remoteId",
+            "unique": true,
+            "columnNames": [
+              "seriesId",
+              "remoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodes_seriesId_remoteId` ON `${TABLE_NAME}` (`seriesId`, `remoteId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "series",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "seriesId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "seasons",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "seasonId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "favorites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileId` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `itemId` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorites_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorites_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_favorites_profileId_mediaType_itemId",
+            "unique": true,
+            "columnNames": [
+              "profileId",
+              "mediaType",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_favorites_profileId_mediaType_itemId` ON `${TABLE_NAME}` (`profileId`, `mediaType`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "watch_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileId` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `itemId` INTEGER NOT NULL, `watchedAt` INTEGER NOT NULL, FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watchedAt",
+            "columnName": "watchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_watch_history_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_watch_history_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_watch_history_profileId_watchedAt",
+            "unique": false,
+            "columnNames": [
+              "profileId",
+              "watchedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_watch_history_profileId_watchedAt` ON `${TABLE_NAME}` (`profileId`, `watchedAt`)"
+          },
+          {
+            "name": "index_watch_history_profileId_mediaType_itemId",
+            "unique": true,
+            "columnNames": [
+              "profileId",
+              "mediaType",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_watch_history_profileId_mediaType_itemId` ON `${TABLE_NAME}` (`profileId`, `mediaType`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileId` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `itemId` INTEGER NOT NULL, `positionMs` INTEGER NOT NULL, `durationMs` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "positionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_progress_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_progress_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_playback_progress_profileId_mediaType_itemId",
+            "unique": true,
+            "columnNames": [
+              "profileId",
+              "mediaType",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_playback_progress_profileId_mediaType_itemId` ON `${TABLE_NAME}` (`profileId`, `mediaType`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "content_order",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileId` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `contextKey` TEXT NOT NULL, `itemId` INTEGER NOT NULL, `position` INTEGER NOT NULL, FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextKey",
+            "columnName": "contextKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_content_order_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_content_order_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_content_order_profileId_mediaType_contextKey",
+            "unique": false,
+            "columnNames": [
+              "profileId",
+              "mediaType",
+              "contextKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_content_order_profileId_mediaType_contextKey` ON `${TABLE_NAME}` (`profileId`, `mediaType`, `contextKey`)"
+          },
+          {
+            "name": "index_content_order_profileId_mediaType_contextKey_itemId",
+            "unique": true,
+            "columnNames": [
+              "profileId",
+              "mediaType",
+              "contextKey",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_content_order_profileId_mediaType_contextKey_itemId` ON `${TABLE_NAME}` (`profileId`, `mediaType`, `contextKey`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileId` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `itemId` INTEGER NOT NULL, `title` TEXT NOT NULL, `posterUrl` TEXT, `streamUrl` TEXT NOT NULL, `filePath` TEXT, `status` TEXT NOT NULL, `downloadedBytes` INTEGER NOT NULL, `totalBytes` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "posterUrl",
+            "columnName": "posterUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedBytes",
+            "columnName": "downloadedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalBytes",
+            "columnName": "totalBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_downloads_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_downloads_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_downloads_profileId_mediaType_itemId",
+            "unique": true,
+            "columnNames": [
+              "profileId",
+              "mediaType",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_downloads_profileId_mediaType_itemId` ON `${TABLE_NAME}` (`profileId`, `mediaType`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "tv_provider_programs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileId` INTEGER NOT NULL, `surface` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `groupId` INTEGER NOT NULL, `targetItemId` INTEGER NOT NULL, `providerProgramId` INTEGER, `lastPositionMs` INTEGER NOT NULL, `durationMs` INTEGER NOT NULL, `lastEngagementAt` INTEGER NOT NULL, `lastPublishedAt` INTEGER NOT NULL, FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surface",
+            "columnName": "surface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetItemId",
+            "columnName": "targetItemId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerProgramId",
+            "columnName": "providerProgramId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastPositionMs",
+            "columnName": "lastPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastEngagementAt",
+            "columnName": "lastEngagementAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPublishedAt",
+            "columnName": "lastPublishedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tv_provider_programs_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tv_provider_programs_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_tv_provider_programs_profileId_surface_mediaType_groupId",
+            "unique": true,
+            "columnNames": [
+              "profileId",
+              "surface",
+              "mediaType",
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tv_provider_programs_profileId_surface_mediaType_groupId` ON `${TABLE_NAME}` (`profileId`, `surface`, `mediaType`, `groupId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "epg_channels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `epgChannelId` TEXT NOT NULL, `displayName` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epgChannelId",
+            "columnName": "epgChannelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_epg_channels_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_epg_channels_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_epg_channels_sourceId_epgChannelId",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "epgChannelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_epg_channels_sourceId_epgChannelId` ON `${TABLE_NAME}` (`sourceId`, `epgChannelId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "epg_programmes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `epgChannelId` TEXT NOT NULL, `startMs` INTEGER NOT NULL, `stopMs` INTEGER NOT NULL, `title` TEXT NOT NULL, `description` TEXT, `contentHash` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epgChannelId",
+            "columnName": "epgChannelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startMs",
+            "columnName": "startMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopMs",
+            "columnName": "stopMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_epg_programmes_epgChannelId_startMs",
+            "unique": false,
+            "columnNames": [
+              "epgChannelId",
+              "startMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_epg_programmes_epgChannelId_startMs` ON `${TABLE_NAME}` (`epgChannelId`, `startMs`)"
+          },
+          {
+            "name": "index_epg_programmes_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_epg_programmes_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_epg_programmes_stopMs",
+            "unique": false,
+            "columnNames": [
+              "stopMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_epg_programmes_stopMs` ON `${TABLE_NAME}` (`stopMs`)"
+          },
+          {
+            "name": "index_epg_programmes_sourceId_epgChannelId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "epgChannelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_epg_programmes_sourceId_epgChannelId` ON `${TABLE_NAME}` (`sourceId`, `epgChannelId`)"
+          },
+          {
+            "name": "index_epg_programmes_natural_key",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "epgChannelId",
+              "startMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_epg_programmes_natural_key` ON `${TABLE_NAME}` (`sourceId`, `epgChannelId`, `startMs`)"
+          }
+        ]
+      },
+      {
+        "tableName": "metadata_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `tmdbId` INTEGER NOT NULL, `imdbId` TEXT, `type` TEXT NOT NULL, `title` TEXT NOT NULL, `year` INTEGER, `overview` TEXT, `posterPath` TEXT, `backdropPath` TEXT, `rating` REAL, `genresJson` TEXT, `castJson` TEXT, `trailerKey` TEXT, `logoPath` TEXT, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tmdbId",
+            "columnName": "tmdbId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imdbId",
+            "columnName": "imdbId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "overview",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "posterPath",
+            "columnName": "posterPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "backdropPath",
+            "columnName": "backdropPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "genresJson",
+            "columnName": "genresJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "castJson",
+            "columnName": "castJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trailerKey",
+            "columnName": "trailerKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "logoPath",
+            "columnName": "logoPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_metadata_cache_tmdbId",
+            "unique": false,
+            "columnNames": [
+              "tmdbId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_metadata_cache_tmdbId` ON `${TABLE_NAME}` (`tmdbId`)"
+          },
+          {
+            "name": "index_metadata_cache_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_metadata_cache_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "metadata_match",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localKey` TEXT NOT NULL, `type` TEXT NOT NULL, `tmdbId` INTEGER, `confidence` REAL NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`localKey`))",
+        "fields": [
+          {
+            "fieldPath": "localKey",
+            "columnName": "localKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tmdbId",
+            "columnName": "tmdbId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "localKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_metadata_match_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_metadata_match_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "channels_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`name` TEXT NOT NULL, content=`channels`)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "channels",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_channels_fts_BEFORE_UPDATE BEFORE UPDATE ON `channels` BEGIN DELETE FROM `channels_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_channels_fts_BEFORE_DELETE BEFORE DELETE ON `channels` BEGIN DELETE FROM `channels_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_channels_fts_AFTER_UPDATE AFTER UPDATE ON `channels` BEGIN INSERT INTO `channels_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_channels_fts_AFTER_INSERT AFTER INSERT ON `channels` BEGIN INSERT INTO `channels_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END"
+        ]
+      },
+      {
+        "tableName": "movies_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`name` TEXT NOT NULL, content=`movies`)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "movies",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_movies_fts_BEFORE_UPDATE BEFORE UPDATE ON `movies` BEGIN DELETE FROM `movies_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_movies_fts_BEFORE_DELETE BEFORE DELETE ON `movies` BEGIN DELETE FROM `movies_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_movies_fts_AFTER_UPDATE AFTER UPDATE ON `movies` BEGIN INSERT INTO `movies_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_movies_fts_AFTER_INSERT AFTER INSERT ON `movies` BEGIN INSERT INTO `movies_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END"
+        ]
+      },
+      {
+        "tableName": "series_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`name` TEXT NOT NULL, content=`series`)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "series",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_series_fts_BEFORE_UPDATE BEFORE UPDATE ON `series` BEGIN DELETE FROM `series_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_series_fts_BEFORE_DELETE BEFORE DELETE ON `series` BEGIN DELETE FROM `series_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_series_fts_AFTER_UPDATE AFTER UPDATE ON `series` BEGIN INSERT INTO `series_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_series_fts_AFTER_INSERT AFTER INSERT ON `series` BEGIN INSERT INTO `series_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END"
+        ]
+      },
+      {
+        "tableName": "episodes_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`name` TEXT NOT NULL, content=`episodes`)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "episodes",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_episodes_fts_BEFORE_UPDATE BEFORE UPDATE ON `episodes` BEGIN DELETE FROM `episodes_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_episodes_fts_BEFORE_DELETE BEFORE DELETE ON `episodes` BEGIN DELETE FROM `episodes_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_episodes_fts_AFTER_UPDATE AFTER UPDATE ON `episodes` BEGIN INSERT INTO `episodes_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_episodes_fts_AFTER_INSERT AFTER INSERT ON `episodes` BEGIN INSERT INTO `episodes_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END"
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'dde0682ffeb2bcd5437fa88316e28c52')"
+    ]
+  }
+}

--- a/app/src/main/java/tv/own/owntv/core/database/OwnTVDatabase.kt
+++ b/app/src/main/java/tv/own/owntv/core/database/OwnTVDatabase.kt
@@ -74,7 +74,7 @@ import tv.own.owntv.core.database.entity.TvProviderProgramEntity
         SeriesFtsEntity::class,
         EpisodeFtsEntity::class,
     ],
-    version = 12, // v7: content_order (Move). v8: contentHash + browse/unique indexes. v9: EPG contentHash + natural key. v10: TMDB metadata cache. v11: movies/series rating-sort indexes. v12: metadata_cache trailerKey
+    version = 13, // v7: content_order (Move). v8: contentHash + browse/unique indexes. v9: EPG contentHash + natural key. v10: TMDB metadata cache. v11: movies/series rating-sort indexes. v12: metadata_cache trailerKey. v13: metadata_cache logoPath
 
     exportSchema = true,
 )
@@ -333,6 +333,16 @@ abstract class OwnTVDatabase : RoomDatabase() {
         val MIGRATION_11_12 = object : androidx.room.migration.Migration(11, 12) {
             override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE `metadata_cache` ADD COLUMN `trailerKey` TEXT")
+            }
+        }
+
+        /**
+         * v12 → v13: nullable `logoPath` on the metadata_cache table (Home hero title-logo treatment).
+         * Additive column on a pure cache table; existing rows simply use text-title fallback until refreshed.
+         */
+        val MIGRATION_12_13 = object : androidx.room.migration.Migration(12, 13) {
+            override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `metadata_cache` ADD COLUMN `logoPath` TEXT")
             }
         }
 

--- a/app/src/main/java/tv/own/owntv/core/database/dao/ChannelDao.kt
+++ b/app/src/main/java/tv/own/owntv/core/database/dao/ChannelDao.kt
@@ -234,9 +234,9 @@ interface ChannelDao {
     @Query(
         "SELECT c.* FROM channels c " +
             "INNER JOIN favorites f ON f.itemId = c.id AND f.mediaType = 'LIVE' " +
-            "WHERE f.profileId = :profileId ORDER BY LOWER(c.name) ASC, c.id ASC LIMIT :limit",
+            "WHERE f.profileId = :profileId ORDER BY LOWER(c.name) ASC, c.id ASC",
     )
-    fun favoritesListAlpha(profileId: Long, limit: Int): Flow<List<ChannelEntity>>
+    fun favoritesListAlpha(profileId: Long): Flow<List<ChannelEntity>>
 
     // Counts via the same join the list uses, so the badge can't show favorites whose channel id went
     // stale on a re-sync (the old "(2) but the folder is empty" bug) before the relink purges them.

--- a/app/src/main/java/tv/own/owntv/core/database/dao/EpgDao.kt
+++ b/app/src/main/java/tv/own/owntv/core/database/dao/EpgDao.kt
@@ -100,6 +100,14 @@ interface EpgDao {
     )
     suspend fun programmeSummariesForChannel(sourceIds: List<Long>, epgKey: String, from: Long, to: Long): List<EpgProgrammeEntity>
 
+    /** Lightweight rows for several Home On Now channels at once. */
+    @Query(
+        "SELECT id, sourceId, epgChannelId, startMs, stopMs, title, NULL AS description, 0 AS contentHash " +
+            "FROM epg_programmes WHERE epgChannelId IN (:epgKeys) AND sourceId IN (:sourceIds) " +
+            "AND stopMs > :from AND startMs < :to ORDER BY epgChannelId ASC, startMs ASC",
+    )
+    suspend fun programmeSummariesForChannels(sourceIds: List<Long>, epgKeys: List<String>, from: Long, to: Long): List<EpgProgrammeEntity>
+
     /** How many programmes are stored for these sources (to tell "no guide yet" from "empty window"). */
     @Query("SELECT COUNT(*) FROM epg_programmes WHERE sourceId IN (:sourceIds)")
     suspend fun countForSources(sourceIds: List<Long>): Int

--- a/app/src/main/java/tv/own/owntv/core/database/entity/MetadataEntities.kt
+++ b/app/src/main/java/tv/own/owntv/core/database/entity/MetadataEntities.kt
@@ -32,6 +32,7 @@ data class MetadataCacheEntity(
     val genresJson: String?,  // JSON array of genre names
     val castJson: String?,    // JSON array of top cast names
     val trailerKey: String?,  // YouTube video key for the in-app trailer player (plan §7.3); null = no trailer
+    val logoPath: String?,    // TMDB title/logo path for cinematic Home hero treatment; null = text title fallback
     val updatedAt: Long,      // for TTL / manual refresh
 )
 

--- a/app/src/main/java/tv/own/owntv/core/metadata/MetadataImages.kt
+++ b/app/src/main/java/tv/own/owntv/core/metadata/MetadataImages.kt
@@ -14,5 +14,9 @@ object MetadataImages {
     fun backdrop(path: String?, size: String = "w780"): String? =
         path?.takeIf { it.isNotBlank() }?.let { "${TmdbProvider.IMAGE_BASE}/$size${it.ensureLeadingSlash()}" }
 
+    /** Title/logo URL (default w500). */
+    fun logo(path: String?, size: String = "w500"): String? =
+        path?.takeIf { it.isNotBlank() }?.let { "${TmdbProvider.IMAGE_BASE}/$size${it.ensureLeadingSlash()}" }
+
     private fun String.ensureLeadingSlash(): String = if (startsWith("/")) this else "/$this"
 }

--- a/app/src/main/java/tv/own/owntv/core/metadata/MetadataProvider.kt
+++ b/app/src/main/java/tv/own/owntv/core/metadata/MetadataProvider.kt
@@ -94,6 +94,8 @@ data class MovieDetails(
     val cast: List<String>,
     /** Best YouTube trailer video key from `videos` (official Trailer > Trailer > Teaser); null if none. */
     val trailerKey: String?,
+    /** Best title/logo image path from TMDB images; null when no usable logo exists. */
+    val logoPath: String?,
 )
 
 /** Per-episode TMDB details (`/tv/{id}/season/{n}/episode/{m}`). Its own still, plot, air date, rating. */

--- a/app/src/main/java/tv/own/owntv/core/metadata/MetadataRepository.kt
+++ b/app/src/main/java/tv/own/owntv/core/metadata/MetadataRepository.kt
@@ -117,13 +117,14 @@ class MetadataRepository(
                 genresJson = details.genres.takeIf { it.isNotEmpty() }?.let { JSONArray(it).toString() },
                 castJson = details.cast.takeIf { it.isNotEmpty() }?.let { JSONArray(it).toString() },
                 trailerKey = details.trailerKey,
+                logoPath = details.logoPath,
                 updatedAt = now,
             )
             fallback != null -> MetadataCacheEntity(
                 key = tvCacheKey(tmdbId), tmdbId = tmdbId, imdbId = null, type = TYPE_TV,
                 title = fallback.title, year = fallback.year, overview = fallback.overview,
                 posterPath = fallback.posterPath, backdropPath = null, rating = null,
-                genresJson = null, castJson = null, trailerKey = null, updatedAt = now,
+                genresJson = null, castJson = null, trailerKey = null, logoPath = null, updatedAt = now,
             )
             else -> return dao.getCache(tvCacheKey(tmdbId))
         }
@@ -160,6 +161,7 @@ class MetadataRepository(
             backdropPath = d.stillPath,
             rating = d.rating,
             genresJson = null, castJson = null, trailerKey = null, updatedAt = now,
+            logoPath = null,
         )
         dao.upsertCache(entity)
         return entity
@@ -277,13 +279,14 @@ class MetadataRepository(
                 genresJson = details.genres.takeIf { it.isNotEmpty() }?.let { JSONArray(it).toString() },
                 castJson = details.cast.takeIf { it.isNotEmpty() }?.let { JSONArray(it).toString() },
                 trailerKey = details.trailerKey,
+                logoPath = details.logoPath,
                 updatedAt = now,
             )
             fallback != null -> MetadataCacheEntity(
                 key = cacheKey(tmdbId), tmdbId = tmdbId, imdbId = null, type = TYPE_MOVIE,
                 title = fallback.title, year = fallback.year, overview = fallback.overview,
                 posterPath = fallback.posterPath, backdropPath = null, rating = null,
-                genresJson = null, castJson = null, trailerKey = null, updatedAt = now,
+                genresJson = null, castJson = null, trailerKey = null, logoPath = null, updatedAt = now,
             )
             else -> return dao.getCache(cacheKey(tmdbId)) // nothing to write; return existing if any
         }

--- a/app/src/main/java/tv/own/owntv/core/metadata/TmdbProvider.kt
+++ b/app/src/main/java/tv/own/owntv/core/metadata/TmdbProvider.kt
@@ -69,7 +69,8 @@ class TmdbProvider(
         val ep = resolveEndpoint()
         val url = buildString {
             append(ep.baseUrl).append("/3/movie/").append(tmdbId)
-            append("?append_to_response=credits,external_ids,videos")
+            append("?append_to_response=credits,external_ids,videos,images")
+            append("&include_image_language=en,null")
             ep.apiKey?.takeIf { it.isNotBlank() }?.let { append("&api_key=").append(enc(it)) }
         }
         val json = runCatching { http.getText(url) }
@@ -83,7 +84,8 @@ class TmdbProvider(
         val ep = resolveEndpoint()
         val url = buildString {
             append(ep.baseUrl).append("/3/tv/").append(tmdbId)
-            append("?append_to_response=credits,external_ids,videos")
+            append("?append_to_response=credits,external_ids,videos,images")
+            append("&include_image_language=en,null")
             ep.apiKey?.takeIf { it.isNotBlank() }?.let { append("&api_key=").append(enc(it)) }
         }
         val json = runCatching { http.getText(url) }
@@ -140,6 +142,7 @@ class TmdbProvider(
             genres = genres,
             cast = cast,
             trailerKey = parseTrailerKey(o),
+            logoPath = parseLogoPath(o),
         )
     }
 
@@ -168,6 +171,7 @@ class TmdbProvider(
             genres = genres,
             cast = cast,
             trailerKey = parseTrailerKey(o),
+            logoPath = parseLogoPath(o),
         )
     }
 
@@ -194,6 +198,25 @@ class TmdbProvider(
             }
         }
         return officialTrailer ?: trailer ?: teaser
+    }
+
+    private data class LogoCandidate(val path: String, val languageRank: Int, val width: Int)
+
+    private fun parseLogoPath(details: JSONObject): String? {
+        val arr = details.optJSONObject("images")?.optJSONArray("logos") ?: return null
+        val candidates = ArrayList<LogoCandidate>(arr.length())
+        for (i in 0 until arr.length()) {
+            val logo = arr.optJSONObject(i) ?: continue
+            val path = logo.optString("file_path").takeIf { it.isNotBlank() && it != "null" } ?: continue
+            if (path.endsWith(".svg", ignoreCase = true)) continue
+            val languageRank = when (logo.optString("iso_639_1").takeIf { it.isNotBlank() && it != "null" }) {
+                "en" -> 0
+                null -> 1
+                else -> 2
+            }
+            candidates += LogoCandidate(path = path, languageRank = languageRank, width = logo.optInt("width", 0))
+        }
+        return candidates.minWithOrNull(compareBy<LogoCandidate> { it.languageRank }.thenByDescending { it.width })?.path
     }
 
     private fun parseResults(type: MetadataType, body: String): List<MetadataSearchResult> {

--- a/app/src/main/java/tv/own/owntv/di/AppModule.kt
+++ b/app/src/main/java/tv/own/owntv/di/AppModule.kt
@@ -28,7 +28,7 @@ val appModule = module {
     // Merged (v4.0.0 + PR#31 Home/launcher). Koin resolves each get() by type, so only the count must match
     // each ViewModel's merged constructor.
     viewModel { ShellViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
-    viewModel { HomeViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { HomeViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { SetupViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { LiveViewModel(androidContext(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { MovieViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }

--- a/app/src/main/java/tv/own/owntv/di/DatabaseModule.kt
+++ b/app/src/main/java/tv/own/owntv/di/DatabaseModule.kt
@@ -28,6 +28,7 @@ val databaseModule = module {
                 OwnTVDatabase.MIGRATION_9_10,
                 OwnTVDatabase.MIGRATION_10_11,
                 OwnTVDatabase.MIGRATION_11_12,
+                OwnTVDatabase.MIGRATION_12_13,
             )
             .fallbackToDestructiveMigration(dropAllTables = true) // safety net for unforeseen jumps
             .build()

--- a/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeScreen.kt
@@ -271,6 +271,7 @@ fun HomeScreen(
                             heroPreviewEngine = heroPreviewEngine,
                             engineState = engineState,
                             heroFocusRequester = heroFocus,
+                            heroMetadata = state.heroMetadata,
                             onHeroFocusChanged = { index, hasFocus ->
                                 if (hasFocus) {
                                     if (expandedHeroIndex != index) {
@@ -345,8 +346,14 @@ fun HomeScreen(
                     ContinueWatchingRow(
                         title = row.title,
                         items = state.continueSeries,
+                        posterOverrides = state.continuationArtwork,
+                        landscapeTiles = true,
                         onItemClick = { onPlayEpisode(0L, it.targetItemId, it.positionMs) },
                         onFocus = onNonHeroFocused,
+                        onItemFocus = {
+                            onNonHeroFocused()
+                            vm.resolveSeriesContinuationArtwork(it)
+                        },
                         firstItemFocusRequester = firstItemFocusRequester,
                     )
                 }
@@ -402,6 +409,24 @@ private fun HeroItem.heroKey(): String = when (this) {
     is HeroItem.LiveHero -> "live:${channel.id}"
 }
 
+private fun expandedHeroImageUrl(item: HeroItem, metadata: HomeHeroMetadata?): String? = when (item) {
+    is HeroItem.MovieHero ->
+        metadata?.backdropUrl
+            ?: item.movie.backdropUrl?.takeIf { it.isNotBlank() }
+            ?: item.movie.posterUrl?.takeIf { it.isNotBlank() }
+    is HeroItem.SeriesHero ->
+        metadata?.backdropUrl
+            ?: item.series.backdropUrl?.takeIf { it.isNotBlank() }
+            ?: item.series.posterUrl?.takeIf { it.isNotBlank() }
+    is HeroItem.LiveHero -> item.channel.logoUrl?.takeIf { it.isNotBlank() }
+}
+
+private fun expandedHeroPlot(item: HeroItem, metadata: HomeHeroMetadata?): String? = when (item) {
+    is HeroItem.MovieHero -> metadata?.plot ?: item.movie.plot?.takeIf { it.isNotBlank() }
+    is HeroItem.SeriesHero -> metadata?.plot ?: item.episode.plot?.takeIf { it.isNotBlank() } ?: item.series.plot?.takeIf { it.isNotBlank() }
+    is HeroItem.LiveHero -> null
+}
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun HeroRowSection(
@@ -411,6 +436,7 @@ private fun HeroRowSection(
     heroPreviewEngine: HeroPreviewEngine,
     engineState: HeroPreviewEngine.State,
     heroFocusRequester: FocusRequester,
+    heroMetadata: Map<String, HomeHeroMetadata>,
     onHeroFocusChanged: (index: Int, hasFocus: Boolean) -> Unit,
     onPlay: (HeroItem) -> Unit,
     modifier: Modifier = Modifier,
@@ -523,6 +549,8 @@ private fun HeroRowSection(
                         is HeroItem.SeriesHero -> item.series.posterUrl
                         is HeroItem.LiveHero -> item.channel.logoUrl
                     }
+                    val itemMetadata = heroMetadata[item.heroKey()]
+                    val expandedImageUrl = expandedHeroImageUrl(item, itemMetadata)
 
                     val heroGlowColor = colors.focusGlow
                     Box(
@@ -597,17 +625,18 @@ private fun HeroRowSection(
                                 // as previewRectInRowPx is known and renders the blur itself — doubling the
                                 // blur underneath just costs frames on TV hardware.
                                 Box(Modifier.fillMaxSize().background(Color.Black)) {
-                                    if (!imageUrl.isNullOrBlank()) {
+                                    val cardImageUrl = expandedImageUrl ?: imageUrl
+                                    if (!cardImageUrl.isNullOrBlank()) {
                                         if (item is HeroItem.LiveHero) {
                                             AsyncImage(
-                                                model = imageUrl,
+                                                model = cardImageUrl,
                                                 contentDescription = null,
                                                 modifier = Modifier.fillMaxSize().blur(20.dp),
                                                 contentScale = ContentScale.Crop,
                                                 alpha = 0.5f,
                                             )
                                             AsyncImage(
-                                                model = imageUrl,
+                                                model = cardImageUrl,
                                                 contentDescription = null,
                                                 contentScale = ContentScale.Fit,
                                                 modifier = Modifier
@@ -616,9 +645,9 @@ private fun HeroRowSection(
                                             )
                                         } else {
                                             AsyncImage(
-                                                model = imageUrl,
+                                                model = cardImageUrl,
                                                 contentDescription = null,
-                                                contentScale = ContentScale.Fit,
+                                                contentScale = ContentScale.Crop,
                                                 modifier = Modifier.fillMaxSize(),
                                             )
                                         }
@@ -746,14 +775,11 @@ private fun HeroRowSection(
                             if (engineState != HeroPreviewEngine.State.PLAYING) {
                                 // Opaque cover: the SurfaceView below holds the previous preview's last
                                 // frame after stop(), and the parent's black background is punched out by
-                                // the SurfaceView. Everything above (loading images, translucent blur,
-                                // transparent logos, bare fallback icon) relies on this layer to hide it.
+                                // the SurfaceView. The loading images and fallback icon rely on this layer
+                                // to hide it.
                                 Box(Modifier.fillMaxSize().background(Color.Black))
-                                val artUrl = when (expandedItem) {
-                                    is HeroItem.MovieHero -> expandedItem.movie.posterUrl
-                                    is HeroItem.SeriesHero -> expandedItem.series.posterUrl
-                                    is HeroItem.LiveHero -> expandedItem.channel.logoUrl
-                                }
+                                val expandedMeta = heroMetadata[expandedItem.heroKey()]
+                                val artUrl = expandedHeroImageUrl(expandedItem, expandedMeta)
                                 if (!artUrl.isNullOrBlank()) {
                                     if (expandedItem is HeroItem.LiveHero) {
                                         AsyncImage(
@@ -773,14 +799,7 @@ private fun HeroRowSection(
                                         AsyncImage(
                                             model = artUrl,
                                             contentDescription = null,
-                                            modifier = Modifier.fillMaxSize().blur(20.dp),
                                             contentScale = ContentScale.Crop,
-                                            alpha = 0.5f,
-                                        )
-                                        AsyncImage(
-                                            model = artUrl,
-                                            contentDescription = null,
-                                            contentScale = ContentScale.Fit,
                                             modifier = Modifier.fillMaxSize(),
                                         )
                                     }
@@ -815,19 +834,30 @@ private fun HeroRowSection(
                                 .padding(start = 16.dp, end = 16.dp, bottom = 16.dp)
                                 .widthIn(max = Dimens.HeroOverlayMaxWidth),
                         ) {
+                            val expandedMeta = heroMetadata[expandedItem.heroKey()]
                             val title = when (expandedItem) {
                                 is HeroItem.MovieHero -> expandedItem.item.title
                                 is HeroItem.SeriesHero -> expandedItem.item.title
                                 is HeroItem.LiveHero -> expandedItem.channel.name
                             }
-                            Text(
-                                text = title,
-                                style = MaterialTheme.typography.titleMedium,
-                                color = colors.onSurface,
-                                maxLines = 2,
-                                overflow = TextOverflow.Ellipsis,
-                                fontWeight = FontWeight.Bold,
-                            )
+                            val logoUrl = expandedMeta?.logoUrl?.takeIf { expandedItem !is HeroItem.LiveHero }
+                            if (!logoUrl.isNullOrBlank()) {
+                                AsyncImage(
+                                    model = logoUrl,
+                                    contentDescription = title,
+                                    contentScale = ContentScale.Fit,
+                                    modifier = Modifier.width(260.dp).height(58.dp),
+                                )
+                            } else {
+                                Text(
+                                    text = title,
+                                    style = MaterialTheme.typography.titleMedium,
+                                    color = colors.onSurface,
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis,
+                                    fontWeight = FontWeight.Bold,
+                                )
+                            }
 
                             val subtitle = when (expandedItem) {
                                 is HeroItem.MovieHero ->
@@ -855,6 +885,18 @@ private fun HeroRowSection(
                                     style = MaterialTheme.typography.bodySmall,
                                     color = colors.primary,
                                     maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
+
+                            val plot = expandedHeroPlot(expandedItem, expandedMeta)
+                            if (!plot.isNullOrBlank()) {
+                                Spacer(Modifier.height(6.dp))
+                                Text(
+                                    text = plot,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = colors.onSurfaceVariant,
+                                    maxLines = 3,
                                     overflow = TextOverflow.Ellipsis,
                                 )
                             }
@@ -989,8 +1031,11 @@ private fun HeroPreviewSurface(
 private fun ContinueWatchingRow(
     title: String,
     items: List<LauncherContinuationItem>,
+    posterOverrides: Map<String, String> = emptyMap(),
+    landscapeTiles: Boolean = false,
     onItemClick: (LauncherContinuationItem) -> Unit,
     onFocus: () -> Unit,
+    onItemFocus: (LauncherContinuationItem) -> Unit = { onFocus() },
     firstItemFocusRequester: FocusRequester? = null,
     modifier: Modifier = Modifier,
 ) {
@@ -1011,22 +1056,146 @@ private fun ContinueWatchingRow(
             modifier = Modifier.focusGroup(),
         ) {
             itemsIndexed(items, key = { _, item -> item.stableKey }) { index, item ->
-                Box(Modifier.width(150.dp)) {
-                    PosterCard(
-                        posterUrl = item.posterUrl,
-                        title = item.title,
-                        progressFraction = if (item.durationMs > 0) {
-                            (item.positionMs.toFloat() / item.durationMs.toFloat()).coerceIn(0f, 1f)
-                        } else null,
-                        modifier = when {
-                            firstItemFocusRequester != null && index == 0 -> Modifier.focusRequester(firstItemFocusRequester)
-                            else -> Modifier
-                        },
-                        onFocus = onFocus,
-                        onClick = { onItemClick(item) },
-                    )
+                val itemModifier = when {
+                    firstItemFocusRequester != null && index == 0 -> Modifier.focusRequester(firstItemFocusRequester)
+                    else -> Modifier
+                }
+                val progress = continuationProgress(item)
+                if (landscapeTiles) {
+                    val overrideImageUrl = posterOverrides[item.stableKey]
+                    Box(Modifier.width(275.dp)) {
+                        LandscapeContinuationCard(
+                            imageUrl = overrideImageUrl ?: item.posterUrl,
+                            cropImage = !overrideImageUrl.isNullOrBlank(),
+                            title = item.title,
+                            chipText = seasonEpisodeChip(item),
+                            progressFraction = progress,
+                            modifier = itemModifier,
+                            onFocus = { onItemFocus(item) },
+                            onClick = { onItemClick(item) },
+                        )
+                    }
+                } else {
+                    Box(Modifier.width(150.dp)) {
+                        PosterCard(
+                            posterUrl = posterOverrides[item.stableKey] ?: item.posterUrl,
+                            title = item.title,
+                            progressFraction = progress,
+                            modifier = itemModifier,
+                            onFocus = { onItemFocus(item) },
+                            onClick = { onItemClick(item) },
+                        )
+                    }
                 }
             }
+        }
+    }
+}
+
+private fun continuationProgress(item: LauncherContinuationItem): Float? =
+    if (item.durationMs > 0) {
+        (item.positionMs.toFloat() / item.durationMs.toFloat()).coerceIn(0f, 1f)
+    } else {
+        null
+    }
+
+private fun seasonEpisodeChip(item: LauncherContinuationItem): String? {
+    val season = item.seasonNumber?.takeIf { it > 0 }
+    val episode = item.episodeNumber?.takeIf { it > 0 }
+    return when {
+        season != null && episode != null -> "S%02d E%02d".format(season, episode)
+        season != null -> "S%02d".format(season)
+        episode != null -> "E%02d".format(episode)
+        else -> null
+    }
+}
+
+@Composable
+private fun LandscapeContinuationCard(
+    imageUrl: String?,
+    cropImage: Boolean,
+    title: String,
+    chipText: String?,
+    progressFraction: Float?,
+    modifier: Modifier = Modifier,
+    onFocus: () -> Unit,
+    onClick: () -> Unit,
+) {
+    val colors = OwnTVTheme.colors
+    FocusableSurface(
+        onClick = onClick,
+        modifier = modifier.onFocusChanged { if (it.hasFocus) onFocus() },
+        shape = RoundedCornerShape(14.dp),
+        focusedScale = 1.04f,
+        glowElevation = 14,
+        focusedContainerColor = colors.surfaceContainerHigh,
+        unfocusedContainerColor = colors.surfaceContainerHigh,
+        selectedContainerColor = colors.surfaceContainerHigh,
+        contentAlignment = Alignment.Center,
+    ) { focused ->
+        Column(modifier = Modifier.fillMaxWidth().padding(6.dp)) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(16f / 9f)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(colors.surfaceContainerLowest),
+            ) {
+                if (!imageUrl.isNullOrBlank()) {
+                    AsyncImage(
+                        model = imageUrl,
+                        contentDescription = null,
+                        contentScale = if (cropImage) ContentScale.Crop else ContentScale.Fit,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                } else {
+                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        OwnTVIcon(OwnTVIcon.SERIES, tint = colors.onSurfaceVariant, modifier = Modifier.size(36.dp))
+                    }
+                }
+
+                if (!chipText.isNullOrBlank()) {
+                    Text(
+                        text = chipText,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier
+                            .align(Alignment.TopStart)
+                            .padding(8.dp)
+                            .clip(RoundedCornerShape(50))
+                            .background(Color.Black.copy(alpha = 0.62f))
+                            .padding(horizontal = 8.dp, vertical = 3.dp),
+                    )
+                }
+
+                if (progressFraction != null && progressFraction > 0f) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.BottomStart)
+                            .fillMaxWidth()
+                            .height(4.dp)
+                            .background(Color.Black.copy(alpha = 0.4f)),
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth(progressFraction.coerceIn(0f, 1f))
+                                .height(4.dp)
+                                .background(colors.primary),
+                        )
+                    }
+                }
+            }
+            Spacer(Modifier.height(6.dp))
+            Text(
+                title,
+                style = MaterialTheme.typography.labelLarge,
+                color = if (focused) colors.primary else colors.onSurface,
+                maxLines = 2,
+                minLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth(),
+            )
         }
     }
 }

--- a/app/src/main/java/tv/own/owntv/features/home/HomeViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeViewModel.kt
@@ -3,6 +3,7 @@ package tv.own.owntv.features.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -35,6 +36,8 @@ import tv.own.owntv.core.launcher.LauncherRecommendationPlanner
 import tv.own.owntv.core.launcher.LauncherWatchNextType
 import tv.own.owntv.core.model.MediaType
 import tv.own.owntv.core.epg.EpgSourceStore
+import tv.own.owntv.core.metadata.MetadataImages
+import tv.own.owntv.core.metadata.MetadataRepository
 import tv.own.owntv.core.repository.activeSourceIds
 import tv.own.owntv.features.settings.data.SettingsRepository
 import tv.own.owntv.player.HeroPreviewEngine
@@ -89,11 +92,19 @@ sealed interface HeroItem {
     }
 }
 
+data class HomeHeroMetadata(
+    val backdropUrl: String? = null,
+    val logoUrl: String? = null,
+    val plot: String? = null,
+)
+
 data class HomeUiState(
     val heroItems: List<HeroItem> = emptyList(),
     val activeHeroIndex: Int = 0,
     val continueMovies: List<LauncherContinuationItem> = emptyList(),
     val continueSeries: List<LauncherContinuationItem> = emptyList(),
+    val heroMetadata: Map<String, HomeHeroMetadata> = emptyMap(),
+    val continuationArtwork: Map<String, String> = emptyMap(),
     val recentLive: List<ChannelEntity> = emptyList(),
     val favoriteLive: List<ChannelEntity> = emptyList(),
     val config: HomeConfig = HomeConfig(),
@@ -137,6 +148,7 @@ class HomeViewModel(
     private val heroPreviewEngine: HeroPreviewEngine,
     private val epgSourceStore: EpgSourceStore,
     private val epgDao: EpgDao,
+    private val metadata: MetadataRepository,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(HomeUiState())
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
@@ -144,6 +156,8 @@ class HomeViewModel(
     private val _heroFocused = MutableStateFlow(false)
     private val _previewEnabled = MutableStateFlow(true)
     private val _lastHeroInteractionMs = MutableStateFlow(0L)
+    private val resolvingHeroKeys = mutableSetOf<String>()
+    private val resolvingContinuationArtworkKeys = mutableSetOf<String>()
 
     val lastHeroInteractionMs: StateFlow<Long> = _lastHeroInteractionMs.asStateFlow()
 
@@ -168,6 +182,25 @@ class HomeViewModel(
     fun onHeroUserNavigate(index: Int) {
         _lastHeroInteractionMs.value = System.currentTimeMillis()
         navigateHero(index)
+        resolveHeroMetadata(index)
+    }
+
+    fun resolveSeriesContinuationArtwork(item: LauncherContinuationItem) {
+        if (item.kind != LauncherContinuationKind.EPISODE) return
+        if (_uiState.value.continuationArtwork.containsKey(item.stableKey)) return
+        if (!resolvingContinuationArtworkKeys.add(item.stableKey)) return
+
+        viewModelScope.launch {
+            try {
+                delay(250)
+                val art = withContext(Dispatchers.IO) { seriesContinuationArtwork(item) } ?: return@launch
+                _uiState.value = _uiState.value.copy(
+                    continuationArtwork = _uiState.value.continuationArtwork + (item.stableKey to art),
+                )
+            } finally {
+                resolvingContinuationArtworkKeys.remove(item.stableKey)
+            }
+        }
     }
 
     fun stopPreview() {
@@ -182,6 +215,7 @@ class HomeViewModel(
     }
 
     private suspend fun loadHomeData(profileId: Long) {
+        val previous = _uiState.value
         val state = withContext(Dispatchers.IO) {
             val config = settings.homeConfig(profileId).first()
             // Active-playlist filter: when a "Default" playlist is chosen, the home rails narrow to it too
@@ -221,6 +255,8 @@ class HomeViewModel(
                 activeHeroIndex = 0,
                 continueMovies = movies,
                 continueSeries = series,
+                heroMetadata = previous.heroMetadata.filterKeys { key -> heroItems.any { homeHeroKey(it) == key } },
+                continuationArtwork = previous.continuationArtwork.filterKeys { key -> series.any { it.stableKey == key } },
                 recentLive = live,
                 favoriteLive = favLive,
                 config = config,
@@ -231,6 +267,65 @@ class HomeViewModel(
         }
         _uiState.value = state
         tv.own.owntv.Perf.stamp("home-data")
+    }
+
+    private fun resolveHeroMetadata(index: Int) {
+        val item = _uiState.value.heroItems.getOrNull(index) ?: return
+        if (item is HeroItem.LiveHero) return
+
+        val key = homeHeroKey(item)
+        if (_uiState.value.heroMetadata.containsKey(key)) return
+        if (!resolvingHeroKeys.add(key)) return
+
+        viewModelScope.launch {
+            try {
+                delay(250)
+                val current = _uiState.value.heroItems.getOrNull(_uiState.value.activeHeroIndex)
+                if (current == null || homeHeroKey(current) != key) return@launch
+
+                val resolved = withContext(Dispatchers.IO) { heroMetadata(item) } ?: return@launch
+                _uiState.value = _uiState.value.copy(
+                    heroMetadata = _uiState.value.heroMetadata + (key to resolved),
+                )
+            } finally {
+                resolvingHeroKeys.remove(key)
+            }
+        }
+    }
+
+    private suspend fun heroMetadata(item: HeroItem): HomeHeroMetadata? = when (item) {
+        is HeroItem.MovieHero -> metadata.resolveMovie(item.movie)?.let { cache ->
+            HomeHeroMetadata(
+                backdropUrl = MetadataImages.backdrop(cache.backdropPath, size = "w1280"),
+                logoUrl = MetadataImages.logo(cache.logoPath),
+                plot = cache.overview?.takeIf { it.isNotBlank() },
+            )
+        }
+        is HeroItem.SeriesHero -> {
+            val show = metadata.resolveSeries(item.series)
+            val episode = if (show?.overview.isNullOrBlank()) metadata.resolveEpisode(item.series, item.episode) else null
+            when {
+                show != null || episode != null -> HomeHeroMetadata(
+                    backdropUrl = MetadataImages.backdrop(show?.backdropPath, size = "w1280")
+                        ?: MetadataImages.backdrop(episode?.backdropPath ?: episode?.posterPath, size = "w1280"),
+                    logoUrl = MetadataImages.logo(show?.logoPath),
+                    plot = show?.overview?.takeIf { it.isNotBlank() } ?: episode?.overview?.takeIf { it.isNotBlank() },
+                )
+                else -> null
+            }
+        }
+        is HeroItem.LiveHero -> null
+    }
+
+    private suspend fun seriesContinuationArtwork(item: LauncherContinuationItem): String? {
+        val episode = seriesDao.getEpisodeById(item.targetItemId) ?: return null
+        val series = seriesDao.getSeriesById(episode.seriesId) ?: return null
+        val episodeMeta = metadata.resolveEpisode(series, episode)
+        val showMeta = if (episodeMeta == null) metadata.resolveSeries(series) else null
+        return MetadataImages.backdrop(episodeMeta?.backdropPath ?: episodeMeta?.posterPath, size = "w780")
+            ?: MetadataImages.backdrop(showMeta?.backdropPath, size = "w780")
+            ?: series.backdropUrl?.takeIf { it.isNotBlank() }
+            ?: series.posterUrl?.takeIf { it.isNotBlank() }
     }
 
     /** This profile's hide customizations across all three sections, with category keys resolved to ids. */
@@ -334,6 +429,12 @@ class HomeViewModel(
             candidate.resolve()?.let { result += it }
         }
         return result
+    }
+
+    private fun homeHeroKey(item: HeroItem): String = when (item) {
+        is HeroItem.MovieHero -> "movie:${item.movie.id}"
+        is HeroItem.SeriesHero -> "episode:${item.episode.id}"
+        is HeroItem.LiveHero -> "live:${item.channel.id}"
     }
 
     private suspend fun recentlyWatchedLive(

--- a/app/src/main/java/tv/own/owntv/features/home/HomeViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/home/HomeViewModel.kt
@@ -122,8 +122,7 @@ data class GuideSliceState(
 }
 
 private const val SLICE_WINDOW_MS = 360 * 60_000L
-private const val LIVE_ROW_CHANNEL_LIMIT = 20
-private const val LIVE_ROW_EPG_LIMIT = 10
+private const val RECENT_LIVE_ROW_LIMIT = 20
 
 class HomeViewModel(
     private val planner: LauncherRecommendationPlanner,
@@ -199,13 +198,12 @@ class HomeViewModel(
                 .filterNot { isContinuationHidden(it, hidden) }
             val movies = items.filter { it.kind == LauncherContinuationKind.MOVIE }
             val series = items.filter { it.kind == LauncherContinuationKind.EPISODE }
-            val liveWithTs = recentlyWatchedLive(profileId, activeIds, filtering, LIVE_ROW_CHANNEL_LIMIT)
+            val liveWithTs = recentlyWatchedLive(profileId, activeIds, filtering, RECENT_LIVE_ROW_LIMIT)
                 .filterNot { isChannelHidden(it.channel, hidden) }
             val live = liveWithTs.map { it.channel }
-            val favLive = channelDao.favoritesListAlpha(profileId, 50).first()
+            val favLive = channelDao.favoritesListAlpha(profileId).first()
                 .let { if (!filtering) it else it.filter { c -> c.sourceId in activeIds } }
                 .filterNot { isChannelHidden(it, hidden) }
-                .take(LIVE_ROW_CHANNEL_LIMIT)
             val heroItems = buildHeroItems(items, liveWithTs, config)
             val recentGuide = if (HomeRow.RECENT_CHANNELS in config.visibleOrder && config.recentLiveMode == HomeLiveRowMode.ON_NOW) {
                 buildLiveGuide(profileId, activeIds, live)
@@ -358,24 +356,28 @@ class HomeViewModel(
         val now = System.currentTimeMillis()
         val windowStart = floorToHalfHour(now)
         val windowEnd = windowStart + SLICE_WINDOW_MS
-        val channels = candidates.take(LIVE_ROW_CHANNEL_LIMIT)
+        val channels = candidates
         if (channels.isEmpty()) return@withContext GuideSliceState(now = now, windowStart = windowStart, windowEnd = windowEnd)
 
         val epgIds = epgSourceStore.getAll().map { it.id }
         val sourceIds = (activeIds.toList() + epgIds).distinct()
         val customizations = customize.observe(profileId, tv.own.owntv.core.model.MediaType.LIVE).first()
         val programmes = linkedMapOf<Long, List<EpgProgrammeEntity>>()
+        val channelKeys = channels.mapNotNull { channel ->
+            val key = customizations.epgMatches[CustomizeKeys.channel(channel)] ?: channel.epgChannelId
+            key?.trim()?.lowercase()
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { channel.id to it }
+        }
+        val rowsByKey = channelKeys
+            .map { it.second }
+            .distinct()
+            .chunked(400)
+            .flatMap { epgKeys -> epgDao.programmeSummariesForChannels(sourceIds, epgKeys, windowStart, windowEnd) }
+            .groupBy { it.epgChannelId }
 
-        for (channel in channels.take(LIVE_ROW_EPG_LIMIT)) {
-            val key = customizations.epgMatches[CustomizeKeys.channel(channel)]
-                ?: channel.epgChannelId
-            val epgKey = key?.trim()?.lowercase().orEmpty()
-            if (epgKey.isBlank()) continue
-
-            val rows = epgDao.programmeSummariesForChannel(sourceIds, epgKey, windowStart, windowEnd)
-            if (rows.isNotEmpty()) {
-                programmes[channel.id] = rows
-            }
+        for ((channelId, epgKey) in channelKeys) {
+            rowsByKey[epgKey]?.takeIf { it.isNotEmpty() }?.let { programmes[channelId] = it }
         }
 
         GuideSliceState(

--- a/app/src/main/java/tv/own/owntv/features/shell/OwnTVShell.kt
+++ b/app/src/main/java/tv/own/owntv/features/shell/OwnTVShell.kt
@@ -261,7 +261,7 @@ fun OwnTVShell(
         if (selectedSection != MainSection.HOME || playerMode != PlayerMode.NONE) homeVm.stopPreview()
     }
 
-    LaunchedEffect(selectedSection, playerMode, activeProfileId) {
+    LaunchedEffect(selectedSection, playerMode, activeProfileId, activePlaylistId) {
         if (selectedSection == MainSection.HOME && playerMode == PlayerMode.NONE && (activeProfileId?.let { it >= 0 } == true)) {
             homeVm.refresh()
         }


### PR DESCRIPTION
<!-- Thanks for contributing to OwnTV! Please fill this in so it's easy to review. -->

## Before you open this PR (required)
<!-- These are mandatory — PRs that duplicate an existing in-app feature are closed. -->
- [x] I read the **[User Guide](https://github.com/ahXN00/OwnTV/blob/main/extras/USER_GUIDE.md)** and checked the app's **Settings** and existing **functions** — this change isn't already possible in the app.
- [x] I searched existing issues/PRs and this isn't a duplicate.

## What does this PR do?
<!-- A clear summary of the change and how it works. -->

This PR tightens three Home-screen follow-ups around the customizable Home experience:

- Fixes Home Favourite Channels when the row is set to **On Now** so the inline mini-guide can cover every visible favourite channel instead of silently limiting guide lookups to the first small subset.
- Improves Home hero and Continue Watching artwork by reusing TMDB metadata that OwnTV already resolves for movies, series, and episodes.
- Refreshes Home immediately after switching the active playlist from the top-bar quick switcher while already sitting on Home.

Implementation details:

- Home's On Now guide builder now batches programme-summary reads for the whole candidate channel list instead of querying only a capped prefix.
- Favourite live rows are filtered by the active playlist and hidden-item state before guide data is built, so the Home row keeps matching the same profile/source visibility rules as the rest of Home.
- The Home hero can use TMDB backdrops, logos, and plot text when metadata is available, while preserving provider artwork/text fallbacks.
- Continue Watching series tiles can resolve episode/show artwork lazily on focus and render as landscape cards, which avoids stretched portrait art for episode continuation rows.
- Metadata cache gains an additive nullable `logoPath` column through Room migration `12 -> 13`; existing cached rows keep working and simply fall back until refreshed.
- The shell-level Home refresh effect now keys on `activePlaylistId`, so the top-bar playlist picker updates Home rows after the selected playlist StateFlow changes. `HomeScreen` stays presentation-only.

## Which issue / improvement does it address?
<!-- Link the issue it fixes ("Closes #12"), or describe the upgrade it makes and why it's worth it. -->

No single linked issue. This is a Home-screen polish/fix PR for behavior already documented in the User Guide:

- The top-bar playlist quick switcher is documented as applying to Home rails immediately.
- Home live rows support the Cards vs. On Now mini-guide modes.
- TMDB metadata is already an OwnTV feature and is expected to improve Home rails and artwork where available.

The upgrade is worth it because it removes stale/partial Home behavior in those existing flows:

- Favourite Channels in On Now mode should not hide guide data just because the favourite list is longer than the old guide query cap.
- Hero cards and episode continuation rows should prefer landscape/backdrop-style artwork and useful plot/title-logo metadata when available.
- Switching playlists from the top bar should make Home reflect the new source without leaving and reopening Home.

## How was it tested?
<!-- IMPORTANT: OwnTV is a TV app — please test on a REAL Android TV / Fire TV device, not the emulator
     only. The emulator misses a lot: HDR, hardware decoding, surround/passthrough, and real remote
     (D-pad) behaviour. -->
- **Device(s) tested on:** Not tested on a real Android TV / Fire TV device in this pass.
- **What you exercised:** Local compile validation and code-path review for the Home data refresh, Home On Now guide batching, metadata cache migration, TMDB artwork resolution, and shell playlist-switch refresh trigger.

Validation run:

```bash
JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" GRADLE_USER_HOME="$PWD/.gradle-cache" ./gradlew --no-daemon :app:compileDebugKotlin
```

Result: build passed.

Manual follow-up recommended before merge:

- On a real Android TV / Fire TV device, open Home with a profile that has more favourite live channels than the old On Now query cap and confirm guide rows appear across the visible favourites.
- Switch the top-bar playlist picker between **All playlists** and a single playlist while Home is visible and confirm hero/Continue Watching/Recent/Favourites update in place.
- Focus movie, series, and live hero items and confirm artwork, logo/title fallback, plot text, preview start, and D-pad navigation still behave correctly.
- Focus Continue Watching episode tiles and confirm landscape artwork appears where TMDB episode/show artwork exists, with provider art fallback otherwise.

## Checklist
- [ ] Builds locally (`./gradlew assembleDebug`) and CI is green
- [ ] **Tested on a real Android TV / Fire TV device** (not emulator only) — D-pad/remote navigation works
- [x] No user data is wiped (Room migrations stay additive)
- [x] Keeps OwnTV player-only (no bundled channels/content)
- [x] Commit messages are clear (they become the release notes)
