### PR TITLE
feat: add companion cloud app

### DIFF
--- a/app/src/main/java/tv/own/owntv/core/cloud/XtreamCloudListener.kt
+++ b/app/src/main/java/tv/own/owntv/core/cloud/XtreamCloudListener.kt
@@ -1,0 +1,558 @@
+package tv.own.owntv.core.cloud
+
+import android.util.Log
+import java.io.BufferedInputStream
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.net.Inet4Address
+import java.net.InetSocketAddress
+import java.net.NetworkInterface
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+import java.util.Collections
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+
+sealed interface CloudServerState {
+    data object Idle : CloudServerState
+    data object Starting : CloudServerState
+    data class Listening(val port: Int, val urls: List<String>) : CloudServerState
+    data class Failed(val message: String) : CloudServerState
+}
+
+data class XtreamCloudPayload(
+  val sourceType: String = "xtream",
+    val name: String,
+    val server: String,
+    val user: String,
+    val pass: String,
+  val portalUrl: String = "",
+  val mac: String = "",
+    val userAgent: String = "",
+    val epgUrl: String = "",
+    val autoRefresh: String = "OFF",
+    val syncLive: Boolean = true,
+    val syncMovies: Boolean = true,
+    val syncSeries: Boolean = true,
+    val isDefault: Boolean = false,
+)
+
+/**
+ * Tiny embedded HTTP listener used by the Cloud tab. It serves a simple HTML form and accepts the
+ * submitted Xtream fields on the same device or any device on the same LAN.
+ */
+class XtreamCloudListener {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val running = AtomicBoolean(false)
+
+    @Volatile
+    private var serverSocket: ServerSocket? = null
+
+    fun start(port: Int, onPayload: (XtreamCloudPayload) -> Unit): List<String> {
+        stop()
+        val socket = ServerSocket()
+        socket.reuseAddress = true
+        socket.bind(InetSocketAddress(port))
+        serverSocket = socket
+        running.set(true)
+        scope.launch {
+            acceptLoop(socket, onPayload)
+        }
+        return cloudUrls(port)
+    }
+
+    fun stop() {
+        running.set(false)
+        runCatching { serverSocket?.close() }
+        serverSocket = null
+    }
+
+    fun close() {
+        stop()
+        scope.cancel()
+    }
+
+    private suspend fun acceptLoop(socket: ServerSocket, onPayload: (XtreamCloudPayload) -> Unit) {
+        try {
+            while (running.get() && !socket.isClosed) {
+                val client = try {
+                    socket.accept()
+                } catch (e: IOException) {
+                    if (running.get()) Log.w(TAG, "Cloud listener accept failed", e)
+                    break
+                }
+                scope.launch { handleClient(client, onPayload) }
+            }
+        } finally {
+            stop()
+        }
+    }
+
+    private fun handleClient(client: Socket, onPayload: (XtreamCloudPayload) -> Unit) {
+        client.use { socket ->
+            socket.soTimeout = 10_000
+            val input = BufferedInputStream(socket.getInputStream())
+            val requestLine = readLine(input) ?: return sendResponse(socket, 400, "text/plain; charset=utf-8", "Bad request")
+            val parts = requestLine.split(' ')
+            if (parts.size < 3) return sendResponse(socket, 400, "text/plain; charset=utf-8", "Bad request")
+
+            val method = parts[0].uppercase()
+            val path = parts[1].substringBefore('?')
+            val headers = LinkedHashMap<String, String>()
+            while (true) {
+                val line = readLine(input) ?: break
+                if (line.isEmpty()) break
+                val colon = line.indexOf(':')
+                if (colon <= 0) continue
+                headers[line.substring(0, colon).trim().lowercase()] = line.substring(colon + 1).trim()
+            }
+
+            if (method == "GET" && (path == "/" || path == "/index.html")) {
+                val hostUrls = headers["host"]?.let { host -> listOf("http://$host/") } ?: emptyList()
+                val body = renderFormPage(hostUrls.ifEmpty { cloudUrls(socket.localPort) })
+                return sendResponse(socket, 200, "text/html; charset=utf-8", body)
+            }
+
+            if (method != "POST" || (path != "/xtream" && path != "/stalker" && path != "/source")) {
+                return sendResponse(socket, 404, "text/plain; charset=utf-8", "Not found")
+            }
+
+            val length = headers["content-length"]?.toIntOrNull()?.coerceAtLeast(0) ?: 0
+            val bodyBytes = ByteArray(length)
+            var offset = 0
+            while (offset < length) {
+                val read = input.read(bodyBytes, offset, length - offset)
+                if (read <= 0) break
+                offset += read
+            }
+            val bodyText = String(bodyBytes, 0, offset, StandardCharsets.UTF_8)
+            val fallbackType = if (path == "/stalker") "stalker" else "xtream"
+            val payload = parsePayload(headers["content-type"], bodyText, fallbackType)
+              ?: return sendResponse(socket, 400, "text/plain; charset=utf-8", "Missing required fields")
+
+            onPayload(payload)
+            val okHtml = renderSavedPage(payload)
+            sendResponse(socket, 200, "text/html; charset=utf-8", okHtml)
+        }
+    }
+
+        private fun parsePayload(contentType: String?, bodyText: String, fallbackType: String): XtreamCloudPayload? {
+        val fields = when {
+            contentType?.contains("application/json", ignoreCase = true) == true || bodyText.trimStart().startsWith("{") ->
+                parseJsonFields(bodyText)
+            else -> parseFormFields(bodyText)
+        }
+
+          val sourceType = stringField(fields, "type", "sourceType", "source_type")
+            .ifBlank { fallbackType }
+            .trim()
+            .lowercase()
+
+          val portalUrl = stringField(fields, "portalUrl", "portal_url", "url", "server").trim()
+          val mac = stringField(fields, "mac", "macAddress", "mac_address").trim()
+
+        val server = stringField(fields, "server", "url", "portalUrl", "portal_url").trim()
+        val user = stringField(fields, "user", "username").trim()
+        val pass = stringField(fields, "pass", "password").trim()
+
+          if (sourceType == "stalker") {
+            if (portalUrl.isBlank() || mac.isBlank()) return null
+          } else {
+            if (server.isBlank() || user.isBlank() || pass.isBlank()) return null
+          }
+
+        return XtreamCloudPayload(
+            sourceType = sourceType,
+            name = stringField(fields, "name").trim(),
+            server = server,
+            user = user,
+            pass = pass,
+            portalUrl = portalUrl,
+            mac = mac,
+            userAgent = stringField(fields, "userAgent", "user_agent").trim(),
+            epgUrl = stringField(fields, "epgUrl", "epg_url").trim(),
+            autoRefresh = stringField(fields, "autoRefresh", "auto_refresh").ifBlank { "OFF" },
+            syncLive = booleanField(fields, "syncLive", "sync_live", defaultValue = true),
+            syncMovies = booleanField(fields, "syncMovies", "sync_movies", defaultValue = true),
+            syncSeries = booleanField(fields, "syncSeries", "sync_series", defaultValue = true),
+            isDefault = booleanField(fields, "isDefault", "is_default", defaultValue = false),
+        )
+    }
+
+    private fun parseJsonFields(bodyText: String): Map<String, String> {
+        val json = org.json.JSONObject(bodyText)
+        val out = LinkedHashMap<String, String>()
+        json.keys().forEach { key ->
+            val value = json.opt(key)
+            when (value) {
+                null, org.json.JSONObject.NULL -> Unit
+                is Boolean -> out[key] = value.toString()
+                is Number -> out[key] = value.toString()
+                else -> out[key] = value.toString()
+            }
+        }
+        return out
+    }
+
+    private fun parseFormFields(bodyText: String): Map<String, String> {
+        if (bodyText.isBlank()) return emptyMap()
+        val out = LinkedHashMap<String, String>()
+        bodyText.split('&').forEach { pair ->
+            if (pair.isBlank()) return@forEach
+            val split = pair.split('=', limit = 2)
+            val key = urlDecode(split[0])
+            val value = urlDecode(split.getOrNull(1).orEmpty())
+            if (key.isNotBlank()) out[key] = value
+        }
+        return out
+    }
+
+    private fun stringField(fields: Map<String, String>, vararg keys: String): String =
+        keys.firstNotNullOfOrNull { key -> fields[key]?.takeIf { it.isNotBlank() } } ?: ""
+
+    private fun booleanField(fields: Map<String, String>, primary: String, secondary: String, defaultValue: Boolean): Boolean {
+        val raw = fields[primary] ?: fields[secondary] ?: return defaultValue
+        return raw.isTruthy() || (!raw.isFalsy() && defaultValue)
+    }
+
+    private fun String.isTruthy(): Boolean =
+        equals("true", ignoreCase = true) || equals("1") || equals("on", ignoreCase = true) || equals("yes", ignoreCase = true)
+
+    private fun String.isFalsy(): Boolean =
+        equals("false", ignoreCase = true) || equals("0") || equals("off", ignoreCase = true) || equals("no", ignoreCase = true)
+
+    private fun renderFormPage(urls: List<String>): String = """
+        <!doctype html>
+        <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <title>OwnTV Cloud Import</title>
+          <style>
+            :root {
+              color-scheme: dark;
+              --bg-0: #030711;
+              --bg-1: #091224;
+              --surface: rgba(11, 19, 36, 0.92);
+              --surface-2: rgba(13, 26, 46, 0.9);
+              --line: rgba(116, 154, 194, 0.22);
+              --text: #f8fbff;
+              --muted: #a6bdd8;
+              --primary: #52dbc8;
+              --primary-ink: #052b28;
+            }
+            body {
+              margin: 0;
+              font-family: "Segoe UI", "Trebuchet MS", sans-serif;
+              background:
+                radial-gradient(1200px 500px at 10% -10%, #123057 0%, transparent 60%),
+                radial-gradient(800px 420px at 100% 0%, #0d3f5d 0%, transparent 62%),
+                linear-gradient(160deg, var(--bg-0), var(--bg-1));
+              color: var(--text);
+            }
+            main {
+              max-width: 820px;
+              margin: 0 auto;
+              padding: 32px 20px 48px;
+            }
+            .card {
+              background: var(--surface);
+              border: 1px solid var(--line);
+              border-radius: 18px;
+              padding: 20px;
+              margin-top: 18px;
+              box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+            }
+            .card-title { margin: 0 0 8px; }
+            h1, h2 { margin: 0 0 12px; }
+            p { line-height: 1.5; color: var(--muted); }
+            .urls { display: grid; gap: 8px; margin-top: 12px; }
+            .url {
+              padding: 10px 12px;
+              background: var(--surface-2);
+              border-radius: 12px;
+              overflow-wrap: anywhere;
+              color: var(--text);
+            }
+            form { display: grid; gap: 14px; }
+            label { display: grid; gap: 6px; font-size: 14px; color: var(--text); }
+            input, select {
+              border: 1px solid var(--line);
+              border-radius: 12px;
+              padding: 12px 14px;
+              background: #0a1427;
+              color: var(--text);
+              font-size: 16px;
+            }
+            .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
+            .checks { display: grid; gap: 8px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+            .check { display: flex; align-items: center; gap: 8px; }
+            .check input { width: 18px; height: 18px; }
+            .type-switch {
+              display: grid;
+              grid-template-columns: repeat(2, minmax(0, 1fr));
+              gap: 10px;
+              margin-bottom: 14px;
+            }
+            .type-btn {
+              border: 1px solid var(--line);
+              border-radius: 12px;
+              padding: 10px 12px;
+              background: #08152b;
+              color: var(--muted);
+              font-weight: 700;
+              cursor: pointer;
+            }
+            .type-btn.active {
+              border-color: var(--primary);
+              background: #0c2738;
+              color: #d4fff9;
+            }
+            .source-panel { display: none; }
+            .source-panel.active { display: block; }
+            button {
+              border: 0;
+              border-radius: 12px;
+              padding: 14px 16px;
+              background: var(--primary);
+              color: var(--primary-ink);
+              font-weight: 700;
+              font-size: 16px;
+              cursor: pointer;
+            }
+            .hint { font-size: 13px; color: #89a8c7; }
+            @media (max-width: 720px) {
+              .grid, .checks { grid-template-columns: 1fr; }
+            }
+          </style>
+        </head>
+        <body>
+          <main>
+            <h1>OwnTV Cloud Import</h1>
+            <p>Open this page from any device on the same network, then submit either Xtream or Stalker details. OwnTV will add it using the same import path as the in-app forms.</p>
+
+            <section class="card">
+              <h2>Listener URLs</h2>
+              <div class="urls">
+                ${urls.joinToString(separator = "\n") { "<div class=\"url\">$it</div>" }}
+              </div>
+              <p class="hint">Use the root page for the form, or POST directly to <strong>/xtream</strong> (Xtream) / <strong>/stalker</strong> (Stalker).</p>
+            </section>
+
+            <section class="card">
+              <h2 class="card-title">Add Source</h2>
+              <div class="type-switch">
+                <button type="button" class="type-btn active" id="xtreamBtn">Xtream</button>
+                <button type="button" class="type-btn" id="stalkerBtn">Stalker</button>
+              </div>
+
+              <div id="xtreamPanel" class="source-panel active">
+                <form method="post" action="/xtream">
+                  <input type="hidden" name="type" value="xtream">
+                  <div class="grid">
+                    <label>Name
+                      <input name="name" placeholder="My IPTV">
+                    </label>
+                    <label>Auto refresh
+                      <select name="autoRefresh">
+                        <option value="OFF" selected>Off</option>
+                        <option value="STARTUP">Refresh at startup</option>
+                        <option value="HOURS_6">6 hours</option>
+                        <option value="HOURS_12">12 hours</option>
+                        <option value="HOURS_24">24 hours</option>
+                        <option value="HOURS_48">48 hours</option>
+                      </select>
+                    </label>
+                  </div>
+                  <label>Server URL
+                    <input name="server" placeholder="http://host:port" required>
+                  </label>
+                  <div class="grid">
+                    <label>Username
+                      <input name="user" autocomplete="username" required>
+                    </label>
+                    <label>Password
+                      <input name="pass" type="password" autocomplete="current-password" required>
+                    </label>
+                  </div>
+                  <label>User-Agent
+                    <input name="userAgent" placeholder="Optional">
+                  </label>
+                  <label>EPG URL
+                    <input name="epgUrl" placeholder="Optional">
+                  </label>
+                  <div class="checks">
+                    <label class="check"><input type="checkbox" name="syncLive" checked> Sync live TV</label>
+                    <label class="check"><input type="checkbox" name="syncMovies" checked> Sync movies</label>
+                    <label class="check"><input type="checkbox" name="syncSeries" checked> Sync series</label>
+                    <label class="check"><input type="checkbox" name="isDefault"> Make default playlist</label>
+                  </div>
+                  <button type="submit">Add Xtream source</button>
+                </form>
+              </div>
+
+              <div id="stalkerPanel" class="source-panel">
+                <form method="post" action="/stalker">
+                  <input type="hidden" name="type" value="stalker">
+                  <div class="grid">
+                    <label>Name
+                      <input name="name" placeholder="My Portal">
+                    </label>
+                    <label>Auto refresh
+                      <select name="autoRefresh">
+                        <option value="OFF" selected>Off</option>
+                        <option value="STARTUP">Refresh at startup</option>
+                        <option value="HOURS_6">6 hours</option>
+                        <option value="HOURS_12">12 hours</option>
+                        <option value="HOURS_24">24 hours</option>
+                        <option value="HOURS_48">48 hours</option>
+                      </select>
+                    </label>
+                  </div>
+                  <label>Portal URL
+                    <input name="portalUrl" placeholder="http://host:port/c/" required>
+                  </label>
+                  <label>MAC address
+                    <input name="mac" placeholder="00:1A:79:AA:BB:CC" required>
+                  </label>
+                  <label>User-Agent
+                    <input name="userAgent" placeholder="Optional">
+                  </label>
+                  <label class="check"><input type="checkbox" name="isDefault"> Make default playlist</label>
+                  <button type="submit">Add Stalker source</button>
+                </form>
+              </div>
+            </section>
+          </main>
+          <script>
+              const xtreamBtn = document.getElementById('xtreamBtn');
+              const stalkerBtn = document.getElementById('stalkerBtn');
+              const xtreamPanel = document.getElementById('xtreamPanel');
+              const stalkerPanel = document.getElementById('stalkerPanel');
+
+              function showSource(type) {
+                const xtream = type === 'xtream';
+                xtreamBtn.classList.toggle('active', xtream);
+                stalkerBtn.classList.toggle('active', !xtream);
+                xtreamPanel.classList.toggle('active', xtream);
+                stalkerPanel.classList.toggle('active', !xtream);
+              }
+
+              xtreamBtn.addEventListener('click', () => showSource('xtream'));
+              stalkerBtn.addEventListener('click', () => showSource('stalker'));
+          </script>
+        </body>
+        </html>
+    """.trimIndent()
+
+    private fun renderSavedPage(payload: XtreamCloudPayload): String = """
+        <!doctype html>
+        <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <title>OwnTV Cloud Import Saved</title>
+          <style>
+            body {
+              margin: 0;
+              font-family: Arial, Helvetica, sans-serif;
+              background: #020617;
+              color: #e2e8f0;
+              display: grid;
+              place-items: center;
+              min-height: 100vh;
+              padding: 24px;
+            }
+            .card {
+              max-width: 620px;
+              width: 100%;
+              background: rgba(15, 23, 42, 0.94);
+              border: 1px solid rgba(148, 163, 184, 0.18);
+              border-radius: 18px;
+              padding: 24px;
+              box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+            }
+            a { color: #38bdf8; }
+          </style>
+        </head>
+        <body>
+          <div class="card">
+            <h1>Saved</h1>
+            <p>OwnTV received <strong>${payload.name.ifBlank { if (payload.sourceType == "stalker") "My Portal" else "My IPTV" }}</strong> and started the ${payload.sourceType.uppercase()} import flow.</p>
+            <p>You can submit another source from the form, or go back to the listener page.</p>
+            <p><a href="/">Back to form</a></p>
+          </div>
+        </body>
+        </html>
+    """.trimIndent()
+
+    private fun sendResponse(socket: Socket, code: Int, contentType: String, body: String) {
+        val bytes = body.toByteArray(StandardCharsets.UTF_8)
+        val status = when (code) {
+            200 -> "OK"
+            400 -> "Bad Request"
+            404 -> "Not Found"
+            else -> "OK"
+        }
+        socket.getOutputStream().use { output ->
+            val header = buildString {
+                append("HTTP/1.1 ").append(code).append(' ').append(status).append("\r\n")
+                append("Content-Type: ").append(contentType).append("\r\n")
+                append("Content-Length: ").append(bytes.size).append("\r\n")
+                append("Connection: close\r\n\r\n")
+            }
+            output.write(header.toByteArray(StandardCharsets.UTF_8))
+            output.write(bytes)
+            output.flush()
+        }
+    }
+
+    private fun readLine(input: BufferedInputStream): String? {
+        val buffer = ByteArrayOutputStream()
+        while (true) {
+            val next = input.read()
+            if (next == -1) {
+                if (buffer.size() == 0) return null
+                break
+            }
+            if (next == '\n'.code) break
+            if (next != '\r'.code) buffer.write(next)
+        }
+        return buffer.toString(StandardCharsets.UTF_8.name())
+    }
+
+    private fun urlDecode(value: String): String = URLDecoder.decode(value, StandardCharsets.UTF_8.name())
+
+    companion object {
+        private const val TAG = "XtreamCloud"
+
+      fun cloudUrls(port: Int): List<String> {
+        val lanHosts = buildList {
+          Collections.list(NetworkInterface.getNetworkInterfaces()).forEach { iface ->
+            if (!iface.isUp || iface.isLoopback || iface.isVirtual) return@forEach
+            Collections.list(iface.inetAddresses)
+              .filterIsInstance<Inet4Address>()
+              .mapNotNull { address ->
+                val host = address.hostAddress?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                if (address.isLoopbackAddress || address.isLinkLocalAddress) null else host
+              }
+              .forEach { host -> add(host) }
+          }
+        }.distinct()
+
+        val preferredHost = lanHosts.firstOrNull { host ->
+          host.startsWith("10.") ||
+            host.startsWith("192.168.") ||
+            host.startsWith("172.")
+        } ?: lanHosts.firstOrNull() ?: "127.0.0.1"
+
+        return listOf("http://$preferredHost:$port/")
+      }
+    }
+}

