### PR TITLE
Add measured fps, bitrate, and dropped-frame reporting for ExoPlayer

### DIFF
--- a/app/src/main/java/tv/own/owntv/player/ExoStreamStats.kt
+++ b/app/src/main/java/tv/own/owntv/player/ExoStreamStats.kt
@@ -1,0 +1,28 @@
+package tv.own.owntv.player
+
+import androidx.media3.common.Format
+import androidx.media3.exoplayer.ExoPlayer
+
+/** Live measured bitrate once available, else the declared value, else 0. */
+fun bitrateRow(f: Format, throughputTracker: ThroughputTracker): Pair<String, String> {
+    val bps = if (throughputTracker.hasMeasured) throughputTracker.bitsPerSecond else f.bitrate.takeIf { it > 0 }?.toLong() ?: 0L
+    return "Bitrate" to "%.1f Mbps".format(bps / 1_000_000.0)
+}
+
+/** Buffered duration + dropped frames since [dropsBaseline]. We can't reset ExoPlayer's own drop
+ *  counter, so callers snapshot it per item and we subtract instead. */
+fun bufferRow(p: ExoPlayer, dropsBaseline: Int): Pair<String, String>? {
+    val drops = p.videoDecoderCounters?.let { it.ensureUpdated(); (it.droppedBufferCount - dropsBaseline).coerceAtLeast(0) }
+    val line = listOfNotNull(
+        if (p.totalBufferedDuration > 0) "%.1f s".format(p.totalBufferedDuration / 1000.0) else null,
+        drops?.let { "drops $it" },
+    ).joinToString(" · ")
+    return line.takeIf { it.isNotBlank() }?.let { "Buffer" to it }
+}
+
+/** Snapshot of the current drop count, for [bufferRow]'s baseline. */
+fun currentDroppedFrames(p: ExoPlayer?): Int {
+    val counters = p?.videoDecoderCounters ?: return 0
+    counters.ensureUpdated()
+    return counters.droppedBufferCount
+}

