### PR TITLE
Improve resolution badge to use pixel area matching

### DIFF
--- a/app/src/main/java/tv/own/owntv/player/LivePreviewEngine.kt
+++ b/app/src/main/java/tv/own/owntv/player/LivePreviewEngine.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlin.math.abs
 import okhttp3.OkHttpClient
 import tv.own.owntv.core.network.HttpClient
 
@@ -228,7 +229,7 @@ class LivePreviewEngine(
         val chips = ArrayList<String>(5)
         p.videoFormat?.let { f ->
             if (f.width > 0 && f.height > 0) aspectLabel(f.width, f.height)?.let { chips += it }
-            qualityLabel(f.height)?.let { chips += it }
+            qualityLabel(f.width, f.height)?.let { chips += it }
             displayFps(f)?.let { chips += "${Math.round(it)} FPS" }
             f.bitrate.takeIf { it > 0 }?.let { chips += "%.1f Mbps".format(it / 1_000_000.0) }
         }
@@ -259,15 +260,25 @@ class LivePreviewEngine(
             else -> "%.2f:1".format(r)
         }
     }
-    private fun qualityLabel(h: Int): String? = when {
-        h <= 0 -> null
-        h >= 2160 -> "4K"
-        h >= 1440 -> "1440p"
-        h >= 1080 -> "1080p"
-        h >= 720 -> "720p"
-        h >= 480 -> "480p"
-        else -> "${h}p"
+    private fun qualityLabel(w: Int, h: Int): String? {
+        if (h <= 0) return null
+        if (h < 480) return "${h}p"
+        if (w <= 0) return null
+        val area = w.toLong() * h.toLong()
+        return standards.minByOrNull { (_, stdArea) ->
+            abs(area - stdArea).toDouble() / stdArea.toDouble()
+        }?.label
     }
+
+    private data class ResStd(val label: String, val pixelArea: Long)
+
+    private val standards = listOf(
+        ResStd("4K",     8_294_400),     // 3840×2160
+        ResStd("1440p",  3_686_400),     // 2560×1440
+        ResStd("1080p",  2_073_600),     // 1920×1080
+        ResStd("720p",   921_600),       // 1280×720
+        ResStd("480p",   409_920),       // 854×480
+    )
 
     private val _currentMeta = MutableStateFlow(MediaMeta())
     override val currentMeta: StateFlow<MediaMeta> = _currentMeta.asStateFlow()


### PR DESCRIPTION
<!-- Thanks for contributing to OwnTV! Please fill this in so it's easy to review. -->

## Before you open this PR (required)
<!-- These are mandatory — PRs that duplicate an existing in-app feature are closed. -->
- [x] I read the **[User Guide](https://github.com/ahXN00/OwnTV/blob/main/extras/USER_GUIDE.md)** and checked the app's **Settings** and existing **functions** — this change isn't already possible in the app.
- [x] I searched existing issues/PRs and this isn't a duplicate.

## What does this PR do?
Improves the resolution/quality badge display in the live preview to use pixel area (width × height) matching against standard resolutions instead of relying solely on height.

Previously, the quality label was determined only by video height (e.g., 1080 for 1080p). This approach fails for videos with non-standard aspect ratios — for example, a 1920×800 video would be labeled as "800p" instead of "1080p".

The new implementation:
- Calculates the pixel area (width × height) of the video
- Compares it against standard resolution areas (4K, 1440p, 1080p, 720p, 480p)
- Matches to the closest standard resolution by area percentage difference
- Falls back to displaying the raw height (e.g., "600p") only for non-standard resolutions below 480p

## Which issue / improvement does it address?
This fixes inaccurate resolution badges for content with non-standard aspect ratios, which is common with movies and ultrawide content. Users will now see "1080p" for a 1920×800 movie instead of "800p", matching industry-standard labeling.

## How was it tested?
<!-- IMPORTANT: OwnTV is a TV app — please test on a REAL Android TV / Fire TV device, not the emulator
     only. The emulator misses a lot: HDR, hardware decoding, surround/passthrough, and real remote
     (D-pad) behaviour. -->
- **Device(s) tested on:** <!-- e.g. Fire TV Stick 4K Max, NVIDIA Shield, TCL Google TV -->
- **What you exercised:** <!-- e.g. played a 4K HDR movie, switched audio track on live, EPG catch-up, D-pad nav -->

## Checklist
- [x] Builds locally (`./gradlew assembleDebug`) and CI is green
- [ ] **Tested on a real Android TV / Fire TV device** (not emulator only) — D-pad/remote navigation works
- [x] No user data is wiped (Room migrations stay additive)
- [x] Keeps OwnTV player-only (no bundled channels/content)
- [x] Commit messages are clear (they become the release notes)