--- a/app/src/main/java/tv/own/owntv/features/settings/ManageSourcesScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/settings/ManageSourcesScreen.kt
@@ -35,6 +35,7 @@ import org.koin.androidx.compose.koinViewModel
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import tv.own.owntv.core.database.entity.SourceEntity
+import tv.own.owntv.core.cloud.CloudServerState
 import tv.own.owntv.core.model.SourceType
 import tv.own.owntv.core.sync.SyncCounts
 import tv.own.owntv.core.sync.SyncProgressCounts
@@ -64,6 +65,7 @@ fun ManageSourcesScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
     val sourceExpiry by vm.sourceExpiry.collectAsStateWithLifecycle()
     val deletingIds by vm.deletingSourceIds.collectAsStateWithLifecycle()
     val epgSync by vm.epgSync.collectAsStateWithLifecycle()
+    val cloudState by vm.cloudState.collectAsStateWithLifecycle()
     val colors = OwnTVTheme.colors
 
     var showAdd by remember { mutableStateOf(false) }
@@ -86,7 +88,7 @@ fun ManageSourcesScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
 
     BackHandler {
         when {
-            showAdd -> { showAdd = false; vm.cancelImport() }
+            showAdd -> { showAdd = false; vm.clearTransientAddSourceState() }
             editingSource != null -> editingSource = null
             else -> onBack()
         }
@@ -110,6 +112,9 @@ fun ManageSourcesScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
                 editingSource = null
             },
             onStartM3u = { n, url, ua, epg, autoRefresh, isDefault -> vm.updateSource(src.id, n, url, "", "", ua, epg, autoRefresh, isDefault); editingSource = null },
