### PR TITLE
Harden customize PIN storage and redact preview URL logs

### DIFF
--- a/app/src/main/java/tv/own/owntv/features/customize/CustomizeScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/customize/CustomizeScreen.kt
@@ -41,6 +41,7 @@ import org.koin.androidx.compose.koinViewModel
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import tv.own.owntv.core.model.MediaType
+import tv.own.owntv.core.util.Pin
 import tv.own.owntv.features.profiles.PinDialog
 import tv.own.owntv.ui.components.FocusableSurface
 import tv.own.owntv.ui.components.OwnTVButton
@@ -98,7 +99,7 @@ fun CustomizeScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
         PinDialog(
             title = if (pinError) "Wrong PIN — try again" else "Enter PIN",
             onSubmit = { entered ->
-                if (entered == pinLock.pin) {
+                if (entered == pinLock.pin || Pin.verify(entered, pinLock.pin)) {
                     unlocked = true
                     pinError = false
                 } else {

--- a/app/src/main/java/tv/own/owntv/features/settings/data/SettingsRepository.kt
+++ b/app/src/main/java/tv/own/owntv/features/settings/data/SettingsRepository.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import tv.own.owntv.features.home.HomeConfig
+import tv.own.owntv.core.util.Pin
 import tv.own.owntv.ui.theme.AccentColor
 import tv.own.owntv.ui.theme.ThemeMode
 import tv.own.owntv.ui.theme.UiZoom
@@ -161,7 +162,7 @@ class SettingsRepository(private val context: Context) {
     suspend fun setCustomizePin(profileId: Long, pin: String?) {
         context.dataStore.edit { prefs ->
             val k = stringPreferencesKey("customize_pin_$profileId")
-            if (pin.isNullOrBlank()) prefs.remove(k) else prefs[k] = pin.trim()
+            if (pin.isNullOrBlank()) prefs.remove(k) else prefs[k] = Pin.hash(pin.trim())
         }
     }
 
@@ -793,9 +794,18 @@ class SettingsRepository(private val context: Context) {
                 val pid = key.toLongOrNull() ?: return@forEach
                 if (pid !in existingProfileIds) return@forEach
                 val pin = o.optString(key).takeIf { it.isNotEmpty() } ?: return@forEach
-                prefs[stringPreferencesKey("customize_pin_$pid")] = pin
+                prefs[stringPreferencesKey("customize_pin_$pid")] = normalizeCustomizePin(pin)
             }
         }
+    }
+
+    private fun normalizeCustomizePin(value: String): String {
+        val trimmed = value.trim()
+        return if (CUSTOMIZE_PIN_HASH_REGEX.matches(trimmed)) trimmed else Pin.hash(trimmed)
+    }
+
+    private companion object {
+        val CUSTOMIZE_PIN_HASH_REGEX = Regex("^[0-9a-fA-F]{16}:[0-9a-fA-F]{64}$")
     }
 
     // --- Backup: per-profile startup landing (dynamic "startup_mode_<id>" keys) ---

--- a/app/src/main/java/tv/own/owntv/player/HeroPreviewEngine.kt
+++ b/app/src/main/java/tv/own/owntv/player/HeroPreviewEngine.kt
@@ -98,7 +98,7 @@ class HeroPreviewEngine(
             p.prepare()
             p.playWhenReady = true
         }.onFailure {
-            android.util.Log.w(TAG, "Hero preview play failed for $url", it)
+            android.util.Log.w(TAG, "Hero preview play failed for ${HttpClient.redactUrl(url)}", it)
             hasStarted = false
             currentUrl = null
             player?.run {


### PR DESCRIPTION
## Before you open this PR (required)
- [x] I read the **[User Guide](https://github.com/ahXN00/OwnTV/blob/main/extras/USER_GUIDE.md)** and checked the app's **Settings** and existing **functions** — this change isn't already possible in the app.
- [x] I searched existing issues/PRs and this isn't a duplicate.

## What this fixes

- Store Customize screen PIN as a salted hash instead of plaintext in DataStore
- Keep backward compatibility for existing installs/backups by accepting legacy raw values at verification time and normalizing imported backup values
- Redact hero preview URLs in error logs to avoid leaking credential-bearing query/path segments

## Security impact

This removes plaintext PIN-at-rest for Customize lock and prevents accidental credential leakage in logs from preview playback failures.

## Notes

Could not run a local Android compile in this environment because Android SDK is not configured (missing ANDROID_HOME / local.properties sdk.dir).
