### PR TITLE
Group categories by provider + configurable default for new categories

### DIFF
--- a/app/src/main/java/tv/own/owntv/core/backup/BackupManager.kt
+++ b/app/src/main/java/tv/own/owntv/core/backup/BackupManager.kt
@@ -111,6 +111,7 @@ class BackupManager(
                         },
                     )
                     put("homeConfigs", filterByProfile(settings.exportHomeConfigs(), pidKeys))
+                    put("hideNewCategories", filterByProfile(settings.exportHideNewCategories(), pidKeys))
                     // User-corrected TMDB titles/years. Keyed by "type:sourceId:remoteId|name" — source ids
                     // are preserved on restore, so the map rides verbatim. Optional block; older readers ignore it.
                     tmdbOverrides.exportJson().takeIf { it.isNotBlank() }?.let { put("tmdbOverrides", it) }
@@ -170,6 +171,7 @@ class BackupManager(
             if (
                 root.optJSONObject("customizations")?.keys()?.hasNext() == true ||
                 root.optJSONObject("homeConfigs")?.keys()?.hasNext() == true ||
+                root.optJSONObject("hideNewCategories")?.keys()?.hasNext() == true ||
                 root.optString("tmdbOverrides").isNotBlank()
             ) out += Section.CUSTOMIZE
             if (root.optJSONObject("settings")?.keys()?.hasNext() == true) out += Section.SETTINGS
@@ -366,6 +368,7 @@ class BackupManager(
                     count += cust.size
                 }
                 root.optJSONObject("homeConfigs")?.let { settings.importHomeConfigs(remapKeys(it, profileIdMap), existingProfileIds) }
+                root.optJSONObject("hideNewCategories")?.let { settings.importHideNewCategories(remapKeys(it, profileIdMap), existingProfileIds) }
                 // Custom TMDB names: merge (backup wins per key), then drop any cached match/details stored
                 // under the imported keys so the corrected title is re-fetched instead of showing stale art.
                 // Keys embed the source id ("movie:<sourceId>:…") — remap before merging.

--- a/app/src/main/java/tv/own/owntv/core/database/dao/CategoryDao.kt
+++ b/app/src/main/java/tv/own/owntv/core/database/dao/CategoryDao.kt
@@ -21,7 +21,14 @@ interface CategoryDao {
     @Update
     suspend fun updateAll(categories: List<CategoryEntity>)
 
-    @Query("SELECT * FROM categories WHERE sourceId IN (:sourceIds) AND mediaType = :type ORDER BY sortOrder ASC, name ASC")
+    /** Grouped by provider (source creation order) first, so multi-source lists don't interleave two
+     *  providers' categories. */
+    @Query(
+        "SELECT categories.* FROM categories " +
+            "JOIN sources ON sources.id = categories.sourceId " +
+            "WHERE categories.sourceId IN (:sourceIds) AND categories.mediaType = :type " +
+            "ORDER BY sources.createdAt ASC, categories.sortOrder ASC, categories.name ASC",
+    )
     fun observe(sourceIds: List<Long>, type: MediaType): Flow<List<CategoryEntity>>
 
     @Query("SELECT * FROM categories WHERE id = :id")

--- a/app/src/main/java/tv/own/owntv/core/sync/StalkerSyncer.kt
+++ b/app/src/main/java/tv/own/owntv/core/sync/StalkerSyncer.kt
@@ -87,7 +87,7 @@ internal class StalkerSyncer(
         }.filter { it.id.isNotBlank() && it.id != "*" }
         Log.i(TAG, "$label genres sourceId=${s.id} count=${genres.size}")
 
-        val categories = support.refreshCategories(s, MediaType.LIVE, genres.map { XtCategory(it.id, it.title) })
+        val categories = support.refreshCategories(s, MediaType.LIVE, genres.map { XtCategory(it.id, it.title) }, stats)
         val catMap = categories.idsByRemoteId
 
         val insertFn: suspend (List<ChannelEntity>) -> UpsertStats = if (freshSource) {
@@ -168,7 +168,7 @@ internal class StalkerSyncer(
             }
             if (!freshSource && remoteIds != null) {
                 support.pruneRemoteIds(label, s.id, remoteIds, adapter.remoteIdsForSource, adapter.deleteByRemoteIds)
-                support.pruneCategories(s.id, MediaType.LIVE, categories.seenRemoteIds, label)
+                support.pruneCategories(s.id, MediaType.LIVE, categories.seenRemoteIds, label, stats)
             }
         }
 
@@ -250,7 +250,7 @@ internal class StalkerSyncer(
         val cats = auth.withAuthRetry(creds) { fetchCategories(it) }
             .filter { it.id.isNotBlank() && it.id != "*" }
         Log.i(TAG, "$label categories sourceId=${s.id} count=${cats.size}")
-        val categories = support.refreshCategories(s, mediaType, cats.map { XtCategory(it.id, it.title) })
+        val categories = support.refreshCategories(s, mediaType, cats.map { XtCategory(it.id, it.title) }, stats)
         val catMap = categories.idsByRemoteId
 
         val insertFn: suspend (List<T>) -> UpsertStats = if (freshSource) {
@@ -409,7 +409,7 @@ internal class StalkerSyncer(
                 }
                 if (pageFailures.get() == 0) {
                     support.pruneRemoteIds(label, s.id, remoteIds, adapter.remoteIdsForSource, adapter.deleteByRemoteIds)
-                    support.pruneCategories(s.id, mediaType, categories.seenRemoteIds, label)
+                    support.pruneCategories(s.id, mediaType, categories.seenRemoteIds, label, stats)
                 } else {
                     // Failed pages mean this pass's remoteIds set is incomplete; pruning against it would
                     // delete every item of the missing pages/categories as "stale" (mirrors Xtream's

--- a/app/src/main/java/tv/own/owntv/core/sync/SyncManager.kt
+++ b/app/src/main/java/tv/own/owntv/core/sync/SyncManager.kt
@@ -10,12 +10,14 @@ import tv.own.owntv.core.database.dao.CategoryDao
 import tv.own.owntv.core.database.dao.ChannelDao
 import tv.own.owntv.core.database.dao.MovieDao
 import tv.own.owntv.core.database.dao.SeriesDao
+import tv.own.owntv.core.customize.CustomizationStore
 import tv.own.owntv.core.database.dao.SourceDao
 import tv.own.owntv.core.database.entity.SourceEntity
 import tv.own.owntv.core.model.SourceType
 import tv.own.owntv.core.network.HttpClient
 import tv.own.owntv.core.parser.M3uParser
 import tv.own.owntv.core.parser.XtreamClient
+import tv.own.owntv.features.settings.data.SettingsRepository
 
 /**
  * Imports a source into the database — a thin dispatcher over the per-source-type syncers
@@ -39,8 +41,10 @@ class SyncManager(
     stalkerClient: tv.own.owntv.core.stalker.StalkerClient,
     stalkerAuth: tv.own.owntv.core.stalker.StalkerAuthManager,
     private val activityTracker: SyncActivityTracker,
+    customize: CustomizationStore,
+    settings: SettingsRepository,
 ) {
-    private val support = SyncSupport(categoryDao, channelDao, movieDao, seriesDao)
+    private val support = SyncSupport(categoryDao, channelDao, movieDao, seriesDao, sourceDao, customize, settings)
     private val xtreamSyncer = XtreamSyncer(xtream, bulkInsertHelper, support)
     private val m3uSyncer = M3uSyncer(context, sourceDao, categoryDao, channelDao, movieDao, seriesDao, m3u, http, bulkInsertHelper)
     private val stalkerSyncer = StalkerSyncer(stalkerClient, stalkerAuth, bulkInsertHelper, support, sourceDao)

--- a/app/src/main/java/tv/own/owntv/core/sync/SyncManager.kt
+++ b/app/src/main/java/tv/own/owntv/core/sync/SyncManager.kt
@@ -90,7 +90,11 @@ class SyncManager(
                     Log.d(TAG, "markSynced sourceId=${source.id} ms=${SystemClock.elapsedRealtime() - markStartedAt}")
                 }
                 progress.completeAll()
-                SyncResult.Success(stats.warnings())
+                SyncResult.Success(
+                    warnings = stats.warnings(),
+                    categoriesAdded = stats.processedCounts[SyncSupport.CATEGORIES_ADDED_KEY] ?: 0,
+                    categoriesRemoved = stats.processedCounts[SyncSupport.CATEGORIES_REMOVED_KEY] ?: 0,
+                )
             } catch (c: CancellationException) {
                 throw c
             } catch (e: Exception) {

--- a/app/src/main/java/tv/own/owntv/core/sync/SyncStatus.kt
+++ b/app/src/main/java/tv/own/owntv/core/sync/SyncStatus.kt
@@ -22,12 +22,25 @@ enum class SyncPhase(val label: String) {
 
 /** Terminal result of a sync run. */
 sealed interface SyncResult {
-    data class Success(val warnings: List<SyncWarning> = emptyList()) : SyncResult {
+    data class Success(
+        val warnings: List<SyncWarning> = emptyList(),
+        /** Category churn on a resync (always 0 on a source's first sync, where everything is "new"). */
+        val categoriesAdded: Int = 0,
+        val categoriesRemoved: Int = 0,
+    ) : SyncResult {
         fun warningSummary(): String? =
             warnings.takeIf { it.isNotEmpty() }?.joinToString(
                 prefix = "Imported with warnings: ",
                 separator = " · ",
             ) { "${it.label} failed" }
+
+        fun categoryChangeSummary(): String? {
+            if (categoriesAdded == 0 && categoriesRemoved == 0) return null
+            return listOfNotNull(
+                "$categoriesAdded categories added".takeIf { categoriesAdded > 0 },
+                "$categoriesRemoved removed".takeIf { categoriesRemoved > 0 },
+            ).joinToString(", ")
+        }
     }
 
     data object Cancelled : SyncResult

--- a/app/src/main/java/tv/own/owntv/core/sync/SyncSupport.kt
+++ b/app/src/main/java/tv/own/owntv/core/sync/SyncSupport.kt
@@ -6,11 +6,15 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.first
+import tv.own.owntv.core.customize.CustomizationStore
+import tv.own.owntv.core.customize.CustomizeKeys
 import tv.own.owntv.core.database.BulkInsertHelper
 import tv.own.owntv.core.database.dao.CategoryDao
 import tv.own.owntv.core.database.dao.ChannelDao
 import tv.own.owntv.core.database.dao.MovieDao
 import tv.own.owntv.core.database.dao.SeriesDao
+import tv.own.owntv.core.database.dao.SourceDao
 import tv.own.owntv.core.database.entity.CategoryEntity
 import tv.own.owntv.core.database.entity.ChannelEntity
 import tv.own.owntv.core.database.entity.ContentHashProjection
@@ -19,6 +23,7 @@ import tv.own.owntv.core.database.entity.SeriesEntity
 import tv.own.owntv.core.database.entity.SourceEntity
 import tv.own.owntv.core.database.entity.computeContentHash
 import tv.own.owntv.core.model.MediaType
+import tv.own.owntv.features.settings.data.SettingsRepository
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -33,6 +38,9 @@ internal class SyncSupport(
     channelDao: ChannelDao,
     movieDao: MovieDao,
     seriesDao: SeriesDao,
+    private val sourceDao: SourceDao,
+    private val customize: CustomizationStore,
+    private val settings: SettingsRepository,
 ) {
     val channelAdapter = ContentAdapter<ChannelEntity>(
         remoteIdOf = { it.remoteId },
@@ -143,6 +151,10 @@ internal class SyncSupport(
         parsed: List<tv.own.owntv.core.parser.XtCategory>,
     ): CategoryRefresh {
         val start = SystemClock.elapsedRealtime()
+        // s.lastSyncAt never changes during a sync run (SyncManager stamps it only after the syncer
+        // returns), so this is safe to derive here rather than threading a freshSource param through
+        // every call site.
+        val freshSource = s.lastSyncAt == null
         Log.d(TAG, "refreshCategories start sourceId=${s.id} type=$type count=${parsed.size}")
         val uniqueCategories = parsed.distinctBy { it.id }
         val existing = existingCategoriesByRemoteId(s.id, type, uniqueCategories.map { it.id })
@@ -165,6 +177,11 @@ internal class SyncSupport(
                 "dbInserted=${upsert.stats.inserted} dbUpdated=${upsert.stats.updated} " +
                 "dbSkipped=${upsert.stats.skippedUnchanged} ms=${SystemClock.elapsedRealtime() - upsertStart}",
         )
+        // Everything is technically "new" on a fresh source's first sync — the hide-by-default
+        // preference isn't meaningful there, only on a genuine resync.
+        if (!freshSource && upsert.newRows.isNotEmpty()) {
+            applyHideNewCategoriesDefault(s.id, type, upsert.newRows)
+        }
         // C5: ids come straight from the upsert (existing rows + returned insert rowids) — the old
         // second existingCategoriesByRemoteId round-trip only re-fetched just-upserted rows.
         return CategoryRefresh(idsByRemoteId = upsert.idsByRemoteId, seenRemoteIds = uniqueCategories.mapTo(HashSet()) { it.id }).also {
@@ -177,7 +194,7 @@ internal class SyncSupport(
             .mapNotNull { category -> category.remoteId?.let { it to category } }
             .toMap()
 
-    private class CategoryUpsert(val stats: UpsertStats, val idsByRemoteId: Map<String, Long>)
+    private class CategoryUpsert(val stats: UpsertStats, val idsByRemoteId: Map<String, Long>, val newRows: List<CategoryEntity>)
 
     private suspend fun upsertCategoriesStable(
         sourceId: Long,
@@ -215,7 +232,21 @@ internal class SyncSupport(
         return CategoryUpsert(
             stats = UpsertStats(inserted = inserts.size, updated = updates.size, skippedUnchanged = skipped),
             idsByRemoteId = ids,
+            newRows = inserts,
         )
+    }
+
+    /** Applies each profile's own "hide new categories" preference (same across Live/Movies/Series) to
+     *  categories just discovered on a resync — a source can be shared by several profiles. */
+    private suspend fun applyHideNewCategoriesDefault(sourceId: Long, type: MediaType, newRows: List<CategoryEntity>) {
+        val profileIds = sourceDao.profileIdsForSource(sourceId)
+        if (profileIds.isEmpty()) return
+        val keys = newRows.map { CustomizeKeys.category(it) }
+        profileIds.forEach { profileId ->
+            if (settings.hideNewCategoriesDefault(profileId).first()) {
+                customize.setCategoriesHidden(profileId, type, keys, hidden = true)
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/tv/own/owntv/core/sync/SyncSupport.kt
+++ b/app/src/main/java/tv/own/owntv/core/sync/SyncSupport.kt
@@ -125,10 +125,11 @@ internal class SyncSupport(
         }
     }
 
-    suspend fun pruneCategories(sourceId: Long, type: MediaType, seenRemoteIds: Set<String>, label: String) {
+    suspend fun pruneCategories(sourceId: Long, type: MediaType, seenRemoteIds: Set<String>, label: String, stats: SyncStatsCollector) {
         val start = SystemClock.elapsedRealtime()
         val stale = categoryDao.remoteIdsForSource(sourceId, type).filterNot(seenRemoteIds::contains)
         stale.chunked(QUERY_CHUNK).forEach { categoryDao.deleteByRemoteIds(sourceId, type, it) }
+        if (stale.isNotEmpty()) stats.processedCounts.merge(CATEGORIES_REMOVED_KEY, stale.size, Int::plus)
         Log.i(TAG, "$label category prune sourceId=$sourceId type=$type stale=${stale.size} ms=${SystemClock.elapsedRealtime() - start}")
     }
 
@@ -149,6 +150,7 @@ internal class SyncSupport(
         s: SourceEntity,
         type: MediaType,
         parsed: List<tv.own.owntv.core.parser.XtCategory>,
+        stats: SyncStatsCollector,
     ): CategoryRefresh {
         val start = SystemClock.elapsedRealtime()
         // s.lastSyncAt never changes during a sync run (SyncManager stamps it only after the syncer
@@ -177,9 +179,10 @@ internal class SyncSupport(
                 "dbInserted=${upsert.stats.inserted} dbUpdated=${upsert.stats.updated} " +
                 "dbSkipped=${upsert.stats.skippedUnchanged} ms=${SystemClock.elapsedRealtime() - upsertStart}",
         )
-        // Everything is technically "new" on a fresh source's first sync — the hide-by-default
-        // preference isn't meaningful there, only on a genuine resync.
+        // Everything is technically "new" on a fresh source's first sync — neither the hide-by-default
+        // preference nor the sync summary is meaningful there, only on a genuine resync.
         if (!freshSource && upsert.newRows.isNotEmpty()) {
+            stats.processedCounts.merge(CATEGORIES_ADDED_KEY, upsert.newRows.size, Int::plus)
             applyHideNewCategoriesDefault(s.id, type, upsert.newRows)
         }
         // C5: ids come straight from the upsert (existing rows + returned insert rowids) — the old
@@ -349,6 +352,11 @@ internal class SyncSupport(
         const val CATEGORY_REQUEST_DELAY_MS = 150L // pace per-category fallback requests (avoid HTTP 429)
         private const val SLOW_INSERT_LOG_MS = 250L
         val IgnoreByteProgress: (Long, Long?) -> Unit = { _, _ -> }
+
+        /** [SyncStatsCollector.processedCounts] keys aggregating category changes across all phases,
+         *  for the sync-complete summary — not shown at all when a fresh source makes every category "new". */
+        const val CATEGORIES_ADDED_KEY = "categoriesAdded"
+        const val CATEGORIES_REMOVED_KEY = "categoriesRemoved"
     }
 }
 

--- a/app/src/main/java/tv/own/owntv/core/sync/XtreamSyncer.kt
+++ b/app/src/main/java/tv/own/owntv/core/sync/XtreamSyncer.kt
@@ -201,7 +201,7 @@ internal class XtreamSyncer(
         val cats = p.fetchCategories(SyncSupport.IgnoreByteProgress)
         Log.d(TAG, "$label categories fetched sourceId=${s.id} count=${cats.size} ms=${SystemClock.elapsedRealtime() - categoriesStart}")
         val refreshStart = SystemClock.elapsedRealtime()
-        val categories = support.refreshCategories(s, p.type, cats)
+        val categories = support.refreshCategories(s, p.type, cats, stats)
         Log.d(TAG, "$label categories refreshed sourceId=${s.id} mapped=${categories.idsByRemoteId.size} ms=${SystemClock.elapsedRealtime() - refreshStart}")
         val streams = p.makeStreams(categories.idsByRemoteId)
         val insertFn: suspend (List<T>) -> UpsertStats = if (freshSource) {
@@ -237,7 +237,7 @@ internal class XtreamSyncer(
             }
             if (!freshSource && done) {
                 support.pruneRemoteIds(label, s.id, remoteIds!!, p.adapter.remoteIdsForSource, p.adapter.deleteByRemoteIds)
-                support.pruneCategories(s.id, p.type, categories.seenRemoteIds, label)
+                support.pruneCategories(s.id, p.type, categories.seenRemoteIds, label, stats)
             } else if (!freshSource) {
                 Log.i(TAG, "$label prune skipped sourceId=${s.id} reason=incomplete_bulk")
             }

--- a/app/src/main/java/tv/own/owntv/di/DataModule.kt
+++ b/app/src/main/java/tv/own/owntv/di/DataModule.kt
@@ -124,6 +124,8 @@ val dataModule = module {
             stalkerClient = get(),
             stalkerAuth = get(),
             activityTracker = get(),
+            customize = get(),
+            settings = get(),
         )
     }
     // App-wide "sync running" signal for the shell status pill (every sync funnels through SyncManager).

--- a/app/src/main/java/tv/own/owntv/features/customize/CustomizeScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/customize/CustomizeScreen.kt
@@ -426,13 +426,17 @@ private fun CategoryRow(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
-            if (row.hidden || row.renamed) {
+            if (row.hidden || row.renamed || row.providerName != null) {
                 Text(
                     buildString {
                         if (row.hidden) append("Hidden")
                         if (row.renamed) {
-                            if (row.hidden) append("  ·  ")
+                            if (isNotEmpty()) append("  ·  ")
                             append("was “${row.originalName}”")
+                        }
+                        row.providerName?.let {
+                            if (isNotEmpty()) append("  ·  ")
+                            append(it)
                         }
                     },
                     style = MaterialTheme.typography.labelSmall,

--- a/app/src/main/java/tv/own/owntv/features/customize/CustomizeScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/customize/CustomizeScreen.kt
@@ -43,8 +43,11 @@ import androidx.tv.material3.Text
 import tv.own.owntv.core.model.MediaType
 import tv.own.owntv.core.util.Pin
 import tv.own.owntv.features.profiles.PinDialog
+import tv.own.owntv.features.settings.PickerDialog
+import tv.own.owntv.features.settings.Row2
 import tv.own.owntv.ui.components.FocusableSurface
 import tv.own.owntv.ui.components.OwnTVButton
+import tv.own.owntv.ui.components.OwnTVIcon
 import tv.own.owntv.ui.components.dialogPanel
 import tv.own.owntv.ui.components.OwnTVButtonStyle
 import tv.own.owntv.ui.components.TextInputDialog
@@ -63,10 +66,12 @@ fun CustomizeScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
     val section by vm.section.collectAsStateWithLifecycle()
     val rows by vm.rows.collectAsStateWithLifecycle()
     val hiddenChannels by vm.hiddenChannels.collectAsStateWithLifecycle()
+    val hideNewCategories by vm.hideNewCategories.collectAsStateWithLifecycle()
     val rangeAnchorKey by vm.rangeAnchorKey.collectAsStateWithLifecycle()
     val pinLock by vm.pinLock.collectAsStateWithLifecycle()
     val colors = OwnTVTheme.colors
     var renaming by remember { mutableStateOf<CustomizeCatRow?>(null) }
+    var showNewCatPicker by remember { mutableStateOf(false) }
     // The category whose Hide button was clicked to close a range — opens the Show/Hide/Cancel prompt.
     var rangeEnd by remember { mutableStateOf<CustomizeCatRow?>(null) }
     // PIN gate: asked on every entry (state is per-composition, so leaving the screen re-locks it).
@@ -162,6 +167,23 @@ fun CustomizeScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
                 "profile. Survives re-syncs.",
             style = MaterialTheme.typography.bodyMedium,
             color = colors.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(16.dp))
+
+        // Same preference for every section (Live/Movies/Series), so it lives above the section picker
+        // rather than being buried in each section's category list.
+        Row2(
+            icon = OwnTVIcon.PLAYLIST,
+            title = "New category behavior",
+            desc = if (hideNewCategories) {
+                "Hide - new categories added on re-sync are hidden by default"
+            } else {
+                "Show - new categories added on re-sync are shown by default"
+            },
+            chip = if (hideNewCategories) "Hide" else "Show",
+            primaryChip = !hideNewCategories,
+            chevron = true,
+            onClick = { showNewCatPicker = true },
         )
         Spacer(Modifier.height(16.dp))
 
@@ -266,6 +288,16 @@ fun CustomizeScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
                 )
             }
         }
+    }
+
+    if (showNewCatPicker) {
+        PickerDialog(
+            title = "New category behavior",
+            options = listOf("SHOW" to "Show", "HIDE" to "Hide"),
+            selected = if (hideNewCategories) "HIDE" else "SHOW",
+            onSelect = { value -> vm.setHideNewCategories(value == "HIDE"); showNewCatPicker = false },
+            onDismiss = { showNewCatPicker = false },
+        )
     }
 
     renaming?.let { row ->

--- a/app/src/main/java/tv/own/owntv/features/customize/CustomizeViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/customize/CustomizeViewModel.kt
@@ -125,6 +125,18 @@ class CustomizeViewModel(
         }
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyMap())
 
+    /** Whether a category this provider adds on a future resync should be hidden automatically, for
+     *  this profile — same across Live/Movies/Series, so it doesn't follow [_section]. */
+    val hideNewCategories: StateFlow<Boolean> = ctx
+        .flatMapLatest { c -> if (c.profileId < 0) flowOf(false) else settings.hideNewCategoriesDefault(c.profileId) }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    fun setHideNewCategories(hidden: Boolean) {
+        val pid = ctx.value.profileId
+        if (pid < 0) return
+        viewModelScope.launch { settings.setHideNewCategoriesDefault(pid, hidden) }
+    }
+
     fun setCategoryHidden(row: CustomizeCatRow, hidden: Boolean) {
         viewModelScope.launch {
             customize.setCategoryHidden(ctx.value.profileId, _section.value, row.key, hidden)

--- a/app/src/main/java/tv/own/owntv/features/customize/CustomizeViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/customize/CustomizeViewModel.kt
@@ -24,13 +24,15 @@ import tv.own.owntv.core.model.MediaType
 import tv.own.owntv.core.repository.activeProfileSources
 import tv.own.owntv.features.settings.data.SettingsRepository
 
-/** One category row in the Customize screen (hidden rows stay visible here, marked, for unhiding). */
+/** One category row in the Customize screen (hidden rows stay visible here, marked, for unhiding).
+ *  [providerName] is null when only one source is in scope. */
 data class CustomizeCatRow(
     val key: String,
     val originalName: String,
     val displayName: String,
     val hidden: Boolean,
     val renamed: Boolean,
+    val providerName: String? = null,
 )
 
 /**
@@ -95,7 +97,9 @@ class CustomizeViewModel(
             else combine(
                 categoryDao.observe(c.sourceIds, type),
                 customize.observe(c.profileId, type),
-            ) { cats, cust ->
+                sourceDao.observeForProfile(c.profileId),
+            ) { cats, cust, sources ->
+                val providerNames = sources.associate { it.id to it.name }.takeIf { c.sourceIds.size > 1 }
                 val orderIndex = cust.categoryOrder.withIndex().associate { (i, k) -> k to i }
                 val keyed = cats.map { it to CustomizeKeys.category(it) }
                 val (pinned, rest) = keyed.partition { (_, k) -> k in orderIndex }
@@ -106,6 +110,7 @@ class CustomizeViewModel(
                         displayName = cust.categoryNames[key] ?: cat.name,
                         hidden = key in cust.hiddenCategories,
                         renamed = key in cust.categoryNames,
+                        providerName = providerNames?.get(cat.sourceId),
                     )
                 }
             }

--- a/app/src/main/java/tv/own/owntv/features/settings/SettingsViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/settings/SettingsViewModel.kt
@@ -803,7 +803,7 @@ class SettingsViewModel(
     }
 
     private fun String.withWarnings(result: SyncResult.Success): String =
-        result.warningSummary()?.let { "$this\n$it" } ?: this
+        listOfNotNull(this, result.categoryChangeSummary(), result.warningSummary()).joinToString("\n")
 
     // --- Global proxy (Approach 1 — one app-wide HTTP proxy) ---
 

--- a/app/src/main/java/tv/own/owntv/features/settings/data/SettingsRepository.kt
+++ b/app/src/main/java/tv/own/owntv/features/settings/data/SettingsRepository.kt
@@ -183,6 +183,16 @@ class SettingsRepository(private val context: Context) {
         }
     }
 
+    /** Whether a category the provider adds on a later resync is hidden automatically. Same across
+     *  Live/Movies/Series for a profile — there's no reason to want it to differ by section. */
+    fun hideNewCategoriesDefault(profileId: Long): Flow<Boolean> = context.dataStore.data.map { prefs ->
+        prefs[booleanPreferencesKey("hide_new_categories_$profileId")] ?: false
+    }
+
+    suspend fun setHideNewCategoriesDefault(profileId: Long, hidden: Boolean) {
+        context.dataStore.edit { it[booleanPreferencesKey("hide_new_categories_$profileId")] = hidden }
+    }
+
     // --- Home: per-profile row order / visibility / hero filters. ---
     private fun homeConfigKey(profileId: Long) = stringPreferencesKey("home_config_$profileId")
 
@@ -905,6 +915,31 @@ class SettingsRepository(private val context: Context) {
                 if (pid !in existingProfileIds) return@forEach
                 val blob = o.optJSONObject(key) ?: return@forEach
                 prefs[homeConfigKey(pid)] = blob.toString()
+            }
+        }
+    }
+
+    // --- Backup: per-profile "hide new categories" preference (dynamic "hide_new_categories_<id>" keys) ---
+
+    /** Exports all per-profile "hide new categories" preferences as { "<profileId>": true/false }. */
+    suspend fun exportHideNewCategories(): org.json.JSONObject {
+        val prefix = "hide_new_categories_"
+        val out = org.json.JSONObject()
+        context.dataStore.data.first().asMap().forEach { (k, v) ->
+            if (k.name.startsWith(prefix) && v is Boolean) {
+                out.put(k.name.removePrefix(prefix), v)
+            }
+        }
+        return out
+    }
+
+    /** Restores the preference only for profile ids in [existingProfileIds] (others are dropped safely). */
+    suspend fun importHideNewCategories(o: org.json.JSONObject, existingProfileIds: Set<Long>) {
+        context.dataStore.edit { prefs ->
+            o.keys().forEach { key ->
+                val pid = key.toLongOrNull() ?: return@forEach
+                if (pid !in existingProfileIds) return@forEach
+                prefs[booleanPreferencesKey("hide_new_categories_$pid")] = o.getBoolean(key)
             }
         }
     }

--- a/app/src/main/java/tv/own/owntv/features/setup/SetupViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/setup/SetupViewModel.kt
@@ -420,7 +420,7 @@ class SetupViewModel(
     }
 
     private fun String.withWarnings(result: SyncResult.Success): String =
-        result.warningSummary()?.let { "$this\n$it" } ?: this
+        listOfNotNull(this, result.categoryChangeSummary(), result.warningSummary()).joinToString("\n")
 
     private companion object {
         /** Sentinel sourceId for the pre-save Stalker handshake (same as SettingsViewModel's). */


### PR DESCRIPTION

## Before you open this PR (required)
<!-- These are mandatory — PRs that duplicate an existing in-app feature are closed. -->
- [x] I read the **[User Guide](https://github.com/ahXN00/OwnTV/blob/main/extras/USER_GUIDE.md)** and checked the app's **Settings** and existing **functions** — this change isn't already possible in the app.
- [x] I searched existing issues/PRs and this isn't a duplicate.

## What does this PR do?
- Category lists spanning multiple sources (Live/Movies/Series browse, Settings >
  Customize, EPG, Search, Home) interleaved two providers' categories instead of
  staying grouped, since sortOrder alone is only meaningful within a single
  source. Now orders by source creation order first. Only visible with "All
  playlists" selected or a profile with 2+ linked sources — a single selected
  playlist only ever had one source's categories to begin with.
- Customize category rows now show the provider name when more than one source
  is in scope, making bulk-hiding across providers easier to follow.
- New "New category behavior" (Show/Hide) setting in Settings > Customize — a
  category the provider adds on a later resync was always shown by default,
  which might not be desired for a user who prefers to hide all but a few
  specific categories. Rides in settings backup/restore like other per-profile
  Customize preferences.
- Sync-complete message now shows "N categories added, M removed" when nonzero
  — useful if you hide new categories by default, so you're still aware they
  exist in the playlist even though they don't show up in the browse lists.

## Which issue / improvement does it address?
Related to issue 60

## How was it tested?
Hisense Google TV 12
Tested - Settings -> Customize lists, categories lists, re-sync behavior

## Checklist
- [x] Builds locally (`./gradlew assembleDebug`) and CI is green
- [x] **Tested on a real Android TV / Fire TV device** (not emulator only) — D-pad/remote navigation works
- [x] No user data is wiped (Room migrations stay additive)
- [x] Keeps OwnTV player-only (no bundled channels/content)
- [x] Commit messages are clear (they become the release notes)