+            onStartCloud = null,
+            onStopCloud = null,
+            cloudState = CloudServerState.Idle,
             onStartStalker = { n, url, mac, ua, autoRefresh, isDefault ->
                 vm.updateSource(src.id, n, url, "", "", ua, "", autoRefresh, isDefault, mac = mac)
                 vm.resetStalkerTest()
@@ -130,6 +135,9 @@ fun ManageSourcesScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
                     vm.addXtream(n, server, u, p, ua, epg, autoRefresh, live, movies, series, isDefault)
                 },
                 onStartM3u = { n, url, ua, epg, autoRefresh, isDefault -> vm.addM3u(n, url, ua, epg, autoRefresh, isDefault) },
+                onStartCloud = { port -> vm.startCloudListener(port) },
+                onStopCloud = { vm.stopCloudListener() },
+                cloudState = cloudState,
                 onStartStalker = { n, url, mac, ua, autoRefresh, isDefault ->
                     vm.resetStalkerTest()
                     vm.addStalker(n, url, mac, ua, autoRefresh, isDefault)
@@ -138,7 +146,7 @@ fun ManageSourcesScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
                 stalkerTest = stalkerTestUi,
                 // A newly-added playlist can be made default only when others already exist.
                 showDefaultToggle = sources.isNotEmpty(),
-                onBack = { vm.resetStalkerTest(); showAdd = false },
+                onBack = { vm.clearTransientAddSourceState(); showAdd = false },
                 modifier = modifier,
                 initial = vm.lastFailedSource, // pre-fill on retry — no re-typing after a typo
             )