--- a/app/src/main/java/tv/own/owntv/player/ExoSubtitleEngine.kt
+++ b/app/src/main/java/tv/own/owntv/player/ExoSubtitleEngine.kt
@@ -90,6 +90,21 @@ class ExoSubtitleEngine(
 
     val isActive: Boolean get() = player != null
 
+    private val throughputTracker = ThroughputTracker()
+    private val fpsSample = FpsSample()
+    private var dropsBaseline = 0
+    private val analytics = object : androidx.media3.exoplayer.analytics.AnalyticsListener {
+        override fun onVideoDecoderInitialized(eventTime: androidx.media3.exoplayer.analytics.AnalyticsListener.EventTime, decoderName: String, initializedTimestampMs: Long, initializationDurationMs: Long) {
+            dropsBaseline = currentDroppedFrames(player) // a new decoder session may start its own counters
+        }
+    }
+
+    /** Declared fps if present, else a live measurement. */
+    fun currentFps(): Float? {
+        val p = player ?: return null
+        return p.videoFormat?.frameRate?.takeIf { it > 0 } ?: fpsSample.sample(p)
+    }
+
     private val listener = object : Player.Listener {
         override fun onIsPlayingChanged(isPlaying: Boolean) {
             callbacks.onPlayingChanged(isPlaying)
@@ -142,6 +157,7 @@ class ExoSubtitleEngine(
         pendingSubTypeIndex = subTypeIndex
         subtitleApplied = false
         firstFrameSeen = false
+        throughputTracker.reset(); fpsSample.resetAll(); dropsBaseline = currentDroppedFrames(player)
         mainHandler.removeCallbacks(noVideoTimeout)
         mainHandler.postDelayed(noVideoTimeout, NO_VIDEO_TIMEOUT_MS)
 
@@ -156,6 +172,7 @@ class ExoSubtitleEngine(
     private fun build(): ExoPlayer {
         val dataSource = OkHttpDataSource.Factory(okHttpClient)
             .setUserAgent(HttpClient.DEFAULT_USER_AGENT)
+            .setTransferListener(throughputTracker)
         // Match mpv's buffering depth so stability doesn't drop after the handoff (Dev refinement #3).
         val maxBufferMs = (budget.cacheSecs.toIntOrNull() ?: 30) * 1000
         val minBufferMs = (maxBufferMs / 2).coerceIn(15_000, maxBufferMs)
@@ -172,7 +189,7 @@ class ExoSubtitleEngine(
             .setLoadControl(loadControl)
             .setTrackSelector(trackSelector)
             .build()
-            .apply { addListener(listener) }
+            .apply { addListener(listener); addAnalyticsListener(analytics) }
     }
 
     /** Re-point ExoPlayer at a (re)created surface, or null to release it (surfaceDestroyed). */
@@ -316,22 +333,25 @@ class ExoSubtitleEngine(
         return listOfNotNull(title?.takeIf { it.isNotBlank() }, l).joinToString(" · ").ifBlank { "Track ${id + 1}" }
     }
 
+    fun setBitrateTrackingEnabled(enabled: Boolean) = throughputTracker.setEnabled(enabled)
+
     /** Technical readout for the stream-info overlay while this engine owns playback (main thread only —
      *  the overlay polls from composition). Mirrors [LivePreviewEngine.streamInfo]'s format. */
     fun streamInfo(): List<Pair<String, String>> {
         val p = player ?: return emptyList()
         val out = ArrayList<Pair<String, String>>()
         p.videoFormat?.let { f ->
+            val fps = currentFps()
             val line = listOfNotNull(
                 f.sampleMimeType?.substringAfterLast('/')?.let { mimeName(it) },
                 if (f.width > 0 && f.height > 0) "${f.width}×${f.height}" else null,
-                if (f.frameRate > 0) "%.2f fps".format(f.frameRate) else null,
+                fps?.let { "%.2f fps".format(it) },
             ).joinToString(" · ")
             if (line.isNotBlank()) out += "Video" to line
             when (f.colorInfo?.colorTransfer) {
                 C.COLOR_TRANSFER_ST2084 -> "HDR10 (PQ)"; C.COLOR_TRANSFER_HLG -> "HLG"; else -> null
             }?.let { out += "HDR" to it }
-            if (f.bitrate > 0) out += "Bitrate" to "%.1f Mbps".format(f.bitrate / 1_000_000.0)
+            out += bitrateRow(f, throughputTracker)
         }
         p.audioFormat?.let { f ->
             val line = listOfNotNull(
@@ -341,7 +361,7 @@ class ExoSubtitleEngine(
             ).joinToString(" · ")
             if (line.isNotBlank()) out += "Audio" to line
         }
-        if (p.totalBufferedDuration > 0) out += "Buffer" to "%.1f s".format(p.totalBufferedDuration / 1000.0)
+        bufferRow(p, dropsBaseline)?.let { out += it }
         return out
     }
 

--- a/app/src/main/java/tv/own/owntv/player/FpsSample.kt
+++ b/app/src/main/java/tv/own/owntv/player/FpsSample.kt
@@ -1,0 +1,73 @@
+package tv.own.owntv.player
+
+import android.os.SystemClock
+import androidx.media3.exoplayer.ExoPlayer
+import kotlin.math.abs
+
+/**
+ * Give each independently-timed poller its own instance to avoid corruption.
+ */
+class FpsSample {
+    var renderedCount = 0
+    var atMs = 0L
+    var lastFps: Float? = null
+
+    /** True once a reading has actually matched a standard rate — a window that caught a brief stall
+     *  produces an off-rate value instead, which callers can use as a signal to sample again. */
+    var confident = false
+        private set
+
+    /** Takes one sample via [p]'s decoder counters and immediately publishes it to [lastFps]. */
+    fun sample(p: ExoPlayer): Float? {
+        peek(p)?.let { lastFps = it }
+        return lastFps
+    }
+
+    /** Like [sample], but returns the fresh reading (if any) without publishing it to [lastFps] — for a
+     *  caller that wants to judge [confident] before deciding whether to [publish] it. */
+    fun peek(p: ExoPlayer): Float? {
+        val counters = p.videoDecoderCounters ?: return null
+        counters.ensureUpdated()
+        val rendered = counters.renderedOutputBufferCount
+        if (rendered == 0) return null
+        val now = SystemClock.elapsedRealtime()
+        var fresh: Float? = null
+        if (atMs > 0) {
+            val dFrames = rendered - renderedCount
+            val dSecs = (now - atMs) / 1000f
+            if (dFrames > 0 && dSecs > 0) {
+                val raw = dFrames / dSecs
+                fresh = snapToStandardRate(raw)
+                confident = fresh != raw
+            }
+        }
+        renderedCount = rendered
+        atMs = now
+        return fresh
+    }
+
+    fun publish(fps: Float) {
+        lastFps = fps
+    }
+
+    /** Fresh window on the next measurement; keeps [lastFps] so a display doesn't blank mid-remeasure. */
+    fun resetWindow() {
+        atMs = 0L
+    }
+
+    /** Full reset for a genuine channel/file change. */
+    fun resetAll() {
+        renderedCount = 0
+        atMs = 0L
+        lastFps = null
+        confident = false
+    }
+
+    private companion object {
+        val STANDARD_FRAME_RATES = floatArrayOf(24f, 25f, 30f, 50f, 60f, 90f, 120f)
+        fun snapToStandardRate(fps: Float): Float {
+            val nearest = STANDARD_FRAME_RATES.minByOrNull { abs(it - fps) } ?: return fps
+            return if (abs(nearest - fps) <= nearest * 0.05f) nearest else fps
+        }
+    }
+}

--- a/app/src/main/java/tv/own/owntv/player/LivePreviewEngine.kt
+++ b/app/src/main/java/tv/own/owntv/player/LivePreviewEngine.kt
@@ -3,6 +3,7 @@ package tv.own.owntv.player
 import android.content.Context
 import android.view.Surface
 import androidx.media3.common.C
+import androidx.media3.common.Format
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
@@ -133,6 +134,9 @@ class LivePreviewEngine(
     // (e.g. 0x80001000); AudioSink errors name the audio failure. Reset per load, preferred when present.
     @Volatile private var lastCodecError: String? = null
     @Volatile private var lastVideoDecoder: String? = null // e.g. "OMX.realtek.video.decoder", for the spec line
+    private val throughputTracker = ThroughputTracker()
+    private val fpsSample = FpsSample()
+    private var dropsBaseline = 0
     private val analytics = object : androidx.media3.exoplayer.analytics.AnalyticsListener {
         override fun onVideoCodecError(eventTime: androidx.media3.exoplayer.analytics.AnalyticsListener.EventTime, videoCodecError: Exception) {
             lastCodecError = codecDetail("video", videoCodecError)
@@ -145,6 +149,7 @@ class LivePreviewEngine(
         }
         override fun onVideoDecoderInitialized(eventTime: androidx.media3.exoplayer.analytics.AnalyticsListener.EventTime, decoderName: String, initializedTimestampMs: Long, initializationDurationMs: Long) {
             lastVideoDecoder = decoderName
+            dropsBaseline = currentDroppedFrames(player) // a new decoder session may start its own counters
         }
     }
 
@@ -174,13 +179,13 @@ class LivePreviewEngine(
             val line = listOfNotNull(
                 f.sampleMimeType?.substringAfterLast('/')?.let { mimeName(it) },
                 if (f.width > 0 && f.height > 0) "${f.width}×${f.height}" else null,
-                if (f.frameRate > 0) "%.2f fps".format(f.frameRate) else null,
+                displayFps(f)?.let { "%.2f fps".format(it) },
             ).joinToString(" · ")
             if (line.isNotBlank()) out += "Video" to line
             when (f.colorInfo?.colorTransfer) {
                 C.COLOR_TRANSFER_ST2084 -> "HDR10 (PQ)"; C.COLOR_TRANSFER_HLG -> "HLG"; else -> null
             }?.let { out += "HDR" to it }
-            if (f.bitrate > 0) out += "Bitrate" to "%.1f Mbps".format(f.bitrate / 1_000_000.0)
+            out += bitrateRow(f, throughputTracker)
         }
         out += "Decoder" to "ExoPlayer (hardware)"
         p.audioFormat?.let { f ->
@@ -191,7 +196,7 @@ class LivePreviewEngine(
             ).joinToString(" · ")
             if (line.isNotBlank()) out += "Audio" to line
         }
-        if (p.totalBufferedDuration > 0) out += "Buffer" to "%.1f s".format(p.totalBufferedDuration / 1000.0)
+        bufferRow(p, dropsBaseline)?.let { out += it }
         currentUrl?.let { out += "Source" to HttpClient.redactUrl(it) }
         return out
     }
@@ -202,13 +207,23 @@ class LivePreviewEngine(
         p.videoFormat?.let { f ->
             if (f.width > 0 && f.height > 0) aspectLabel(f.width, f.height)?.let { chips += it }
             qualityLabel(f.height)?.let { chips += it }
-            if (f.frameRate > 0) chips += "${Math.round(f.frameRate)} FPS"
+            displayFps(f)?.let { chips += "${Math.round(it)} FPS" }
         }
         p.audioFormat?.let { f ->
             (when (f.channelCount) { 1 -> "MONO"; 2 -> "STEREO"; 6 -> "5.1"; 8 -> "7.1"; else -> null })?.let { chips += it }
         }
         _streamChips.value = chips
     }
+
+    private fun displayFps(f: Format) = f.frameRate.takeIf { it > 0 } ?: fpsSample.lastFps
+
+    override fun refreshStreamChips() = ensureFpsMeasurement()
+    override fun setBitrateTrackingEnabled(enabled: Boolean) = throughputTracker.setEnabled(enabled)
+
+    private fun ensureFpsMeasurement() {
+        if ((player?.videoFormat?.frameRate ?: 0f) <= 0f) restartFpsMeasurement()
+    }
+
     private fun aspectLabel(w: Int, h: Int): String? {
         if (w <= 0 || h <= 0) return null
         val r = w.toFloat() / h
@@ -285,6 +300,25 @@ class LivePreviewEngine(
     private var everRendered = false
     private var videoRenderer: Renderer? = null
     private val frameListener = VideoFrameMetadataListener { _, _, _, _ -> frameCounter.incrementAndGet() }
+    private var fpsAttempts = 0
+    private val fpsFastRefresh: Runnable = Runnable {
+        val fresh = player?.let { fpsSample.peek(it) }
+        fpsAttempts++
+        // Retry until a reading matches a standard rate, capped so a genuinely unusual one doesn't retry forever.
+        val done = fpsAttempts >= FPS_MAX_ATTEMPTS || (fpsAttempts >= 2 && fpsSample.confident)
+        if (done) {
+            fresh?.let { fpsSample.publish(it) }
+            updateStreamChips()
+        } else {
+            mainHandler.postDelayed(fpsFastRefresh, FPS_TICK_MS)
+        }
+    }
+    private fun restartFpsMeasurement() {
+        mainHandler.removeCallbacks(fpsFastRefresh)
+        fpsSample.resetWindow() // keeps the old reading visible until replaced
+        fpsAttempts = 0
+        mainHandler.postDelayed(fpsFastRefresh, FPS_BASELINE_MS)
+    }
     private var lastProgressPos = -1L
     private var lastProgressWallMs = 0L // SystemClock.elapsedRealtime() of the last forward position move
     private var frozenChecks = 0
@@ -379,6 +413,7 @@ class LivePreviewEngine(
                     frameCounter.set(0); lastFrameCount = 0; everRendered = false; lastProgressPos = -1L; lastProgressWallMs = 0L; frozenChecks = 0
                     readySinceMs = android.os.SystemClock.elapsedRealtime(); noVideoTriggered = false
                     mainHandler.removeCallbacks(progressWatchdog); mainHandler.postDelayed(progressWatchdog, PROGRESS_CHECK_MS)
+                    ensureFpsMeasurement()
                 }
                 Player.STATE_ENDED -> {
                     // A live HLS feed shouldn't legitimately "end" — this is a stall/hiccup (e.g. a stray
@@ -441,9 +476,12 @@ class LivePreviewEngine(
                 _videoSize.value = videoSize.width to videoSize.height
             }
             updateStreamChips()
+            ensureFpsMeasurement()
         }
 
-        override fun onTracksChanged(tracks: androidx.media3.common.Tracks) { rebuildTracks(tracks); updateStreamChips() }
+        override fun onTracksChanged(tracks: androidx.media3.common.Tracks) {
+            rebuildTracks(tracks); updateStreamChips(); ensureFpsMeasurement()
+        }
         override fun onCues(cueGroup: androidx.media3.common.text.CueGroup) { _cues.value = cueGroup.cues }
 
         override fun onPlayerError(error: PlaybackException) {
@@ -496,7 +534,7 @@ class LivePreviewEngine(
         this.muted = muted
         currentUrl = url
         hasPlayed = false; retryCount = 0; reconnectPending = false; gaveUp = false
-        mainHandler.removeCallbacks(stallWatchdog); mainHandler.removeCallbacks(progressWatchdog)
+        mainHandler.removeCallbacks(stallWatchdog); mainHandler.removeCallbacks(progressWatchdog); mainHandler.removeCallbacks(fpsFastRefresh)
         audioTrackList = emptyList(); audioSelections = emptyList(); _audioCount.value = 0
         textTrackList = emptyList(); textSelections = emptyList(); _subCount.value = 0
         _subtitleOn.value = false; _cues.value = emptyList(); _audioUnsupported.value = false
@@ -506,6 +544,7 @@ class LivePreviewEngine(
         _error.value = null
         _errorInfo.value = null
         frameCounter.set(0); lastFrameCount = 0; everRendered = false; lastProgressPos = -1L; lastProgressWallMs = 0L; frozenChecks = 0
+        throughputTracker.reset(); fpsSample.resetAll(); dropsBaseline = currentDroppedFrames(player)
         _currentMeta.value = meta
         _volume.value = if (muted) 0 else 100
         _state.value = State.LOADING
@@ -564,7 +603,7 @@ class LivePreviewEngine(
         stoppingIntentionally = true
         currentUrl = null
         hasPlayed = false; retryCount = 0; reconnectPending = false; gaveUp = false
-        mainHandler.removeCallbacks(stallWatchdog); mainHandler.removeCallbacks(progressWatchdog)
+        mainHandler.removeCallbacks(stallWatchdog); mainHandler.removeCallbacks(progressWatchdog); mainHandler.removeCallbacks(fpsFastRefresh)
         frameCounter.set(0); lastFrameCount = 0; everRendered = false; lastProgressPos = -1L; frozenChecks = 0
         audioTrackList = emptyList(); audioSelections = emptyList(); _audioCount.value = 0
         textTrackList = emptyList(); textSelections = emptyList(); _subCount.value = 0
@@ -599,7 +638,7 @@ class LivePreviewEngine(
      *  resolved URL — a [reconnectUrlProvider] mints a fresh one first (null/absent → replay as-is,
      *  which is correct for M3U/Xtream and direct-URL Stalker portals). */
     private fun reconnect(reason: String) {
-        mainHandler.removeCallbacks(stallWatchdog); mainHandler.removeCallbacks(progressWatchdog)
+        mainHandler.removeCallbacks(stallWatchdog); mainHandler.removeCallbacks(progressWatchdog); mainHandler.removeCallbacks(fpsFastRefresh)
         val p = player
         val url = currentUrl
         if (p == null || url == null || retryCount >= MAX_RECONNECTS) {
@@ -756,6 +795,7 @@ class LivePreviewEngine(
     private fun httpDataSourceFor(ua: String): OkHttpDataSource.Factory {
         if (ua != dataSourceForUa || cachedHttpDataSource == null) {
             cachedHttpDataSource = OkHttpDataSource.Factory(okHttpClient).setUserAgent(ua)
+                .setTransferListener(throughputTracker)
             // Raw MPEG-TS (typical Xtream live ".ts"): providers rarely declare caption descriptors in
             // the PMT, so the stock TS extractor never exposes the embedded CEA-608 track (#57).
             // FLAG_OVERRIDE_CAPTION_DESCRIPTORS makes it expose the standard CC1 track regardless; the
@@ -838,5 +878,8 @@ class LivePreviewEngine(
         private const val FROZEN_LIMIT = 3          // picture frozen this many polls (~7.5s) == a dropped feed
         private const val FREEZE_TIMEOUT_MS = 8_000L // zero forward progress this long while READY == dead feed
         private const val NO_VIDEO_TIMEOUT_MS = 8_000L // video track present, zero frames rendered this long == "audio plays, no picture"
+        private const val FPS_BASELINE_MS = 500L
+        private const val FPS_TICK_MS = 1_000L
+        private const val FPS_MAX_ATTEMPTS = 5
     }
 }

--- a/app/src/main/java/tv/own/owntv/player/OwnTVPlayer.kt
+++ b/app/src/main/java/tv/own/owntv/player/OwnTVPlayer.kt
@@ -118,6 +118,7 @@ class OwnTVPlayer(
         const val SURFACE_HANDOFF_MS = 500L        // shorter release wait on the surface-attach handoff paths
         const val CORE_RESET_SETTLE_MS = 500L      // fresh mpv core + recreated surface settle after a hard reset
         const val EXO_POSITION_TICK_MS = 500L      // ExoPlayer position/duration emit interval while Exo is active
+        const val EXO_FPS_RECHECK_MS = 1_500L      // retry the fps chip once a measurement window can have elapsed
         const val SURROUND_CHECK_MS = 7_000L       // wait before verifying surround audio actually produces sound
         const val DECODE_CHECK_MS = 4_000L         // wait before verifying video decode actually produces frames
         const val LIVE_RECONNECT_DELAY_MS = 3_500L // pause before reconnecting a dropped live stream
@@ -625,8 +626,9 @@ class OwnTVPlayer(
         _videoRes.value?.let { base += it }
         val knownFps = _videoFps.value
         val m = mpv
-        if (m == null) {
-            knownFps?.let { if (it > 0) base += "${Math.round(it)} FPS" }
+        // mpv stays alive (just stopped/surfaceless) during a handoff, so check exoActive, not m == null.
+        if (exoActive || m == null) {
+            (knownFps ?: exoEngine?.currentFps())?.let { if (it > 0) base += "${Math.round(it)} FPS" }
             _streamChips.value = base
             return
         }
@@ -741,6 +743,9 @@ class OwnTVPlayer(
             if (height > 0) lastVideoHeightPx = height
             updateAspect()
             _videoRes.value = resolutionLabel(height)
+            updateStreamChips() // onVideoFps may never fire; don't wait on it for resolution/measured fps
+            val gen = loadGeneration // a measured fps needs a rendered-frame window, so retry once it can exist
+            scope.launch { delay(EXO_FPS_RECHECK_MS); if (gen == loadGeneration && exoActive) updateStreamChips() }
         }
         override fun onPositionDuration(positionMs: Long, durationMs: Long) {
             _position.value = positionMs
@@ -1917,6 +1922,12 @@ class OwnTVPlayer(
     fun audioTracks(): List<TrackOption> = _audioTrackList.value
     fun textTracks(): List<TrackOption> = _subTrackList.value
 
+    fun setBitrateTrackingEnabled(enabled: Boolean) {
+        exoEngine?.setBitrateTrackingEnabled(enabled)
+    }
+
+    fun refreshStreamChips() = updateStreamChips()
+
     /** Technical readout for the stream-info overlay, read live from whichever engine owns playback —
      *  mpv (libmpv get_property is thread-safe) or ExoPlayer (image-sub handoff / engine fallback /
      *  ExoPlayer-preferred; the overlay polls from composition, i.e. the main thread Exo requires). */
@@ -2068,6 +2079,8 @@ class OwnTVPlayer(
     }
 
     override fun eventProperty(property: String, value: Long) {
+        // mpv's stop() during a handoff to Exo fires stale events afterward that would overwrite state Exo already set.
+        if (exoActive) return
         when (property) {
             "time-pos" -> {
                 _position.value = value * 1000
@@ -2154,6 +2167,7 @@ class OwnTVPlayer(
     }
 
     override fun eventProperty(property: String, value: Boolean) {
+        if (exoActive) return
         when (property) {
             "pause" -> _isPlaying.value = !value
             "paused-for-cache" -> _buffering.value = value
@@ -2180,6 +2194,7 @@ class OwnTVPlayer(
         }
     }
     override fun eventProperty(property: String, value: Double) {
+        if (exoActive) return
         if (property == "speed") _speed.value = value
         if (property == "container-fps" && value > 0) _videoFps.value = value.toFloat()
     }
@@ -2187,6 +2202,8 @@ class OwnTVPlayer(
     override fun event(eventId: Int) {
         when (eventId) {
             MPVLib.MpvEvent.MPV_EVENT_FILE_LOADED -> {
+                // Stale FILE_LOADED from mpv's own stop() during a handoff to Exo, not a real load.
+                if (exoActive) return
                 fileLoaded = true
                 val pendingStops = pendingStopEndFiles.getAndSet(0)
                 if (pendingStops > 0) {

--- a/app/src/main/java/tv/own/owntv/player/PlaybackEngine.kt
+++ b/app/src/main/java/tv/own/owntv/player/PlaybackEngine.kt
@@ -19,6 +19,10 @@ interface PlaybackEngine {
     val videoRes: StateFlow<String?>
     /** Up-to-4 mini stream chips (aspect · resolution · fps · audio) for the player top bar. */
     val streamChips: StateFlow<List<String>> get() = NO_CHIPS
+    /** Re-check [streamChips] now. */
+    fun refreshStreamChips() {}
+    /** Bitrate is only ever displayed in the debug overlay — enable tracking only while it's open. */
+    fun setBitrateTrackingEnabled(enabled: Boolean) {}
     /** Short label of the engine currently decoding ("MPV" / "EXO"), shown as the first top-bar chip.
      *  Null = don't show one. */
     val engineChip: StateFlow<String?> get() = NULL_STRING
@@ -105,6 +109,8 @@ class MpvPlaybackEngine(private val p: OwnTVPlayer) : PlaybackEngine {
     override fun audioTracks() = p.audioTracks()
     override fun textTracks() = p.textTracks()
     override fun streamInfo() = p.streamInfo()
+    override fun setBitrateTrackingEnabled(enabled: Boolean) = p.setBitrateTrackingEnabled(enabled)
+    override fun refreshStreamChips() = p.refreshStreamChips()
     override fun setSpeed(speed: Double) = p.setSpeed(speed)
     override fun adjustAudioDelay(deltaMs: Int) = p.adjustAudioDelay(deltaMs)
     override fun previous() = p.previous()

--- a/app/src/main/java/tv/own/owntv/player/PlayerHud.kt
+++ b/app/src/main/java/tv/own/owntv/player/PlayerHud.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -167,6 +168,12 @@ fun PlayerHud(
     } }
 
     LaunchedEffect(forceShow) { if (forceShow) controlsVisible = true }
+    LaunchedEffect(controlsVisible, player) { if (controlsVisible) player.refreshStreamChips() }
+    DisposableEffect(showInfo, player) {
+        if (showInfo) player.refreshStreamChips()
+        player.setBitrateTrackingEnabled(showInfo)
+        onDispose { player.setBitrateTrackingEnabled(false) }
+    }
     LaunchedEffect(controlsVisible, wakeTick, forceShow, inert) {
         // Don't auto-hide under an overlay — hiding is what triggers the catch-all focus grab below.
         if (controlsVisible && !forceShow && !inert) { delay(4500); controlsVisible = false }

--- a/app/src/main/java/tv/own/owntv/player/ThroughputTracker.kt
+++ b/app/src/main/java/tv/own/owntv/player/ThroughputTracker.kt
@@ -1,0 +1,63 @@
+package tv.own.owntv.player
+
+import android.os.SystemClock
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.TransferListener
+
+/**
+ * Live network throughput (bits/sec): bytes since [bitsPerSecond] was last read, divided by time since
+ * then. Assumes a single regular poller (the debug overlay) — a second reader would steal bytes meant
+ * for the first. Starts disabled — call [setEnabled] to activate.
+ */
+class ThroughputTracker : TransferListener {
+    private var pendingBytes = 0L
+    private var lastReadMs = 0L
+    @Volatile private var enabled = false
+    @Volatile private var everTransferred = false
+
+    /** True once any byte has been transferred while enabled — distinguishes "never measured" from
+     *  "measured, currently 0". */
+    val hasMeasured: Boolean
+        get() = everTransferred
+
+    val bitsPerSecond: Long
+        get() = readAndReset()
+
+    override fun onTransferInitializing(source: DataSource, dataSpec: DataSpec, isNetwork: Boolean) {}
+    override fun onTransferStart(source: DataSource, dataSpec: DataSpec, isNetwork: Boolean) {}
+    override fun onTransferEnd(source: DataSource, dataSpec: DataSpec, isNetwork: Boolean) {}
+
+    override fun onBytesTransferred(source: DataSource, dataSpec: DataSpec, isNetwork: Boolean, bytesTransferred: Int) {
+        if (!enabled) return
+        everTransferred = true
+        synchronized(this) { pendingBytes += bytesTransferred }
+    }
+
+    @Synchronized
+    private fun readAndReset(): Long {
+        val now = SystemClock.elapsedRealtime()
+        if (lastReadMs == 0L) {
+            lastReadMs = now
+            return 0L
+        }
+        val elapsedMs = now - lastReadMs
+        val bps = if (elapsedMs > 0) pendingBytes * 8_000 / elapsedMs else 0L
+        pendingBytes = 0L
+        lastReadMs = now
+        return bps
+    }
+
+    /** Enabling starts fresh rather than counting bytes from whenever tracking was last on. */
+    fun setEnabled(enabled: Boolean) {
+        this.enabled = enabled
+        if (enabled) reset()
+    }
+
+    @Synchronized
+    fun reset() {
+        pendingBytes = 0L
+        lastReadMs = 0L
+        everTransferred = false
+    }
+}


### PR DESCRIPTION
## Before you open this PR (required)
<!-- These are mandatory — PRs that duplicate an existing in-app feature are closed. -->
- [x] I read the **[User Guide](https://github.com/ahXN00/OwnTV/blob/main/extras/USER_GUIDE.md)** and checked the app's **Settings** and existing **functions** — this change isn't already possible in the app.
- [x] I searched existing issues/PRs and this isn't a duplicate.

## What does this PR do?
ExoPlayer's Format.frameRate/bitrate are usually undeclared for raw MPEG-TS streams, leaving the debug overlay and top-left chips blank whereas mpv shows live values. This PR adds measurement of fps from decoder-rendered-frame deltas (FpsSample), bitrate from actual transferred bytes (ThroughputTracker), and surfaces dropped frames since the last decoder session — shared between LivePreviewEngine and ExoSubtitleEngine via ExoStreamStats.
In addition to debug scenarios, the fps chip in preview window is also useful for stream selection.

Also fixes some minor pre-existing bugs in the mpv<->ExoPlayer handoff that were blocking correct resolution/fps display for VOD playback on Exo.

Care is taken to ensure measurements only made when data actually displayed, and efficient measurements with negligible CPU impact.

## Which issue / improvement does it address?
See above

## How was it tested?
Hisense TV running Google TV 12.
Checked LiveTV preview chips, LiveTV player info and debug overlay, VOD player info and debug overlay when Exo selected
Verified info against same streams when mpv is used. 

## Checklist
- [x] Builds locally (`./gradlew assembleDebug`) and CI is green
- [x] **Tested on a real Android TV / Fire TV device** (not emulator only) — D-pad/remote navigation works
- [x] No user data is wiped (Room migrations stay additive)
- [x] Keeps OwnTV player-only (no bundled channels/content)
- [x] Commit messages are clear (they become the release notes)
