### PR TITLE
Sync improvements

### DIFF
--- a/app/src/main/java/tv/own/owntv/core/backup/BackupManager.kt
+++ b/app/src/main/java/tv/own/owntv/core/backup/BackupManager.kt
@@ -322,7 +322,10 @@ class BackupManager(
                         }
                         applySources -> {
                             val keepId = incoming.id > 0 && incoming.id !in takenSourceIds
-                            val rowId = sourceDao.insert(if (keepId) incoming else incoming.copy(id = 0))
+                            val toInsert = if (keepId) incoming else incoming.copy(id = 0)
+                            // A restored backup starts with empty catalog tables. Nullifying lastSyncAt ensures
+                            // the first sync is treated as a fresh sync, preserving the restored category settings.
+                            val rowId = sourceDao.insert(toInsert.copy(lastSyncAt = null))
                             val deviceId = if (keepId) incoming.id else rowId
                             takenSourceIds += deviceId
                             sourceIdMap[incoming.id] = deviceId

--- a/app/src/main/java/tv/own/owntv/core/database/BulkInsertHelper.kt
+++ b/app/src/main/java/tv/own/owntv/core/database/BulkInsertHelper.kt
@@ -3,6 +3,8 @@ package tv.own.owntv.core.database
 import android.os.SystemClock
 import android.util.Log
 import androidx.annotation.WorkerThread
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 class BulkInsertHelper(
     private val db: OwnTVDatabase,
@@ -14,15 +16,20 @@ class BulkInsertHelper(
         ftsOnly: Boolean = false,
         block: suspend () -> T,
     ): T {
-        val state = if (eligible && tableIsEmpty(table)) {
-            dropIndexesForBulkInsert(table, ftsTable)
-        } else {
-            null
+        if (!eligible || !tableIsEmpty(table)) {
+            return block()
         }
-        return try {
-            block()
-        } finally {
-            if (state != null) restoreIndexes(state, ftsOnly = ftsOnly)
+        return indexMutex.withLock {
+            val state = if (tableIsEmpty(table)) {
+                dropIndexesForBulkInsert(table, ftsTable)
+            } else {
+                null
+            }
+            try {
+                block()
+            } finally {
+                if (state != null) restoreIndexes(state, ftsOnly = ftsOnly)
+            }
         }
     }
 
@@ -117,5 +124,6 @@ class BulkInsertHelper(
         private val KNOWN_TABLES = setOf("channels", "movies", "series", "epg_programmes")
         private val KNOWN_ANALYZE_TABLES = KNOWN_TABLES + setOf("categories", "epg_channels")
         private val KNOWN_FTS = setOf("channels_fts", "movies_fts", "series_fts")
+        private val indexMutex = Mutex()
     }
 }

--- a/app/src/main/java/tv/own/owntv/core/repository/SourceRepository.kt
+++ b/app/src/main/java/tv/own/owntv/core/repository/SourceRepository.kt
@@ -109,6 +109,9 @@ class SourceRepository(
         return result
     }
 
+    fun getLastSyncStats(sourceId: Long): tv.own.owntv.core.sync.SyncRunStats? =
+        syncManager.getLastSyncStats(sourceId)
+
     /** Per-mediaType row counts of a snapshot, e.g. "types={LIVE=8, MOVIE=6}" — upgrade-path diagnostics. */
     private fun org.json.JSONArray.typeCounts(): String {
         val counts = LinkedHashMap<String, Int>()

--- a/app/src/main/java/tv/own/owntv/core/sync/SyncActivityTracker.kt
+++ b/app/src/main/java/tv/own/owntv/core/sync/SyncActivityTracker.kt
@@ -13,10 +13,16 @@ class SyncActivityTracker {
 
     data class ActiveSync(val sourceId: Long, val sourceName: String, val stage: ImportStage? = null)
 
+    data class CompletedSync(val sourceId: Long, val sourceName: String, val result: SyncResult, val timestamp: Long)
+
     private val _active = MutableStateFlow<Map<Long, ActiveSync>>(emptyMap())
+    private val _lastCompleted = MutableStateFlow<CompletedSync?>(null)
 
     /** All currently-running syncs keyed by sourceId (usually 0 or 1 entries). */
     val active: StateFlow<Map<Long, ActiveSync>> = _active.asStateFlow()
+
+    /** The last completed sync (success, failure, or cancellation). */
+    val lastCompleted: StateFlow<CompletedSync?> = _lastCompleted.asStateFlow()
 
     fun started(sourceId: Long, sourceName: String) {
         _active.value = _active.value + (sourceId to ActiveSync(sourceId, sourceName))
@@ -27,7 +33,8 @@ class SyncActivityTracker {
         _active.value = _active.value + (sourceId to existing.copy(stage = stage))
     }
 
-    fun finished(sourceId: Long) {
+    fun finished(sourceId: Long, sourceName: String, result: SyncResult) {
         _active.value = _active.value - sourceId
+        _lastCompleted.value = CompletedSync(sourceId, sourceName, result, android.os.SystemClock.elapsedRealtime())
     }
 }

--- a/app/src/main/java/tv/own/owntv/core/sync/SyncManager.kt
+++ b/app/src/main/java/tv/own/owntv/core/sync/SyncManager.kt
@@ -73,7 +73,8 @@ class SyncManager(
                 activityTracker.progress(source.id, stage)
                 onProgress(stage)
             }
-            val result = try {
+            var result: SyncResult = SyncResult.Cancelled
+            try {
                 when (source.type) {
                     SourceType.XTREAM -> xtreamSyncer.sync(source, progress, stats, contentTypes)
                     SourceType.M3U -> m3uSyncer.sync(source, progress, stats)
@@ -90,17 +91,18 @@ class SyncManager(
                     Log.d(TAG, "markSynced sourceId=${source.id} ms=${SystemClock.elapsedRealtime() - markStartedAt}")
                 }
                 progress.completeAll()
-                SyncResult.Success(
+                result = SyncResult.Success(
                     warnings = stats.warnings(),
                     categoriesAdded = stats.processedCounts[SyncSupport.CATEGORIES_ADDED_KEY] ?: 0,
                     categoriesRemoved = stats.processedCounts[SyncSupport.CATEGORIES_REMOVED_KEY] ?: 0,
                 )
             } catch (c: CancellationException) {
+                result = SyncResult.Cancelled
                 throw c
             } catch (e: Exception) {
-                SyncResult.Failed(e.message ?: "Sync failed")
+                result = SyncResult.Failed(e.message ?: "Sync failed")
             } finally {
-                activityTracker.finished(source.id) // also on cancellation — never leave a stuck pill
+                activityTracker.finished(source.id, source.name, result) // also on cancellation — never leave a stuck pill
             }
             val runStats = stats.build(result)
             lastSyncStats[source.id] = runStats

--- a/app/src/main/java/tv/own/owntv/core/sync/SyncStatus.kt
+++ b/app/src/main/java/tv/own/owntv/core/sync/SyncStatus.kt
@@ -34,12 +34,8 @@ sealed interface SyncResult {
                 separator = " · ",
             ) { "${it.label} failed" }
 
-        fun categoryChangeSummary(): String? {
-            if (categoriesAdded == 0 && categoriesRemoved == 0) return null
-            return listOfNotNull(
-                "$categoriesAdded categories added".takeIf { categoriesAdded > 0 },
-                "$categoriesRemoved removed".takeIf { categoriesRemoved > 0 },
-            ).joinToString(", ")
+        fun categoryChangeSummary(): String {
+            return "$categoriesAdded categories added, $categoriesRemoved removed"
         }
     }
 

--- a/app/src/main/java/tv/own/owntv/core/sync/XtreamSyncer.kt
+++ b/app/src/main/java/tv/own/owntv/core/sync/XtreamSyncer.kt
@@ -211,6 +211,7 @@ internal class XtreamSyncer(
         }
         val total = intArrayOf(0)
         val remoteIds = if (freshSource) null else HashSet<String>()
+        var done = false
         bulkInsertHelper.withOptimizedBulkInsert(
             p.table,
             p.ftsTable,
@@ -220,27 +221,27 @@ internal class XtreamSyncer(
             val bulkStart = SystemClock.elapsedRealtime()
             Log.i(TAG, "$label bulk start sourceId=${s.id}")
             val chunkSize = if (freshSource) BulkInsertHelper.CHUNK_FRESH else BulkInsertHelper.CHUNK
-            val done = bulkOrFallback(label) {
+            done = bulkOrFallback(label) {
                 support.chunked<T, Boolean>(ctx, p.phase, label, progress, insertFn, total, remoteIds, p.adapter.remoteIdOf, chunkSize) { add ->
                     streams.bulk(add)
                 }
             }
             Log.i(TAG, "$label bulk end sourceId=${s.id} complete=$done unique=${total[0]} ms=${SystemClock.elapsedRealtime() - bulkStart}")
-            if (!done) {
-                stats.usedFallback = true
-                val fallbackStart = SystemClock.elapsedRealtime()
-                Log.i(TAG, "$label fallback start sourceId=${s.id} categories=${cats.size} bulkPartial=${total[0]}")
-                sliceByCategory(ctx, p.phase, label, progress, cats, insertFn, total, total[0], remoteIds, p.adapter.remoteIdOf) { cat, add ->
-                    streams.byCategory(cat, add)
-                }
-                Log.i(TAG, "$label fallback end sourceId=${s.id} unique=${total[0]} ms=${SystemClock.elapsedRealtime() - fallbackStart}")
-            }
             if (!freshSource && done) {
                 support.pruneRemoteIds(label, s.id, remoteIds!!, p.adapter.remoteIdsForSource, p.adapter.deleteByRemoteIds)
                 support.pruneCategories(s.id, p.type, categories.seenRemoteIds, label, stats)
             } else if (!freshSource) {
                 Log.i(TAG, "$label prune skipped sourceId=${s.id} reason=incomplete_bulk")
             }
+        }
+        if (!done) {
+            stats.usedFallback = true
+            val fallbackStart = SystemClock.elapsedRealtime()
+            Log.i(TAG, "$label fallback start sourceId=${s.id} categories=${cats.size} bulkPartial=${total[0]}")
+            sliceByCategory(ctx, p.phase, label, progress, cats, insertFn, total, total[0], remoteIds, p.adapter.remoteIdOf) { cat, add ->
+                streams.byCategory(cat, add)
+            }
+            Log.i(TAG, "$label fallback end sourceId=${s.id} unique=${total[0]} ms=${SystemClock.elapsedRealtime() - fallbackStart}")
         }
         progress.update(p.phase, total[0])
         p.timingKey?.let { stats.phaseTiming[it] = System.currentTimeMillis() - phaseStart }

--- a/app/src/main/java/tv/own/owntv/features/settings/ManageSourcesScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/settings/ManageSourcesScreen.kt
@@ -107,172 +107,172 @@ fun ManageSourcesScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
         is SettingsViewModel.StalkerTestState.Failed -> StalkerTestUi.Failed(t.message)
     }
 
-    editingSource?.let { src ->
-        AddSourceScreen(
-            initial = src,
-            initialAutoRefresh = playlistAutoRefresh[src.id] ?: PlaylistAutoRefresh.OFF,
-            initialIsDefault = src.id == defaultId,
-            onStartXtream = { n, server, u, p, ua, epg, autoRefresh, _, _, _, isDefault ->
-                vm.updateSource(src.id, n, server, u, p, ua, epg, autoRefresh, isDefault)
-                editingSource = null
-            },
-            onStartM3u = { n, url, ua, epg, autoRefresh, isDefault -> vm.updateSource(src.id, n, url, "", "", ua, epg, autoRefresh, isDefault); editingSource = null },
-            onStartStalker = { n, url, mac, ua, autoRefresh, isDefault ->
-                vm.updateSource(src.id, n, url, "", "", ua, "", autoRefresh, isDefault, mac = mac)
-                vm.resetStalkerTest()
-                editingSource = null
-            },
-            onTestStalker = { url, mac, ua -> vm.testStalker(url, mac, ua) },
-            stalkerTest = stalkerTestUi,
-            onBack = { vm.resetStalkerTest(); editingSource = null },
-            modifier = modifier,
-        )
-        return
-    }
-
-    if (showAdd) {
-        when (val s = importState) {
-            SettingsViewModel.ImportState.Idle -> when (addMode) {
-                null -> AddSourceChooserScreen(
-                    onRemote = { addMode = AddMode.REMOTE },
-                    onManual = { addMode = AddMode.MANUAL },
-                    onBack = { showAdd = false },
-                    modifier = modifier,
-                )
-                AddMode.REMOTE -> RemoteSetupScreen(
-                    state = vm.remoteState.collectAsStateWithLifecycle().value,
-                    payloads = vm.remotePayloads,
-                    onStartListener = { port -> vm.startRemoteListener(port) },
-                    onStopListener = { vm.stopRemoteListener() },
-                    // A phone submission hands off to the pre-filled Manual form.
-                    onPayloadReceived = { addMode = AddMode.MANUAL },
-                    onBack = { vm.stopRemoteListener(); addMode = null },
-                    modifier = modifier,
-                )
-                AddMode.MANUAL -> AddSourceScreen(
-                onStartXtream = { n, server, u, p, ua, epg, autoRefresh, live, movies, series, isDefault ->
-                    vm.addXtream(n, server, u, p, ua, epg, autoRefresh, live, movies, series, isDefault)
+    Box(modifier = modifier.fillMaxSize()) {
+        if (editingSource != null) {
+            val src = editingSource!!
+            AddSourceScreen(
+                initial = src,
+                initialAutoRefresh = playlistAutoRefresh[src.id] ?: PlaylistAutoRefresh.OFF,
+                initialIsDefault = src.id == defaultId,
+                onStartXtream = { n, server, u, p, ua, epg, autoRefresh, _, _, _, isDefault ->
+                    vm.updateSource(src.id, n, server, u, p, ua, epg, autoRefresh, isDefault)
+                    editingSource = null
                 },
-                onStartM3u = { n, url, ua, epg, autoRefresh, isDefault -> vm.addM3u(n, url, ua, epg, autoRefresh, isDefault) },
+                onStartM3u = { n, url, ua, epg, autoRefresh, isDefault -> vm.updateSource(src.id, n, url, "", "", ua, epg, autoRefresh, isDefault); editingSource = null },
                 onStartStalker = { n, url, mac, ua, autoRefresh, isDefault ->
+                    vm.updateSource(src.id, n, url, "", "", ua, "", autoRefresh, isDefault, mac = mac)
                     vm.resetStalkerTest()
-                    vm.addStalker(n, url, mac, ua, autoRefresh, isDefault)
+                    editingSource = null
                 },
                 onTestStalker = { url, mac, ua -> vm.testStalker(url, mac, ua) },
                 stalkerTest = stalkerTestUi,
-                // Submissions from the Remote screen land here pre-filled (type + fields).
-                remotePayload = vm.remotePayload,
-                onRemotePayloadConsumed = { vm.consumeRemotePayload() },
-                // A newly-added playlist can be made default only when others already exist.
-                showDefaultToggle = sources.isNotEmpty(),
-                onBack = { vm.resetStalkerTest(); addMode = null },
-                modifier = modifier,
-                initial = vm.lastFailedSource, // pre-fill on retry — no re-typing after a typo
-                )
-            }
-            SettingsViewModel.ImportState.Running -> CenterStatus {
-                val display = progress?.importProgressDisplay()
-                OwnTVSpinner(sizeDp = 56)
-                Spacer(Modifier.height(16.dp))
-                Text(
-                    display?.title ?: "Importing catalog…",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = colors.onSurface,
-                )
-                Spacer(Modifier.height(6.dp))
-                Text(display?.primaryText ?: "Preparing catalog", style = MaterialTheme.typography.headlineSmall, color = colors.primary)
-                Spacer(Modifier.height(4.dp))
-                Text(display?.detail ?: "Preparing catalog", style = MaterialTheme.typography.bodyMedium, color = colors.onSurfaceVariant)
-                Spacer(Modifier.height(20.dp))
-                OwnTVButton("Cancel", onClick = { showAdd = false; vm.cancelImport() }, style = OwnTVButtonStyle.SECONDARY)
-            }
-            is SettingsViewModel.ImportState.Success -> {
-                // Semi-auto EPG: ask → sync (with a live count, like the import) → done, before returning.
-                if (epgSync !is EpgSyncUi.Hidden) {
-                    EpgSyncDialog(state = epgSync, onSync = vm::syncPendingEpg, onDismiss = vm::dismissPendingEpg)
-                } else if (s.summary.contains("Imported with warnings:")) {
-                    CenterStatus {
-                        Text("Import complete", style = MaterialTheme.typography.titleLarge, color = colors.onSurface)
-                        Spacer(Modifier.height(8.dp))
-                        Text(s.summary, style = MaterialTheme.typography.bodyMedium, color = colors.onSurfaceVariant)
-                        Spacer(Modifier.height(20.dp))
-                        OwnTVButton("Done", onClick = { showAdd = false; vm.resetImport() })
-                    }
-                } else {
-                    LaunchedEffect(Unit) { showAdd = false; vm.resetImport() }
-                }
-            }
-            is SettingsViewModel.ImportState.Failed -> CenterStatus {
-                Text("Import failed", style = MaterialTheme.typography.titleLarge, color = colors.onSurface)
-                Spacer(Modifier.height(8.dp))
-                Text(s.message, style = MaterialTheme.typography.bodyMedium, color = colors.onSurfaceVariant)
-                Spacer(Modifier.height(20.dp))
-                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    OwnTVButton("Back", onClick = { showAdd = false; vm.resetImport() }, style = OwnTVButtonStyle.SECONDARY)
-                    OwnTVButton("Try again", onClick = { vm.resetImport() }, modifier = Modifier.focusRequester(errorFocus))
-                }
-            }
-        }
-        return
-    }
-
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .roundedPanel()
-            // Spatial D-pad entry from the sidebar would land mid-list — route it to "Add Source".
-            // onEnter fires only for directional entry from outside; internal focus moves and
-            // programmatic restores never re-trigger it (an onFocusChanged redirect did, freezing focus).
-            .focusProperties { onEnter = { runCatching { addFocus.requestFocus() } } }
-            .focusGroup()
-            .padding(horizontal = 40.dp, vertical = 28.dp),
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Text("Sources", style = MaterialTheme.typography.headlineLarge, color = colors.onSurface)
-            Spacer(Modifier.weight(1f))
-            OwnTVButton("Add Source", onClick = { showAdd = true }, icon = tv.own.owntv.ui.components.OwnTVIcon.ADD, modifier = Modifier.focusRequester(addFocus))
-        }
-        Spacer(Modifier.height(8.dp))
-        Text("Sources are shared across all profiles.", style = MaterialTheme.typography.bodyMedium, color = colors.onSurfaceVariant)
-        Spacer(Modifier.height(20.dp))
-
-        if (sources.isEmpty()) {
-            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text("No sources yet. Add an M3U or Xtream source.", color = colors.onSurfaceVariant, style = MaterialTheme.typography.bodyLarge)
-            }
-        } else {
-            LazyColumn(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                items(sources, key = { it.id }) { source ->
-                    // Default is only the explicitly-chosen source; when none is set every playlist shows
-                    // (no badge). Chosen via the add/edit form's "Default playlist" toggle, not a row action.
-                    val isDefault = source.id == defaultId
-                    val counts by remember(source.id) { vm.contentCounts(source.id) }.collectAsStateWithLifecycle(null)
-                    val syncState by remember(source.id) { vm.syncState(source.id) }.collectAsStateWithLifecycle(CatalogSyncState.Idle)
-                    SourceRow(
-                        source = source,
-                        autoRefresh = playlistAutoRefresh[source.id] ?: PlaylistAutoRefresh.OFF,
-                        isDefault = isDefault,
-                        expiry = sourceExpiry[source.id],
-                        counts = counts,
-                        syncState = syncState,
-                        isDeleting = source.id in deletingIds,
-                        onEdit = { editingSource = source },
-                        onResync = { vm.resync(source) },
-                        onCancelSync = { vm.cancelResync(source) },
-                        onDelete = { confirmDelete = source },
+                onBack = { vm.resetStalkerTest(); editingSource = null },
+                modifier = Modifier,
+            )
+        } else if (showAdd) {
+            when (val s = importState) {
+                SettingsViewModel.ImportState.Idle -> when (addMode) {
+                    null -> AddSourceChooserScreen(
+                        onRemote = { addMode = AddMode.REMOTE },
+                        onManual = { addMode = AddMode.MANUAL },
+                        onBack = { showAdd = false },
+                        modifier = Modifier,
+                    )
+                    AddMode.REMOTE -> RemoteSetupScreen(
+                        state = vm.remoteState.collectAsStateWithLifecycle().value,
+                        payloads = vm.remotePayloads,
+                        onStartListener = { port -> vm.startRemoteListener(port) },
+                        onStopListener = { vm.stopRemoteListener() },
+                        // A phone submission hands off to the pre-filled Manual form.
+                        onPayloadReceived = { addMode = AddMode.MANUAL },
+                        onBack = { vm.stopRemoteListener(); addMode = null },
+                        modifier = Modifier,
+                    )
+                    AddMode.MANUAL -> AddSourceScreen(
+                        onStartXtream = { n, server, u, p, ua, epg, autoRefresh, live, movies, series, isDefault ->
+                            vm.addXtream(n, server, u, p, ua, epg, autoRefresh, live, movies, series, isDefault)
+                        },
+                        onStartM3u = { n, url, ua, epg, autoRefresh, isDefault -> vm.addM3u(n, url, ua, epg, autoRefresh, isDefault) },
+                        onStartStalker = { n, url, mac, ua, autoRefresh, isDefault ->
+                            vm.resetStalkerTest()
+                            vm.addStalker(n, url, mac, ua, autoRefresh, isDefault)
+                        },
+                        onTestStalker = { url, mac, ua -> vm.testStalker(url, mac, ua) },
+                        stalkerTest = stalkerTestUi,
+                        // Submissions from the Remote screen land here pre-filled (type + fields).
+                        remotePayload = vm.remotePayload,
+                        onRemotePayloadConsumed = { vm.consumeRemotePayload() },
+                        // A newly-added playlist can be made default only when others already exist.
+                        showDefaultToggle = sources.isNotEmpty(),
+                        onBack = { vm.resetStalkerTest(); addMode = null },
+                        modifier = Modifier,
+                        initial = vm.lastFailedSource, // pre-fill on retry — no re-typing after a typo
                     )
                 }
+                SettingsViewModel.ImportState.Running -> CenterStatus {
+                    val display = progress?.importProgressDisplay()
+                    OwnTVSpinner(sizeDp = 56)
+                    Spacer(Modifier.height(16.dp))
+                    Text(
+                        display?.title ?: "Importing catalog…",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = colors.onSurface,
+                    )
+                    Spacer(Modifier.height(6.dp))
+                    Text(display?.primaryText ?: "Preparing catalog", style = MaterialTheme.typography.headlineSmall, color = colors.primary)
+                    Spacer(Modifier.height(4.dp))
+                    Text(display?.detail ?: "Preparing catalog", style = MaterialTheme.typography.bodyMedium, color = colors.onSurfaceVariant)
+                    Spacer(Modifier.height(20.dp))
+                    OwnTVButton("Cancel", onClick = { showAdd = false; vm.cancelImport() }, style = OwnTVButtonStyle.SECONDARY)
+                }
+                is SettingsViewModel.ImportState.Success -> {
+                    // Semi-auto EPG: ask → sync (with a live count, like the import) → done, before returning.
+                    if (epgSync !is EpgSyncUi.Hidden) {
+                        EpgSyncDialog(state = epgSync, onSync = vm::syncPendingEpg, onDismiss = vm::dismissPendingEpg)
+                    } else if (s.summary.contains("Imported with warnings:")) {
+                        CenterStatus {
+                            Text("Import complete", style = MaterialTheme.typography.titleLarge, color = colors.onSurface)
+                            Spacer(Modifier.height(8.dp))
+                            Text(s.summary, style = MaterialTheme.typography.bodyMedium, color = colors.onSurfaceVariant)
+                            Spacer(Modifier.height(20.dp))
+                            OwnTVButton("Done", onClick = { showAdd = false; vm.resetImport() })
+                        }
+                    } else {
+                        LaunchedEffect(Unit) { showAdd = false; vm.resetImport() }
+                    }
+                }
+                is SettingsViewModel.ImportState.Failed -> CenterStatus {
+                    Text("Import failed", style = MaterialTheme.typography.titleLarge, color = colors.onSurface)
+                    Spacer(Modifier.height(8.dp))
+                    Text(s.message, style = MaterialTheme.typography.bodyMedium, color = colors.onSurfaceVariant)
+                    Spacer(Modifier.height(20.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        OwnTVButton("Back", onClick = { showAdd = false; vm.resetImport() }, style = OwnTVButtonStyle.SECONDARY)
+                        OwnTVButton("Try again", onClick = { vm.resetImport() }, modifier = Modifier.focusRequester(errorFocus))
+                    }
+                }
+            }
+        } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .roundedPanel()
+                    // Spatial D-pad entry from the sidebar would land mid-list — route it to "Add Source".
+                    // onEnter fires only for directional entry from outside; internal focus moves and
+                    // programmatic restores never re-trigger it (an onFocusChanged redirect did, freezing focus).
+                    .focusProperties { onEnter = { runCatching { addFocus.requestFocus() } } }
+                    .focusGroup()
+                    .padding(horizontal = 40.dp, vertical = 28.dp),
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text("Sources", style = MaterialTheme.typography.headlineLarge, color = colors.onSurface)
+                    Spacer(Modifier.weight(1f))
+                    OwnTVButton("Add Source", onClick = { showAdd = true }, icon = tv.own.owntv.ui.components.OwnTVIcon.ADD, modifier = Modifier.focusRequester(addFocus))
+                }
+                Spacer(Modifier.height(8.dp))
+                Text("Sources are shared across all profiles.", style = MaterialTheme.typography.bodyMedium, color = colors.onSurfaceVariant)
+                Spacer(Modifier.height(20.dp))
+
+                if (sources.isEmpty()) {
+                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text("No sources yet. Add an M3U or Xtream source.", color = colors.onSurfaceVariant, style = MaterialTheme.typography.bodyLarge)
+                    }
+                } else {
+                    LazyColumn(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                        items(sources, key = { it.id }) { source ->
+                            // Default is only the explicitly-chosen source; when none is set every playlist shows
+                            // (no badge). Chosen via the add/edit form's "Default playlist" toggle, not a row action.
+                            val isDefault = source.id == defaultId
+                            val counts by remember(source.id) { vm.contentCounts(source.id) }.collectAsStateWithLifecycle(null)
+                            val syncState by remember(source.id) { vm.syncState(source.id) }.collectAsStateWithLifecycle(CatalogSyncState.Idle)
+
+                            SourceRow(
+                                source = source,
+                                autoRefresh = playlistAutoRefresh[source.id] ?: PlaylistAutoRefresh.OFF,
+                                isDefault = isDefault,
+                                expiry = sourceExpiry[source.id],
+                                counts = counts,
+                                syncState = syncState,
+                                isDeleting = source.id in deletingIds,
+                                onEdit = { editingSource = source },
+                                onResync = { vm.resync(source) },
+                                onCancelSync = { vm.cancelResync(source) },
+                                onDelete = { confirmDelete = source },
+                            )
+                        }
+                    }
+                }
             }
         }
-    }
 
-    confirmDelete?.let { src ->
-        ConfirmDialog(
-            title = "Delete “${src.name}”?",
-            message = "This removes the source and all its channels, movies and series from every profile.",
-            onConfirm = { vm.delete(src); confirmDelete = null },
-            onDismiss = { confirmDelete = null },
-        )
+        confirmDelete?.let { src ->
+            ConfirmDialog(
+                title = "Delete “${src.name}”?",
+                message = "This removes the source and all its channels, movies and series from every profile.",
+                onConfirm = { vm.delete(src); confirmDelete = null },
+                onDismiss = { confirmDelete = null },
+            )
+        }
     }
 }
 

--- a/app/src/main/java/tv/own/owntv/features/settings/SettingsViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/settings/SettingsViewModel.kt
@@ -740,6 +740,9 @@ class SettingsViewModel(
         catalogSyncScheduler.cancelSync(source.id)
     }
 
+    fun getLastSyncStats(sourceId: Long): tv.own.owntv.core.sync.SyncRunStats? =
+        sourceRepository.getLastSyncStats(sourceId)
+
     // Deleting a huge source (hundreds of thousands of cascaded rows) takes a while — surface it
     // per-row so the user can see the removal is in progress instead of a silently frozen list.
     private val _deletingSourceIds = MutableStateFlow<Set<Long>>(emptySet())
@@ -803,7 +806,7 @@ class SettingsViewModel(
     }
 
     private fun String.withWarnings(result: SyncResult.Success): String =
-        listOfNotNull(this, result.categoryChangeSummary(), result.warningSummary()).joinToString("\n")
+        listOfNotNull(this, result.warningSummary()).joinToString("\n")
 
     // --- Global proxy (Approach 1 — one app-wide HTTP proxy) ---
 

--- a/app/src/main/java/tv/own/owntv/features/setup/SetupViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/setup/SetupViewModel.kt
@@ -420,7 +420,7 @@ class SetupViewModel(
     }
 
     private fun String.withWarnings(result: SyncResult.Success): String =
-        listOfNotNull(this, result.categoryChangeSummary(), result.warningSummary()).joinToString("\n")
+        listOfNotNull(this, result.warningSummary()).joinToString("\n")
 
     private companion object {
         /** Sentinel sourceId for the pre-save Stalker handshake (same as SettingsViewModel's). */

--- a/app/src/main/java/tv/own/owntv/features/shell/components/SyncStatusPill.kt
+++ b/app/src/main/java/tv/own/owntv/features/shell/components/SyncStatusPill.kt
@@ -19,7 +19,6 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import tv.own.owntv.core.sync.EpgActivityTracker
 import tv.own.owntv.core.sync.SyncActivityTracker
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -50,19 +49,17 @@ fun SyncStatusPill(modifier: Modifier = Modifier) {
     val catalogSync = activeCatalog.values.firstOrNull()
     val epgSync = activeEpg.values.firstOrNull()
 
-    val completedQueue = remember { mutableListOf<SyncActivityTracker.CompletedSync>() }
-    var queueChangeTrigger by remember { mutableStateOf(0) }
+    val completedQueue = remember { mutableStateListOf<SyncActivityTracker.CompletedSync>() }
     var currentCompleted by remember { mutableStateOf<SyncActivityTracker.CompletedSync?>(null) }
 
     LaunchedEffect(lastCompleted) {
         val completed = lastCompleted ?: return@LaunchedEffect
         if (completedQueue.none { it.timestamp == completed.timestamp && it.sourceId == completed.sourceId }) {
             completedQueue.add(completed)
-            queueChangeTrigger++
         }
     }
 
-    LaunchedEffect(catalogSync, epgSync, currentCompleted, queueChangeTrigger) {
+    LaunchedEffect(catalogSync, epgSync, currentCompleted, completedQueue.size) {
         if (catalogSync == null && epgSync == null && currentCompleted == null && completedQueue.isNotEmpty()) {
             currentCompleted = completedQueue.removeAt(0)
         }

--- a/app/src/main/java/tv/own/owntv/features/shell/components/SyncStatusPill.kt
+++ b/app/src/main/java/tv/own/owntv/features/shell/components/SyncStatusPill.kt
@@ -19,6 +19,14 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import tv.own.owntv.core.sync.EpgActivityTracker
 import tv.own.owntv.core.sync.SyncActivityTracker
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.LaunchedEffect
+import kotlinx.coroutines.delay
+import tv.own.owntv.core.sync.SyncResult
 import tv.own.owntv.ui.components.OwnTVSpinner
 import tv.own.owntv.ui.theme.OwnTVTheme
 
@@ -35,37 +43,39 @@ fun SyncStatusPill(modifier: Modifier = Modifier) {
     val epgTracker: EpgActivityTracker = koinInject()
     val activeCatalog by catalogTracker.active.collectAsStateWithLifecycle()
     val activeEpg by epgTracker.active.collectAsStateWithLifecycle()
+    val lastCompleted by catalogTracker.lastCompleted.collectAsStateWithLifecycle()
 
     val colors = OwnTVTheme.colors
 
-    // Catalog syncs take the primary slot; EPG shows when no catalog sync is running.
     val catalogSync = activeCatalog.values.firstOrNull()
     val epgSync = activeEpg.values.firstOrNull()
-    val label = when {
-        catalogSync != null -> {
-            val count = catalogSync.stage?.totalProcessed ?: 0
-            val others = activeCatalog.size - 1
-            buildString {
-                append("Syncing ")
-                append(catalogSync.sourceName)
-                if (count > 0) append(" · ").append(String.format(java.util.Locale.getDefault(), "%,d", count)).append(" items")
-                if (others > 0) append(" (+$others more)")
-                if (epgSync != null) append(" · EPG too")
-            }
+
+    val completedQueue = remember { mutableListOf<SyncActivityTracker.CompletedSync>() }
+    var queueChangeTrigger by remember { mutableStateOf(0) }
+    var currentCompleted by remember { mutableStateOf<SyncActivityTracker.CompletedSync?>(null) }
+
+    LaunchedEffect(lastCompleted) {
+        val completed = lastCompleted ?: return@LaunchedEffect
+        if (completedQueue.none { it.timestamp == completed.timestamp && it.sourceId == completed.sourceId }) {
+            completedQueue.add(completed)
+            queueChangeTrigger++
         }
-        epgSync != null -> {
-            val others = activeEpg.size - 1
-            buildString {
-                append("Updating guide · ")
-                append(epgSync.sourceName)
-                if (epgSync.programmes > 0) {
-                    append(" · ").append(String.format(java.util.Locale.getDefault(), "%,d", epgSync.programmes)).append(" programmes")
-                }
-                if (others > 0) append(" (+$others more)")
-            }
-        }
-        else -> return // nothing running → render nothing
     }
+
+    LaunchedEffect(catalogSync, epgSync, currentCompleted, queueChangeTrigger) {
+        if (catalogSync == null && epgSync == null && currentCompleted == null && completedQueue.isNotEmpty()) {
+            currentCompleted = completedQueue.removeAt(0)
+        }
+    }
+
+    LaunchedEffect(currentCompleted) {
+        if (currentCompleted != null) {
+            delay(5000)
+            currentCompleted = null
+        }
+    }
+
+    if (catalogSync == null && epgSync == null && currentCompleted == null) return
 
     Row(
         modifier = modifier
@@ -77,13 +87,85 @@ fun SyncStatusPill(modifier: Modifier = Modifier) {
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        OwnTVSpinner(sizeDp = 14)
-        Text(
-            label,
-            style = MaterialTheme.typography.labelMedium,
-            color = colors.onSurfaceVariant,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
+        when {
+            catalogSync != null -> {
+                val count = catalogSync.stage?.totalProcessed ?: 0
+                val others = activeCatalog.size - 1
+                val label = buildString {
+                    append("Syncing ")
+                    append(catalogSync.sourceName)
+                    if (count > 0) append(" · ").append(String.format(java.util.Locale.getDefault(), "%,d", count)).append(" items")
+                    if (others > 0) append(" (+$others more)")
+                    if (epgSync != null) append(" · EPG too")
+                }
+                OwnTVSpinner(sizeDp = 14)
+                Text(
+                    label,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = colors.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            epgSync != null -> {
+                val others = activeEpg.size - 1
+                val label = buildString {
+                    append("Updating guide · ")
+                    append(epgSync.sourceName)
+                    if (epgSync.programmes > 0) {
+                        append(" · ").append(String.format(java.util.Locale.getDefault(), "%,d", epgSync.programmes)).append(" programmes")
+                    }
+                    if (others > 0) append(" (+$others more)")
+                }
+                OwnTVSpinner(sizeDp = 14)
+                Text(
+                    label,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = colors.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            currentCompleted != null -> {
+                val completed = currentCompleted!!
+                val label = androidx.compose.ui.text.buildAnnotatedString {
+                    val boldStyle = androidx.compose.ui.text.SpanStyle(fontWeight = androidx.compose.ui.text.font.FontWeight.Bold)
+                    when (val res = completed.result) {
+                        is SyncResult.Success -> {
+                            pushStyle(boldStyle)
+                            append("Sync complete")
+                            pop()
+                            append(" · ")
+                            append(completed.sourceName)
+                            append(" · ")
+                            append(res.categoryChangeSummary())
+                        }
+                        is SyncResult.Failed -> {
+                            pushStyle(boldStyle)
+                            append("Sync failed")
+                            pop()
+                            append(" · ")
+                            append(completed.sourceName)
+                            append(": ")
+                            append(res.message)
+                        }
+                        SyncResult.Cancelled -> {
+                            pushStyle(boldStyle)
+                            append("Sync cancelled")
+                            pop()
+                            append(" · ")
+                            append(completed.sourceName)
+                        }
+                    }
+                }
+                Text(
+                    label,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = colors.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
## Before you open this PR (required)
<!-- These are mandatory — PRs that duplicate an existing in-app feature are closed. -->
- [x] I read the **[User Guide](https://github.com/ahXN00/OwnTV/blob/main/extras/USER_GUIDE.md)** and checked the app's **Settings** and existing **functions** — this change isn't already possible in the app.
- [x] I searched existing issues/PRs and this isn't a duplicate.

## What does this PR do?
Renders sync completion statistics (such as category additions/removals) in the global SyncStatusPill, displaying multiple completion notifications sequentially in a FIFO queue.
Resets lastSyncAt = null for restored backup sources, ensuring their initial sync runs on the fresh-install path.
Bypasses database index/trigger locking for non-empty tables and releases locks early before entering category fallback loops.

## Which issue / improvement does it address?
Sync Completion Notifications: Fixes a bug from 6d6ad0edbc9d74cfb65bf3bceffd1676d64ff250 where completion status toasts never fired.
Invisible Channels on Restore: Fixes an issue where restoring a backup would trigger the "hide new categories on resync" setting during the first sync, hiding all channels.
Sync Locks/Failures: Resolves concurrent SQLite schema exceptions (e.g. SQLiteException: trigger ... already exists) and lock starvation when syncing multiple playlists on a fresh database.


## How was it tested?
Hisense Google TV 12

## Checklist
- [x] Builds locally (`./gradlew assembleDebug`) and CI is green
- [x] **Tested on a real Android TV / Fire TV device** (not emulator only) — D-pad/remote navigation works
- [x] No user data is wiped (Room migrations stay additive)
- [x] Keeps OwnTV player-only (no bundled channels/content)
- [x] Commit messages are clear (they become the release notes)