@@ -156,7 +164,7 @@ fun ManageSourcesScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
                 Spacer(Modifier.height(4.dp))
                 Text(display?.detail ?: "Preparing catalog", style = MaterialTheme.typography.bodyMedium, color = colors.onSurfaceVariant)
                 Spacer(Modifier.height(20.dp))
-                OwnTVButton("Cancel", onClick = { showAdd = false; vm.cancelImport() }, style = OwnTVButtonStyle.SECONDARY)
+                OwnTVButton("Cancel", onClick = { showAdd = false; vm.clearTransientAddSourceState() }, style = OwnTVButtonStyle.SECONDARY)
             }
             is SettingsViewModel.ImportState.Success -> {
                 // Semi-auto EPG: ask → sync (with a live count, like the import) → done, before returning.
@@ -168,10 +176,10 @@ fun ManageSourcesScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
                         Spacer(Modifier.height(8.dp))
                         Text(s.summary, style = MaterialTheme.typography.bodyMedium, color = colors.onSurfaceVariant)
                         Spacer(Modifier.height(20.dp))
-                        OwnTVButton("Done", onClick = { showAdd = false; vm.resetImport() })
+                        OwnTVButton("Done", onClick = { showAdd = false; vm.clearTransientAddSourceState() })
                     }
                 } else {
-                    LaunchedEffect(Unit) { showAdd = false; vm.resetImport() }
+                    LaunchedEffect(Unit) { showAdd = false; vm.clearTransientAddSourceState() }
                 }
             }
             is SettingsViewModel.ImportState.Failed -> CenterStatus {
@@ -180,7 +188,7 @@ fun ManageSourcesScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
                 Text(s.message, style = MaterialTheme.typography.bodyMedium, color = colors.onSurfaceVariant)
                 Spacer(Modifier.height(20.dp))
                 Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    OwnTVButton("Back", onClick = { showAdd = false; vm.resetImport() }, style = OwnTVButtonStyle.SECONDARY)
+                    OwnTVButton("Back", onClick = { showAdd = false; vm.clearTransientAddSourceState() }, style = OwnTVButtonStyle.SECONDARY)
                     OwnTVButton("Try again", onClick = { vm.resetImport() }, modifier = Modifier.focusRequester(errorFocus))
                 }
             }

--- a/app/src/main/java/tv/own/owntv/features/settings/SettingsViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/settings/SettingsViewModel.kt
@@ -26,6 +26,9 @@ import kotlinx.coroutines.withContext
 import tv.own.owntv.core.database.dao.ProfileDao
 import tv.own.owntv.core.database.dao.SourceDao
 import tv.own.owntv.core.database.entity.SourceEntity
+import tv.own.owntv.core.cloud.CloudServerState
+import tv.own.owntv.core.cloud.XtreamCloudListener
+import tv.own.owntv.core.cloud.XtreamCloudPayload
 import tv.own.owntv.core.network.ConnectivityObserver
 import tv.own.owntv.core.repository.SourceRepository
 import tv.own.owntv.core.sync.ImportStage
@@ -75,7 +78,14 @@ class SettingsViewModel(
 
         /** Sentinel session key for pre-save "Test connection" handshakes (no real source id yet). */
         private const val STALKER_TEST_SOURCE_ID = -1L
+
+        private const val CLOUD_LISTENER_PORT = 8089
     }
+
+    private val cloudListener = XtreamCloudListener()
+
+    private val _cloudState = MutableStateFlow<CloudServerState>(CloudServerState.Idle)
+    val cloudState: StateFlow<CloudServerState> = _cloudState.asStateFlow()
 
     // Semi-auto EPG: after a playlist import, if the playlist has a guide URL we offer to sync the EPG now
     // (instead of the old slow auto-sync). "Sync now" shows a live programme count, just like the import.
@@ -139,6 +149,60 @@ class SettingsViewModel(
         /** [summary] is the per-type breakdown, e.g. "40K channels · 100K movies · 30K series synced". */
         data class Success(val summary: String) : ImportState
         data class Failed(val message: String) : ImportState
+    }
+
+    fun startCloudListener(port: Int = CLOUD_LISTENER_PORT) {
+        if (port !in 1..65535) {
+            _cloudState.value = CloudServerState.Failed("Enter a valid port between 1 and 65535.")
+            return
+        }
+        viewModelScope.launch {
+            _cloudState.value = CloudServerState.Starting
+            runCatching {
+                cloudListener.start(port) { payload ->
+                    handleCloudPayload(payload)
+                }
+            }.onSuccess { urls ->
+                _cloudState.value = CloudServerState.Listening(port, urls)
+            }.onFailure { error ->
+                _cloudState.value = CloudServerState.Failed(friendlyCloudError(error))
+            }
+        }
+    }
+
+    fun stopCloudListener() {
+        cloudListener.stop()
+        _cloudState.value = CloudServerState.Idle
+    }
+
+    private fun handleCloudPayload(payload: XtreamCloudPayload) {
+        viewModelScope.launch {
+            val autoRefresh = runCatching { PlaylistAutoRefresh.valueOf(payload.autoRefresh) }.getOrDefault(PlaylistAutoRefresh.OFF)
+            if (payload.sourceType.equals("stalker", ignoreCase = true)) {
+                addStalker(
+                    name = payload.name,
+                    portalUrl = payload.portalUrl,
+                    mac = payload.mac,
+                    userAgent = payload.userAgent,
+                    autoRefresh = autoRefresh,
+                    isDefault = payload.isDefault,
+                )
+            } else {
+                addXtream(
+                    name = payload.name,
+                    server = payload.server,
+                    user = payload.user,
+                    pass = payload.pass,
+                    userAgent = payload.userAgent,
+                    epgUrl = payload.epgUrl,
+                    autoRefresh = autoRefresh,
+                    syncLive = payload.syncLive,
+                    syncMovies = payload.syncMovies,
+                    syncSeries = payload.syncSeries,
+                    isDefault = payload.isDefault,
+                )
+            }
+        }
     }
 
     val sources: StateFlow<List<SourceEntity>> = settings.activeProfileId
@@ -695,6 +759,12 @@ class SettingsViewModel(
     private fun String.isLocalPlaylistPath(): Boolean =
         startsWith("/") || startsWith("file://") || startsWith("content://")
 
+    private fun friendlyCloudError(t: Throwable): String = when (t) {
+        is java.net.BindException -> "Port is already in use. Pick another port."
+        is java.net.SocketException -> t.message?.takeIf { it.isNotBlank() } ?: "Could not open the local server."
+        else -> t.message?.takeIf { it.isNotBlank() } ?: "Could not open the local server."
+    }
+
     /** Re-sync an existing source through WorkManager so it can continue after leaving this screen. */
     fun resync(source: SourceEntity) {
         Log.d(TAG, "resync enqueue sourceId=${source.id}")
@@ -751,6 +821,15 @@ class SettingsViewModel(
         _progress.value = null
     }
 
+    /** Clears transient cloud/import UI state when leaving Add Source. */
+    fun clearTransientAddSourceState() {
+        stopCloudListener()
+        cancelImport()
+        dismissPendingEpg()
+        resetStalkerTest()
+        _lastFailedSource = null
+    }
+
     private suspend fun refreshActiveTvHome(allowBrowsableRequest: Boolean = true) {
         val pid = profileDao.resolveExistingProfileId(settings.activeProfileId.first()) ?: return
         Log.d(TAG, "refreshActiveTvHome profile=$pid allowBrowsable=$allowBrowsableRequest")
@@ -777,6 +856,11 @@ class SettingsViewModel(
 
     private fun String.withWarnings(result: SyncResult.Success): String =
         result.warningSummary()?.let { "$this\n$it" } ?: this
+
+    override fun onCleared() {
+        cloudListener.close()
+        super.onCleared()
+    }
 
     // --- Global proxy (Approach 1 — one app-wide HTTP proxy) ---
 

--- a/app/src/main/java/tv/own/owntv/features/setup/AddSourceScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/setup/AddSourceScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -33,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import tv.own.owntv.core.database.entity.SourceEntity
+import tv.own.owntv.core.cloud.CloudServerState
 import tv.own.owntv.core.model.SourceType
 import tv.own.owntv.features.settings.PickerDialog
 import tv.own.owntv.features.settings.data.PlaylistAutoRefresh
@@ -45,7 +47,7 @@ import tv.own.owntv.ui.components.OwnTVTextField
 import tv.own.owntv.ui.components.roundedPanel
 import tv.own.owntv.ui.theme.OwnTVTheme
 
-private enum class SourceKind { XTREAM, M3U, STALKER }
+private enum class SourceKind { XTREAM, CLOUD, M3U, STALKER }
 
 /** UI state of the Stalker "Test connection" probe (mapped from the owning ViewModel's state). */
 sealed interface StalkerTestUi {
@@ -79,6 +81,9 @@ fun AddSourceScreen(
         syncSeries: Boolean,
         isDefault: Boolean,
     ) -> Unit,
+    onStartCloud: ((port: Int) -> Unit)? = null,
+    onStopCloud: (() -> Unit)? = null,
+    cloudState: CloudServerState = CloudServerState.Idle,
     onStartM3u: (name: String, url: String, userAgent: String, epgUrl: String, autoRefresh: PlaylistAutoRefresh, isDefault: Boolean) -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
@@ -110,6 +115,7 @@ fun AddSourceScreen(
     var portalUrl by remember(initial) { mutableStateOf(if (initial != null && initial.type == SourceType.STALKER) initial.url else "") }
     var mac by remember(initial) { mutableStateOf(initial?.mac ?: "") }
     var showUaPresetPicker by remember { mutableStateOf(false) }
+    var cloudPort by remember { mutableStateOf("8089") }
     var epgUrl by remember(initial) { mutableStateOf(initial?.epgUrl ?: "") }
     var userAgent by remember(initial) { mutableStateOf(initial?.userAgent ?: "") }
     var autoRefresh by remember(initialAutoRefresh) { mutableStateOf(initialAutoRefresh) }
@@ -124,10 +130,22 @@ fun AddSourceScreen(
 
     val showContentToggles = kind == SourceKind.XTREAM && !editing
     val macValid = tv.own.owntv.core.stalker.StalkerClient.canonicalizeMac(mac) != null
+    val cloudPortValid = cloudPort.toIntOrNull()?.let { it in 1..65535 } == true
+    val cloudListening = cloudState is CloudServerState.Listening
     val canStart = when (kind) {
         SourceKind.XTREAM -> server.isNotBlank() && username.isNotBlank() && password.isNotBlank() && (syncLive || syncMovies || syncSeries)
+        SourceKind.CLOUD -> cloudPortValid
         SourceKind.M3U -> m3uUrl.isNotBlank()
         SourceKind.STALKER -> tv.own.owntv.core.stalker.StalkerClient.isValidPortalUrl(portalUrl) && macValid
+    }
+
+    // If the user leaves the Cloud tab, stop the listener so stale URLs/server sessions don't linger.
+    LaunchedEffect(kind, cloudListening, onStopCloud) {
+        if (kind != SourceKind.CLOUD && cloudListening) onStopCloud?.invoke()
+    }
+    // Also stop listener when this screen leaves composition (back/navigation/import transition).
+    DisposableEffect(onStopCloud) {
+        onDispose { onStopCloud?.invoke() }
     }
 
     Box(modifier.fillMaxSize().roundedPanel()) {
@@ -152,6 +170,9 @@ fun AddSourceScreen(
             // goes to the Name field instead of a dead chip).
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 KindChip("Xtream", kind == SourceKind.XTREAM, Modifier.weight(1f).then(if (!editing) Modifier.focusRequester(firstFocus) else Modifier)) { if (!editing) kind = SourceKind.XTREAM }
+                if (onStartCloud != null) {
+                    KindChip("Cloud", kind == SourceKind.CLOUD, Modifier.weight(1f)) { if (!editing) kind = SourceKind.CLOUD }
+                }
                 KindChip("M3U / M3U8", kind == SourceKind.M3U, Modifier.weight(1f)) { if (!editing) kind = SourceKind.M3U }
                 if (onStartStalker != null) {
                     KindChip("Stalker (MAC)", kind == SourceKind.STALKER, Modifier.weight(1f)) { if (!editing) kind = SourceKind.STALKER }
@@ -159,8 +180,10 @@ fun AddSourceScreen(
             }
             Spacer(Modifier.height(20.dp))
 
-            OwnTVTextField(name, { name = it }, label = "Name (optional)", placeholder = "My IPTV", modifier = Modifier.fillMaxWidth(), focusRequester = if (editing) firstFocus else null)
-            Spacer(Modifier.height(14.dp))
+            if (kind != SourceKind.CLOUD) {
+                OwnTVTextField(name, { name = it }, label = "Name (optional)", placeholder = "My IPTV", modifier = Modifier.fillMaxWidth(), focusRequester = if (editing) firstFocus else null)
+                Spacer(Modifier.height(14.dp))
+            }
 
             when (kind) {
                 SourceKind.XTREAM -> {
@@ -169,6 +192,39 @@ fun AddSourceScreen(
                     OwnTVTextField(username, { username = it }, label = "Username", modifier = Modifier.fillMaxWidth())
                     Spacer(Modifier.height(14.dp))
                     OwnTVTextField(password, { password = it }, label = if (editing) "Password (leave blank to keep)" else "Password", isPassword = true, modifier = Modifier.fillMaxWidth())
+                }
+                SourceKind.CLOUD -> {
+                    OwnTVTextField(cloudPort, { cloudPort = it.filter { ch -> ch.isDigit() }.take(5) }, label = "Local server port", placeholder = "8089", keyboardType = KeyboardType.Number, modifier = Modifier.fillMaxWidth())
+                    Spacer(Modifier.height(10.dp))
+                    Text(
+                        "Start the listener, then open the URLs below from any device on the same network.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = colors.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    when (cloudState) {
+                        CloudServerState.Idle -> Unit
+                        CloudServerState.Starting -> {
+                            Text("Opening local server...", style = MaterialTheme.typography.bodySmall, color = colors.primary)
+                        }
+                        is CloudServerState.Listening -> {
+                            Text("Listener is active.", style = MaterialTheme.typography.bodySmall, color = colors.primary)
+                            Spacer(Modifier.height(8.dp))
+                            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                                cloudState.urls.take(4).forEach { url ->
+                                    Text(url, style = MaterialTheme.typography.bodySmall, color = colors.onSurface)
+                                }
+                                if (cloudState.urls.size > 4) {
+                                    Text("... and ${cloudState.urls.size - 4} more", style = MaterialTheme.typography.bodySmall, color = colors.onSurfaceVariant)
+                                }
+                            }
+                            Spacer(Modifier.height(8.dp))
+                            Text("Open the root page to use Xtream/Stalker forms, or POST to /xtream and /stalker.", style = MaterialTheme.typography.bodySmall, color = colors.onSurfaceVariant)
+                        }
+                        is CloudServerState.Failed -> {
+                            Text(cloudState.message, style = MaterialTheme.typography.bodySmall, color = Color(0xFFEF4444))
+                        }
+                    }
                 }
                 SourceKind.M3U -> {
                     val pickedName = remember(m3uUrl) {
@@ -222,23 +278,25 @@ fun AddSourceScreen(
                 }
             }
 
-            // EPG is managed separately now (Settings → EPG Sources), so no EPG field here. For an
-            // Xtream server the guide URL is still derived automatically; M3U EPG can be added there.
-            Spacer(Modifier.height(14.dp))
-            OwnTVTextField(userAgent, { userAgent = it }, label = "User-Agent (optional)", placeholder = "e.g. VLC/3.0.20 LibVLC/3.0.20", modifier = Modifier.fillMaxWidth())
+            if (kind != SourceKind.CLOUD) {
+                // EPG is managed separately now (Settings → EPG Sources), so no EPG field here. For an
+                // Xtream server the guide URL is still derived automatically; M3U EPG can be added there.
+                Spacer(Modifier.height(14.dp))
+                OwnTVTextField(userAgent, { userAgent = it }, label = "User-Agent (optional)", placeholder = "e.g. VLC/3.0.20 LibVLC/3.0.20", modifier = Modifier.fillMaxWidth())
 
-            Spacer(Modifier.height(16.dp))
-            // Auto-refresh dropdown (replaces the old binary "Refresh on startup" toggle). Off/Startup or a
-            // staleness threshold — the source is refreshed when its data is at least this old.
-            AutoRefreshRow(selected = autoRefresh) { showAutoRefreshPicker = true }
-
-            if (showDefaultToggle) {
                 Spacer(Modifier.height(16.dp))
-                ToggleRow(
-                    label = "Default playlist",
-                    desc = "Show only this playlist across the app. Turn off for all playlists; change anytime from the top bar.",
-                    checked = isDefault,
-                ) { isDefault = it }
+                // Auto-refresh dropdown (replaces the old binary "Refresh on startup" toggle). Off/Startup or a
+                // staleness threshold — the source is refreshed when its data is at least this old.
+                AutoRefreshRow(selected = autoRefresh) { showAutoRefreshPicker = true }
+
+                if (showDefaultToggle) {
+                    Spacer(Modifier.height(16.dp))
+                    ToggleRow(
+                        label = "Default playlist",
+                        desc = "Show only this playlist across the app. Turn off for all playlists; change anytime from the top bar.",
+                        checked = isDefault,
+                    ) { isDefault = it }
+                }
             }
 
             if (showContentToggles) {
@@ -259,15 +317,24 @@ fun AddSourceScreen(
                 OwnTVButton("Back", onClick = onBack, style = OwnTVButtonStyle.SECONDARY)
                 Spacer(Modifier.weight(1f))
                 OwnTVButton(
-                    label = if (editing) "Save" else "Start Import",
+                    label = when (kind) {
+                        SourceKind.CLOUD -> if (cloudListening) "Stop server" else "Open server"
+                        else -> if (editing) "Save" else "Start Import"
+                    },
                     onClick = {
                         when (kind) {
                             SourceKind.XTREAM -> onStartXtream(name, server, username, password, userAgent, epgUrl, autoRefresh, syncLive, syncMovies, syncSeries, isDefault)
+                            SourceKind.CLOUD -> {
+                                if (cloudListening) onStopCloud?.invoke() else onStartCloud?.invoke(cloudPort.toIntOrNull() ?: 8089)
+                            }
                             SourceKind.M3U -> onStartM3u(name, m3uUrl, userAgent, epgUrl, autoRefresh, isDefault)
                             SourceKind.STALKER -> onStartStalker?.invoke(name, portalUrl, mac, userAgent, autoRefresh, isDefault)
                         }
                     },
-                    enabled = canStart,
+                    enabled = when (kind) {
+                        SourceKind.CLOUD -> cloudListening || (cloudPortValid && onStartCloud != null)
+                        else -> canStart
+                    },
                 )
             }
         }

--- a/app/src/main/java/tv/own/owntv/features/setup/SetupViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/setup/SetupViewModel.kt
@@ -17,6 +17,9 @@ import tv.own.owntv.core.database.dao.SourceDao
 import tv.own.owntv.core.database.entity.ProfileEntity
 import tv.own.owntv.core.database.entity.ProfileSourceCrossRef
 import tv.own.owntv.core.database.entity.SourceEntity
+import tv.own.owntv.core.cloud.CloudServerState
+import tv.own.owntv.core.cloud.XtreamCloudListener
+import tv.own.owntv.core.cloud.XtreamCloudPayload
 import tv.own.owntv.core.network.ConnectivityObserver
 import tv.own.owntv.core.repository.SourceRepository
 import tv.own.owntv.core.sync.ImportStage
@@ -50,6 +53,10 @@ class SetupViewModel(
     private val catalogSyncScheduler: CatalogSyncScheduler,
     private val stalkerAuth: tv.own.owntv.core.stalker.StalkerAuthManager,
 ) : ViewModel() {
+
+    private val cloudListener = XtreamCloudListener()
+    private val _cloudState = MutableStateFlow<CloudServerState>(CloudServerState.Idle)
+    val cloudState: StateFlow<CloudServerState> = _cloudState.asStateFlow()
 
     // Semi-auto EPG: after the first playlist imports, offer a one-tap guide sync (with a live count) if it
     // has a guide feed.
@@ -132,6 +139,67 @@ class SetupViewModel(
                 userAgent = userAgent.trim().takeIf { it.isNotBlank() },
                 epgUrl = epgUrl.trim().takeIf { it.isNotBlank() },
             )
+        }
+    }
+
+    fun startCloudListener(port: Int = CLOUD_LISTENER_PORT) {
+        if (port !in 1..65535) {
+            _cloudState.value = CloudServerState.Failed("Enter a valid port between 1 and 65535.")
+            return
+        }
+        viewModelScope.launch {
+            _cloudState.value = CloudServerState.Starting
+            runCatching {
+                cloudListener.start(port) { payload ->
+                    handleCloudPayload(payload)
+                }
+            }.onSuccess { urls ->
+                _cloudState.value = CloudServerState.Listening(port, urls)
+            }.onFailure { error ->
+                _cloudState.value = CloudServerState.Failed(friendlyCloudError(error))
+            }
+        }
+    }
+
+    fun stopCloudListener() {
+        cloudListener.stop()
+        _cloudState.value = CloudServerState.Idle
+    }
+
+    /** Clears transient listener/import UI state when leaving the cloud/add-source step. */
+    fun clearTransientAddSourceState() {
+        stopCloudListener()
+        cancelImport()
+        dismissPendingEpg()
+        reset()
+        lastFailedSource = null
+    }
+
+    private fun handleCloudPayload(payload: XtreamCloudPayload) {
+        viewModelScope.launch {
+            val autoRefresh = runCatching { PlaylistAutoRefresh.valueOf(payload.autoRefresh) }.getOrDefault(PlaylistAutoRefresh.OFF)
+            if (payload.sourceType.equals("stalker", ignoreCase = true)) {
+                startStalker(
+                    name = payload.name,
+                    portalUrl = payload.portalUrl,
+                    mac = payload.mac,
+                    userAgent = payload.userAgent,
+                    autoRefresh = autoRefresh,
+                )
+            } else {
+                startXtream(
+                    name = payload.name,
+                    server = payload.server,
+                    username = payload.user,
+                    password = payload.pass,
+                    userAgent = payload.userAgent,
+                    epgUrl = payload.epgUrl,
+                    autoRefresh = autoRefresh,
+                    syncLive = payload.syncLive,
+                    syncMovies = payload.syncMovies,
+                    syncSeries = payload.syncSeries,
+                )
+            }
         }
     }
 
@@ -396,7 +464,20 @@ class SetupViewModel(
     private fun String.withWarnings(result: SyncResult.Success): String =
         result.warningSummary()?.let { "$this\n$it" } ?: this
 
+    private fun friendlyCloudError(t: Throwable): String = when (t) {
+        is java.net.BindException -> "Port is already in use. Pick another port."
+        is java.net.SocketException -> t.message?.takeIf { it.isNotBlank() } ?: "Could not open the local server."
+        else -> t.message?.takeIf { it.isNotBlank() } ?: "Could not open the local server."
+    }
+
+    override fun onCleared() {
+        cloudListener.close()
+        super.onCleared()
+    }
+
     private companion object {
+        private const val CLOUD_LISTENER_PORT = 8089
+
         /** Sentinel sourceId for the pre-save Stalker handshake (same as SettingsViewModel's). */
         const val STALKER_TEST_SOURCE_ID = -1L
 

--- a/app/src/main/java/tv/own/owntv/features/setup/SetupWizard.kt
+++ b/app/src/main/java/tv/own/owntv/features/setup/SetupWizard.kt
@@ -66,6 +66,7 @@ fun Onboarding(firstRun: Boolean, onDone: () -> Unit, onCancel: () -> Unit, modi
     val importState by vm.state.collectAsStateWithLifecycle()
     val progress by vm.progress.collectAsStateWithLifecycle()
     val epgSync by vm.epgSync.collectAsStateWithLifecycle()
+    val cloudState by vm.cloudState.collectAsStateWithLifecycle()
     var existing by remember { mutableStateOf<List<SourceEntity>>(emptyList()) }
     // Where "Try Again" returns to when an import fails (new source vs. linking existing).
     var importOrigin by remember { mutableStateOf(Step.ADD_SOURCE) }
@@ -74,6 +75,14 @@ fun Onboarding(firstRun: Boolean, onDone: () -> Unit, onCancel: () -> Unit, modi
 
     // Refresh the "existing playlists" availability whenever we land on the add-content step.
     LaunchedEffect(step) { if (step == Step.ADD_CONTENT) existing = runCatching { vm.availableExistingSources() }.getOrDefault(emptyList()) }
+    // Cloud import starts asynchronously from the listener callback; move forward automatically when
+    // the first import state arrives so onboarding behaves like pressing "Start Import".
+    LaunchedEffect(step, importState) {
+        if (step == Step.ADD_SOURCE && importState is SetupViewModel.ImportState.Running) {
+            importOrigin = Step.ADD_SOURCE
+            step = Step.IMPORTING
+        }
+    }
 
     Box(modifier = modifier.fillMaxSize().background(OwnTVTheme.colors.background)) {
         when (step) {
@@ -93,7 +102,11 @@ fun Onboarding(firstRun: Boolean, onDone: () -> Unit, onCancel: () -> Unit, modi
             )
             Step.ADD_CONTENT -> AddContentScreen(
                 hasExisting = existing.isNotEmpty(),
-                onNew = { step = Step.ADD_SOURCE },
+                onNew = {
+                    vm.reset()
+                    vm.dismissPendingEpg()
+                    step = Step.ADD_SOURCE
+                },
                 onExisting = { step = Step.EXISTING },
                 onImport = { backupOrigin = Step.ADD_CONTENT; step = Step.IMPORT_BACKUP },
                 onSkip = { vm.finish(onDone) },
@@ -110,7 +123,13 @@ fun Onboarding(firstRun: Boolean, onDone: () -> Unit, onCancel: () -> Unit, modi
                     importOrigin = Step.ADD_SOURCE
                     step = Step.IMPORTING
                 },
-                onBack = { step = Step.ADD_CONTENT },
+                onStartCloud = { port -> vm.startCloudListener(port) },
+                onStopCloud = { vm.stopCloudListener() },
+                cloudState = cloudState,
+                onBack = {
+                    vm.clearTransientAddSourceState()
+                    step = Step.ADD_CONTENT
+                },
                 initial = vm.lastFailedSource, // pre-fill on retry after failed import
                 showDefaultToggle = false, // first playlist in setup: nothing to be "default" over yet
             )
@@ -120,7 +139,6 @@ fun Onboarding(firstRun: Boolean, onDone: () -> Unit, onCancel: () -> Unit, modi
                 onContinue = { vm.finish(onDone) }, // playlist + its EPG synced (auto)
                 onRetry = { vm.reset(); step = importOrigin },
                 onCancel = { vm.cancelImport(); step = importOrigin },
-                onBackground = { vm.continueInBackground(onDone) }, // enter the app; sync keeps running
             )
             Step.EXISTING -> ExistingSourcesScreen(
                 sources = existing,
@@ -355,12 +373,10 @@ private fun ImportProgressScreen(
     onContinue: () -> Unit,
     onRetry: () -> Unit,
     onCancel: () -> Unit,
-    onBackground: () -> Unit,
 ) {
     val colors = OwnTVTheme.colors
     val fr = remember { FocusRequester() }
-    val bgFr = remember { FocusRequester() }
-    LaunchedEffect(Unit) { runCatching { bgFr.requestFocus() } }
+    LaunchedEffect(Unit) { runCatching { fr.requestFocus() } }
     LaunchedEffect(state) {
         if (state is SetupViewModel.ImportState.Success || state is SetupViewModel.ImportState.Failed) runCatching { fr.requestFocus() }
     }
@@ -386,15 +402,10 @@ private fun ImportProgressScreen(
                     color = colors.onSurfaceVariant,
                 )
                 Spacer(Modifier.height(24.dp))
-                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    // Enter the app right away; the import keeps running (VM is activity-scoped) and
-                    // content appears as it lands — no need to sit through a big movies/series sync.
-                    OwnTVButton("Run in background", onClick = onBackground, icon = OwnTVIcon.PLAY, modifier = Modifier.focusRequester(bgFr))
-                    OwnTVButton("Cancel", onClick = onCancel, style = OwnTVButtonStyle.SECONDARY)
-                }
+                OwnTVButton("Cancel", onClick = onCancel, style = OwnTVButtonStyle.SECONDARY, modifier = Modifier.focusRequester(fr))
                 Spacer(Modifier.height(10.dp))
                 Text(
-                    "You can start watching while the rest of the catalog loads.",
+                    "Please wait while channels and catalog data finish loading.",
                     style = MaterialTheme.typography.bodySmall,
                     color = colors.onSurfaceVariant,
                 )


### PR DESCRIPTION
<!-- Thanks for contributing to OwnTV! Please fill this in so it's easy to review. -->

## Before you open this PR (required)
<!-- These are mandatory — PRs that duplicate an existing in-app feature are closed. -->
- [x] I read the **[User Guide](https://github.com/ahXN00/OwnTV/blob/main/extras/USER_GUIDE.md)** and checked the app's **Settings** and existing **functions** — this change isn't already possible in the app.
- [x] I searched existing issues/PRs and this isn't a duplicate.

## What does this PR do?
<!-- A clear summary of the change and how it works. -->
This PR adds a companion app style onboarding flow for OwnTV that makes source setup easier from a phone or laptop on the same network.

Users can open a local server from the TV app, get a local URL, and complete source input from a web page instead of typing everything with a TV remote. The goal is a smoother setup experience, especially for first-time onboarding and multi-playlist users, while keeping OwnTV focused on user-provided content.


## Which issue / improvement does it address?
<!-- Link the issue it fixes ("Closes #12"), or describe the upgrade it makes and why it's worth it. -->
This improves usability and setup speed for TV users by reducing remote-heavy form entry and moving detailed source entry to a companion web flow over LAN. It also improves setup continuity so users can add sources in a cleaner, more predictable way.


## How was it tested?
<!-- IMPORTANT: OwnTV is a TV app — please test on a REAL Android TV / Fire TV device, not the emulator
     only. The emulator misses a lot: HDR, hardware decoding, surround/passthrough, and real remote
     (D-pad) behaviour. -->
- **Device(s) tested on:** <!-- e.g. Fire TV Stick 4K Max, NVIDIA Shield, TCL Google TV -->  Android TV emulator and TCL Android TV
- **What you exercised:** <!-- e.g. played a 4K HDR movie, switched audio track on live, EPG catch-up, D-pad nav -->Started/stopped local listener, opened local URL from another device browser, submitted source details through companion web flow, validated onboarding continuation and repeated add flow behavior, verified project build success.

## Checklist
- [x] Builds locally (`./gradlew assembleDebug`) and CI is green
- [x] **Tested on a real Android TV / Fire TV device** (not emulator only) — D-pad/remote navigation works
- [x] No user data is wiped (Room migrations stay additive)
- [x] Keeps OwnTV player-only (no bundled channels/content)
- [x] Commit messages are clear (they become the release notes)
