### PR TITLE
Direct channel-number tuning for live TV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## v4.1.5 — unreleased
 
+### 📺 Channel numbers — type a number on the remote to tune
+
+- **Type a channel number while watching Live TV full screen** and OwnTV tunes straight to it, the way a
+  set-top box does — no list, no guide, no holding CH+ through fifty channels. Works with the **number
+  row and the numpad** on your remote.
+- The number appears top-left as you type, with a **bar that drains over the two seconds** before it
+  submits, so you always know how long you have to add another digit. Press **OK** to tune immediately,
+  or **Back** to cancel. Five digits submit on their own.
+- Once it resolves, the same card becomes the **channel OSD** — logo, name and number — and stays up
+  until the new channel is actually on screen. If nothing matches you get **"Channel not found"** on that
+  card with the number you entered.
+- The number searched is your provider's own channel number, **from the playlist you're currently
+  watching**. Only if that playlist has no channel with the number do your other active Live playlists
+  get searched, so a number in your current playlist is never hijacked by another one.
+- **Hidden channels and hidden categories are skipped**, and renamed channels show your name. If a
+  playlist genuinely uses one number for several visible channels, the one from the list you opened wins;
+  if that's still not decisive you get **"Multiple channels"** rather than a guess.
+- **CH+/− keeps working right after a numeric jump**, even when you land far outside the list you opened.
+- Channel numbers are now shown in more places so you can learn the ones you use: the **channel-list
+  overlay** lists them before the channel name, and the player's channel card shows **#number** under the
+  name on every channel.
+- Numeric tuning is only active on a live channel in full screen — during **catch-up or timeshift** the
+  number keys are left alone.
+
 ### 💾 A proper backup file — `.own`, with your wallpaper inside and real encryption
 
 - Backups are now written as **`owntv-backup.own`** instead of a plain `owntv-backup.json`. It is one
@@ -214,6 +238,11 @@
 - **Fewer "failed on both engines" errors.** When mpv had to be torn down and playback handed to
   ExoPlayer, the handoff could grab a video surface that was already being replaced and die instantly
   on an item that played fine on the next try. The handoff now waits for the new surface.
+- **The resolution badge no longer under-reports wide-format streams.** The stream-info overlay worked out
+  the quality label from the picture **height** alone, so a channel broadcasting a wide 1920×800 picture was
+  labelled from its short edge and read **720p** even though it's a 1080p-class stream. The label is now
+  chosen by **total pixel count** against the standard resolutions (4K / 1440p / 1080p / 720p / 480p), so
+  cinema-format and letterboxed channels report the quality they actually deliver.
 
 ### 📺 Live TV
 

--- a/CHANGELOG_APP.md
+++ b/CHANGELOG_APP.md
@@ -13,6 +13,7 @@
 
 ### ✨ New features
 
+- **📺 Channel numbers — type a number on the remote to tune in Live TV**
 - **💾 A proper backup file — `.own`, with your wallpaper inside and real encryption**
 - **🗂️ Browsing & lists — decide what Live TV, Movies and Series come back to**
 - **🌍 Metadata language — descriptions and posters in your language**
@@ -58,6 +59,7 @@
 - **A live channel opened from the Guide did not appear in History**
 - **Live preview played sound on surround channels with preview audio off**
 - **The Preview audio setting did not apply to a preview already playing**
+- **Resolution badge under-reported wide-format streams (1920×800 read as 720p)**
 
 ## v4.1.4 — 2026-07-24
 

--- a/app/schemas/tv.own.owntv.core.database.OwnTVDatabase/20.json
+++ b/app/schemas/tv.own.owntv.core.database.OwnTVDatabase/20.json
@@ -1,0 +1,2585 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 20,
+    "identityHash": "6946f43488ca16ce7e8ddef16a7e77ba",
+    "entities": [
+      {
+        "tableName": "profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `avatarColor` INTEGER NOT NULL, `avatarId` INTEGER NOT NULL, `isKids` INTEGER NOT NULL, `pinHash` TEXT, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarColor",
+            "columnName": "avatarColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarId",
+            "columnName": "avatarId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isKids",
+            "columnName": "isKids",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinHash",
+            "columnName": "pinHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `url` TEXT NOT NULL, `username` TEXT, `password` TEXT, `mac` TEXT, `userAgent` TEXT, `epgUrl` TEXT, `syncLive` INTEGER NOT NULL, `syncMovies` INTEGER NOT NULL, `syncSeries` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `lastSyncAt` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mac",
+            "columnName": "mac",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userAgent",
+            "columnName": "userAgent",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "epgUrl",
+            "columnName": "epgUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncLive",
+            "columnName": "syncLive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncMovies",
+            "columnName": "syncMovies",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncSeries",
+            "columnName": "syncSeries",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncAt",
+            "columnName": "lastSyncAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sources_type",
+            "unique": false,
+            "columnNames": [
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sources_type` ON `${TABLE_NAME}` (`type`)"
+          }
+        ]
+      },
+      {
+        "tableName": "profile_source",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`profileId` INTEGER NOT NULL, `sourceId` INTEGER NOT NULL, PRIMARY KEY(`profileId`, `sourceId`), FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "profileId",
+            "sourceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_profile_source_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_profile_source_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `name` TEXT NOT NULL, `remoteId` TEXT, `sortOrder` INTEGER NOT NULL, FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_categories_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_categories_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_categories_sourceId_mediaType",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "mediaType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_categories_sourceId_mediaType` ON `${TABLE_NAME}` (`sourceId`, `mediaType`)"
+          },
+          {
+            "name": "index_categories_sourceId_mediaType_remoteId",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "mediaType",
+              "remoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_categories_sourceId_mediaType_remoteId` ON `${TABLE_NAME}` (`sourceId`, `mediaType`, `remoteId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "channels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `categoryId` INTEGER, `name` TEXT NOT NULL, `logoUrl` TEXT, `streamUrl` TEXT NOT NULL, `epgChannelId` TEXT, `number` INTEGER, `remoteId` TEXT, `sortOrder` INTEGER NOT NULL, `catchup` INTEGER NOT NULL, `catchupDays` INTEGER NOT NULL, `catchupSource` TEXT, `contentHash` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`categoryId`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoUrl",
+            "columnName": "logoUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epgChannelId",
+            "columnName": "epgChannelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catchup",
+            "columnName": "catchup",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catchupDays",
+            "columnName": "catchupDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catchupSource",
+            "columnName": "catchupSource",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_channels_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_channels_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          },
+          {
+            "name": "index_channels_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_channels_epgChannelId",
+            "unique": false,
+            "columnNames": [
+              "epgChannelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_epgChannelId` ON `${TABLE_NAME}` (`epgChannelId`)"
+          },
+          {
+            "name": "index_channels_sourceId_remoteId",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "remoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_channels_sourceId_remoteId` ON `${TABLE_NAME}` (`sourceId`, `remoteId`)"
+          },
+          {
+            "name": "index_channels_sourceId_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_sourceId_name` ON `${TABLE_NAME}` (`sourceId`, `name`)"
+          },
+          {
+            "name": "index_channels_categoryId_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_categoryId_name` ON `${TABLE_NAME}` (`categoryId`, `name`)"
+          },
+          {
+            "name": "index_channels_sourceId_sortOrder_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "sortOrder",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_sourceId_sortOrder_name` ON `${TABLE_NAME}` (`sourceId`, `sortOrder`, `name`)"
+          },
+          {
+            "name": "index_channels_categoryId_sortOrder_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "sortOrder",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_categoryId_sortOrder_name` ON `${TABLE_NAME}` (`categoryId`, `sortOrder`, `name`)"
+          },
+          {
+            "name": "index_channels_sourceId_number",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "number"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_sourceId_number` ON `${TABLE_NAME}` (`sourceId`, `number`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "categories",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "categoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "movies",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `categoryId` INTEGER, `name` TEXT NOT NULL, `posterUrl` TEXT, `backdropUrl` TEXT, `year` INTEGER, `rating` REAL, `durationSecs` INTEGER, `plot` TEXT, `streamUrl` TEXT NOT NULL, `containerExt` TEXT, `remoteId` TEXT, `addedAt` INTEGER, `sortOrder` INTEGER NOT NULL, `contentHash` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`categoryId`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "posterUrl",
+            "columnName": "posterUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "backdropUrl",
+            "columnName": "backdropUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "durationSecs",
+            "columnName": "durationSecs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "plot",
+            "columnName": "plot",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "containerExt",
+            "columnName": "containerExt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_movies_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_movies_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          },
+          {
+            "name": "index_movies_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_movies_sourceId_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_sourceId_name` ON `${TABLE_NAME}` (`sourceId`, `name`)"
+          },
+          {
+            "name": "index_movies_categoryId_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_categoryId_name` ON `${TABLE_NAME}` (`categoryId`, `name`)"
+          },
+          {
+            "name": "index_movies_sourceId_sortOrder_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "sortOrder",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_sourceId_sortOrder_name` ON `${TABLE_NAME}` (`sourceId`, `sortOrder`, `name`)"
+          },
+          {
+            "name": "index_movies_categoryId_sortOrder_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "sortOrder",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_categoryId_sortOrder_name` ON `${TABLE_NAME}` (`categoryId`, `sortOrder`, `name`)"
+          },
+          {
+            "name": "index_movies_sourceId_remoteId",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "remoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_movies_sourceId_remoteId` ON `${TABLE_NAME}` (`sourceId`, `remoteId`)"
+          },
+          {
+            "name": "index_movies_sourceId_rating_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "rating",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_sourceId_rating_name` ON `${TABLE_NAME}` (`sourceId`, `rating`, `name`)"
+          },
+          {
+            "name": "index_movies_categoryId_rating_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "rating",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_categoryId_rating_name` ON `${TABLE_NAME}` (`categoryId`, `rating`, `name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "categories",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "categoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `categoryId` INTEGER, `name` TEXT NOT NULL, `posterUrl` TEXT, `backdropUrl` TEXT, `year` INTEGER, `rating` REAL, `plot` TEXT, `remoteId` TEXT, `sortOrder` INTEGER NOT NULL, `contentHash` INTEGER NOT NULL DEFAULT 0, `episodesSyncedAt` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`categoryId`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "posterUrl",
+            "columnName": "posterUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "backdropUrl",
+            "columnName": "backdropUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "plot",
+            "columnName": "plot",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "episodesSyncedAt",
+            "columnName": "episodesSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_series_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_series_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          },
+          {
+            "name": "index_series_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_series_sourceId_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_sourceId_name` ON `${TABLE_NAME}` (`sourceId`, `name`)"
+          },
+          {
+            "name": "index_series_categoryId_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_categoryId_name` ON `${TABLE_NAME}` (`categoryId`, `name`)"
+          },
+          {
+            "name": "index_series_sourceId_sortOrder_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "sortOrder",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_sourceId_sortOrder_name` ON `${TABLE_NAME}` (`sourceId`, `sortOrder`, `name`)"
+          },
+          {
+            "name": "index_series_categoryId_sortOrder_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "sortOrder",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_categoryId_sortOrder_name` ON `${TABLE_NAME}` (`categoryId`, `sortOrder`, `name`)"
+          },
+          {
+            "name": "index_series_sourceId_remoteId",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "remoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_series_sourceId_remoteId` ON `${TABLE_NAME}` (`sourceId`, `remoteId`)"
+          },
+          {
+            "name": "index_series_sourceId_rating_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "rating",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_sourceId_rating_name` ON `${TABLE_NAME}` (`sourceId`, `rating`, `name`)"
+          },
+          {
+            "name": "index_series_categoryId_rating_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "rating",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_categoryId_rating_name` ON `${TABLE_NAME}` (`categoryId`, `rating`, `name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "categories",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "categoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "seasons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `seriesId` INTEGER NOT NULL, `seasonNumber` INTEGER NOT NULL, `name` TEXT, `remoteId` TEXT, FOREIGN KEY(`seriesId`) REFERENCES `series`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seasonNumber",
+            "columnName": "seasonNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_seasons_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_seasons_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "series",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "seriesId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `seriesId` INTEGER NOT NULL, `seasonId` INTEGER, `seasonNumber` INTEGER NOT NULL, `episodeNumber` INTEGER NOT NULL, `name` TEXT NOT NULL, `plot` TEXT, `streamUrl` TEXT NOT NULL, `durationSecs` INTEGER, `containerExt` TEXT, `remoteId` TEXT, FOREIGN KEY(`seriesId`) REFERENCES `series`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`seasonId`) REFERENCES `seasons`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seasonId",
+            "columnName": "seasonId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seasonNumber",
+            "columnName": "seasonNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeNumber",
+            "columnName": "episodeNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "plot",
+            "columnName": "plot",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationSecs",
+            "columnName": "durationSecs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "containerExt",
+            "columnName": "containerExt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodes_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_episodes_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          },
+          {
+            "name": "index_episodes_seasonId",
+            "unique": false,
+            "columnNames": [
+              "seasonId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_episodes_seasonId` ON `${TABLE_NAME}` (`seasonId`)"
+          },
+          {
+            "name": "index_episodes_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_episodes_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_episodes_seriesId_remoteId",
+            "unique": true,
+            "columnNames": [
+              "seriesId",
+              "remoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodes_seriesId_remoteId` ON `${TABLE_NAME}` (`seriesId`, `remoteId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "series",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "seriesId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "seasons",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "seasonId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "favorites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileId` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `itemId` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorites_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorites_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_favorites_profileId_mediaType_itemId",
+            "unique": true,
+            "columnNames": [
+              "profileId",
+              "mediaType",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_favorites_profileId_mediaType_itemId` ON `${TABLE_NAME}` (`profileId`, `mediaType`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "watch_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileId` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `itemId` INTEGER NOT NULL, `watchedAt` INTEGER NOT NULL, FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watchedAt",
+            "columnName": "watchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_watch_history_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_watch_history_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_watch_history_profileId_watchedAt",
+            "unique": false,
+            "columnNames": [
+              "profileId",
+              "watchedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_watch_history_profileId_watchedAt` ON `${TABLE_NAME}` (`profileId`, `watchedAt`)"
+          },
+          {
+            "name": "index_watch_history_profileId_mediaType_itemId",
+            "unique": true,
+            "columnNames": [
+              "profileId",
+              "mediaType",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_watch_history_profileId_mediaType_itemId` ON `${TABLE_NAME}` (`profileId`, `mediaType`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileId` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `itemId` INTEGER NOT NULL, `positionMs` INTEGER NOT NULL, `durationMs` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "positionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_progress_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_progress_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_playback_progress_profileId_mediaType_itemId",
+            "unique": true,
+            "columnNames": [
+              "profileId",
+              "mediaType",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_playback_progress_profileId_mediaType_itemId` ON `${TABLE_NAME}` (`profileId`, `mediaType`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "content_order",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileId` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `contextKey` TEXT NOT NULL, `itemId` INTEGER NOT NULL, `position` INTEGER NOT NULL, FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextKey",
+            "columnName": "contextKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_content_order_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_content_order_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_content_order_profileId_mediaType_contextKey",
+            "unique": false,
+            "columnNames": [
+              "profileId",
+              "mediaType",
+              "contextKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_content_order_profileId_mediaType_contextKey` ON `${TABLE_NAME}` (`profileId`, `mediaType`, `contextKey`)"
+          },
+          {
+            "name": "index_content_order_profileId_mediaType_contextKey_itemId",
+            "unique": true,
+            "columnNames": [
+              "profileId",
+              "mediaType",
+              "contextKey",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_content_order_profileId_mediaType_contextKey_itemId` ON `${TABLE_NAME}` (`profileId`, `mediaType`, `contextKey`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileId` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `itemId` INTEGER NOT NULL, `title` TEXT NOT NULL, `posterUrl` TEXT, `streamUrl` TEXT NOT NULL, `filePath` TEXT, `status` TEXT NOT NULL, `downloadedBytes` INTEGER NOT NULL, `totalBytes` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "posterUrl",
+            "columnName": "posterUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedBytes",
+            "columnName": "downloadedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalBytes",
+            "columnName": "totalBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_downloads_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_downloads_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_downloads_profileId_mediaType_itemId",
+            "unique": true,
+            "columnNames": [
+              "profileId",
+              "mediaType",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_downloads_profileId_mediaType_itemId` ON `${TABLE_NAME}` (`profileId`, `mediaType`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "tv_provider_programs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileId` INTEGER NOT NULL, `surface` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `groupId` INTEGER NOT NULL, `targetItemId` INTEGER NOT NULL, `providerProgramId` INTEGER, `lastPositionMs` INTEGER NOT NULL, `durationMs` INTEGER NOT NULL, `lastEngagementAt` INTEGER NOT NULL, `lastPublishedAt` INTEGER NOT NULL, FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surface",
+            "columnName": "surface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetItemId",
+            "columnName": "targetItemId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerProgramId",
+            "columnName": "providerProgramId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastPositionMs",
+            "columnName": "lastPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastEngagementAt",
+            "columnName": "lastEngagementAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPublishedAt",
+            "columnName": "lastPublishedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tv_provider_programs_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tv_provider_programs_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_tv_provider_programs_profileId_surface_mediaType_groupId",
+            "unique": true,
+            "columnNames": [
+              "profileId",
+              "surface",
+              "mediaType",
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tv_provider_programs_profileId_surface_mediaType_groupId` ON `${TABLE_NAME}` (`profileId`, `surface`, `mediaType`, `groupId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "epg_channels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `epgChannelId` TEXT NOT NULL, `displayName` TEXT, `iconUrl` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epgChannelId",
+            "columnName": "epgChannelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "iconUrl",
+            "columnName": "iconUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_epg_channels_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_epg_channels_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_epg_channels_sourceId_epgChannelId",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "epgChannelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_epg_channels_sourceId_epgChannelId` ON `${TABLE_NAME}` (`sourceId`, `epgChannelId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "epg_programmes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `epgChannelId` TEXT NOT NULL, `startMs` INTEGER NOT NULL, `stopMs` INTEGER NOT NULL, `title` TEXT NOT NULL, `description` TEXT, `contentHash` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epgChannelId",
+            "columnName": "epgChannelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startMs",
+            "columnName": "startMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopMs",
+            "columnName": "stopMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_epg_programmes_epgChannelId_startMs",
+            "unique": false,
+            "columnNames": [
+              "epgChannelId",
+              "startMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_epg_programmes_epgChannelId_startMs` ON `${TABLE_NAME}` (`epgChannelId`, `startMs`)"
+          },
+          {
+            "name": "index_epg_programmes_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_epg_programmes_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_epg_programmes_stopMs",
+            "unique": false,
+            "columnNames": [
+              "stopMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_epg_programmes_stopMs` ON `${TABLE_NAME}` (`stopMs`)"
+          },
+          {
+            "name": "index_epg_programmes_sourceId_epgChannelId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "epgChannelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_epg_programmes_sourceId_epgChannelId` ON `${TABLE_NAME}` (`sourceId`, `epgChannelId`)"
+          },
+          {
+            "name": "index_epg_programmes_natural_key",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "epgChannelId",
+              "startMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_epg_programmes_natural_key` ON `${TABLE_NAME}` (`sourceId`, `epgChannelId`, `startMs`)"
+          }
+        ]
+      },
+      {
+        "tableName": "metadata_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `tmdbId` INTEGER NOT NULL, `imdbId` TEXT, `type` TEXT NOT NULL, `title` TEXT NOT NULL, `year` INTEGER, `overview` TEXT, `posterPath` TEXT, `backdropPath` TEXT, `rating` REAL, `genresJson` TEXT, `castJson` TEXT, `trailerKey` TEXT, `logoPath` TEXT, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tmdbId",
+            "columnName": "tmdbId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imdbId",
+            "columnName": "imdbId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "overview",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "posterPath",
+            "columnName": "posterPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "backdropPath",
+            "columnName": "backdropPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "genresJson",
+            "columnName": "genresJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "castJson",
+            "columnName": "castJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trailerKey",
+            "columnName": "trailerKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "logoPath",
+            "columnName": "logoPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_metadata_cache_tmdbId",
+            "unique": false,
+            "columnNames": [
+              "tmdbId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_metadata_cache_tmdbId` ON `${TABLE_NAME}` (`tmdbId`)"
+          },
+          {
+            "name": "index_metadata_cache_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_metadata_cache_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "metadata_match",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localKey` TEXT NOT NULL, `type` TEXT NOT NULL, `tmdbId` INTEGER, `confidence` REAL NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`localKey`))",
+        "fields": [
+          {
+            "fieldPath": "localKey",
+            "columnName": "localKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tmdbId",
+            "columnName": "tmdbId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "localKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_metadata_match_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_metadata_match_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subtitle_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `source` TEXT NOT NULL, `openSubFileId` INTEGER, `language` TEXT, `languageName` TEXT, `releaseName` TEXT, `format` TEXT, `hearingImpaired` INTEGER NOT NULL, `fileName` TEXT NOT NULL, `cachedPath` TEXT NOT NULL, `lastUsedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openSubFileId",
+            "columnName": "openSubFileId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "languageName",
+            "columnName": "languageName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "releaseName",
+            "columnName": "releaseName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "hearingImpaired",
+            "columnName": "hearingImpaired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedPath",
+            "columnName": "cachedPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsedAt",
+            "columnName": "lastUsedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subtitle_cache_openSubFileId",
+            "unique": true,
+            "columnNames": [
+              "openSubFileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_subtitle_cache_openSubFileId` ON `${TABLE_NAME}` (`openSubFileId`)"
+          },
+          {
+            "name": "index_subtitle_cache_lastUsedAt",
+            "unique": false,
+            "columnNames": [
+              "lastUsedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subtitle_cache_lastUsedAt` ON `${TABLE_NAME}` (`lastUsedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subtitle_selection",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`profileId` INTEGER NOT NULL, `contentKey` TEXT NOT NULL, `cacheId` INTEGER, `off` INTEGER NOT NULL DEFAULT 0, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`profileId`, `contentKey`), FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`cacheId`) REFERENCES `subtitle_cache`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentKey",
+            "columnName": "contentKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheId",
+            "columnName": "cacheId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "off",
+            "columnName": "off",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "profileId",
+            "contentKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subtitle_selection_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subtitle_selection_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_subtitle_selection_cacheId",
+            "unique": false,
+            "columnNames": [
+              "cacheId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subtitle_selection_cacheId` ON `${TABLE_NAME}` (`cacheId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "subtitle_cache",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "cacheId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "subtitle_timing",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`profileId` INTEGER NOT NULL, `contentKey` TEXT NOT NULL, `subtitleKey` TEXT NOT NULL, `offsetMs` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`profileId`, `contentKey`, `subtitleKey`), FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentKey",
+            "columnName": "contentKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitleKey",
+            "columnName": "subtitleKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offsetMs",
+            "columnName": "offsetMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "profileId",
+            "contentKey",
+            "subtitleKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subtitle_timing_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subtitle_timing_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "subtitle_link",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`profileId` INTEGER NOT NULL, `contentKey` TEXT NOT NULL, `cacheId` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `contentTitle` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`profileId`, `contentKey`, `cacheId`), FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`cacheId`) REFERENCES `subtitle_cache`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentKey",
+            "columnName": "contentKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheId",
+            "columnName": "cacheId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentTitle",
+            "columnName": "contentTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "profileId",
+            "contentKey",
+            "cacheId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subtitle_link_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subtitle_link_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_subtitle_link_cacheId",
+            "unique": false,
+            "columnNames": [
+              "cacheId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subtitle_link_cacheId` ON `${TABLE_NAME}` (`cacheId`)"
+          },
+          {
+            "name": "index_subtitle_link_profileId_mediaType",
+            "unique": false,
+            "columnNames": [
+              "profileId",
+              "mediaType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subtitle_link_profileId_mediaType` ON `${TABLE_NAME}` (`profileId`, `mediaType`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "subtitle_cache",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "cacheId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "channels_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`name` TEXT NOT NULL, content=`channels`)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "channels",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_channels_fts_BEFORE_UPDATE BEFORE UPDATE ON `channels` BEGIN DELETE FROM `channels_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_channels_fts_BEFORE_DELETE BEFORE DELETE ON `channels` BEGIN DELETE FROM `channels_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_channels_fts_AFTER_UPDATE AFTER UPDATE ON `channels` BEGIN INSERT INTO `channels_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_channels_fts_AFTER_INSERT AFTER INSERT ON `channels` BEGIN INSERT INTO `channels_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END"
+        ]
+      },
+      {
+        "tableName": "movies_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`name` TEXT NOT NULL, content=`movies`)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "movies",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_movies_fts_BEFORE_UPDATE BEFORE UPDATE ON `movies` BEGIN DELETE FROM `movies_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_movies_fts_BEFORE_DELETE BEFORE DELETE ON `movies` BEGIN DELETE FROM `movies_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_movies_fts_AFTER_UPDATE AFTER UPDATE ON `movies` BEGIN INSERT INTO `movies_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_movies_fts_AFTER_INSERT AFTER INSERT ON `movies` BEGIN INSERT INTO `movies_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END"
+        ]
+      },
+      {
+        "tableName": "series_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`name` TEXT NOT NULL, content=`series`)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "series",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_series_fts_BEFORE_UPDATE BEFORE UPDATE ON `series` BEGIN DELETE FROM `series_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_series_fts_BEFORE_DELETE BEFORE DELETE ON `series` BEGIN DELETE FROM `series_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_series_fts_AFTER_UPDATE AFTER UPDATE ON `series` BEGIN INSERT INTO `series_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_series_fts_AFTER_INSERT AFTER INSERT ON `series` BEGIN INSERT INTO `series_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END"
+        ]
+      },
+      {
+        "tableName": "episodes_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`name` TEXT NOT NULL, content=`episodes`)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "episodes",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_episodes_fts_BEFORE_UPDATE BEFORE UPDATE ON `episodes` BEGIN DELETE FROM `episodes_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_episodes_fts_BEFORE_DELETE BEFORE DELETE ON `episodes` BEGIN DELETE FROM `episodes_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_episodes_fts_AFTER_UPDATE AFTER UPDATE ON `episodes` BEGIN INSERT INTO `episodes_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_episodes_fts_AFTER_INSERT AFTER INSERT ON `episodes` BEGIN INSERT INTO `episodes_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END"
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6946f43488ca16ce7e8ddef16a7e77ba')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/tv/own/owntv/core/database/ChannelDaoBoundedWindowTest.kt
+++ b/app/src/androidTest/java/tv/own/owntv/core/database/ChannelDaoBoundedWindowTest.kt
@@ -1,0 +1,388 @@
+package tv.own.owntv.core.database
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import tv.own.owntv.core.database.dao.ChannelDao
+import tv.own.owntv.core.database.entity.ChannelEntity
+import tv.own.owntv.core.model.MediaType
+import tv.own.owntv.core.model.SourceType
+
+/**
+ * Behavioral tests for the bounded window queries added for direct-tune's zap-list rebuild.
+ * These verify the (sortOrder, id) cursor predicate matches the ORDER BY so no channel slips
+ * through the gap when sortOrder ties — the P2 regression the DAO was fixed for.
+ */
+@RunWith(AndroidJUnit4::class)
+class ChannelDaoBoundedWindowTest {
+    private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+    private lateinit var db: OwnTVDatabase
+    private lateinit var dao: ChannelDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(context, OwnTVDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.channelDao()
+        runBlocking {
+            db.sourceDao().seedSources(
+                listOf(
+                    SourceSeed(id = 10, name = "Provider A"),
+                    SourceSeed(id = 20, name = "Provider B"),
+                ),
+            )
+            db.categoryDao().seedCategories(
+                listOf(
+                    CategorySeed(id = 100, sourceId = 10, mediaType = MediaType.LIVE, name = "Live", sortOrder = 0),
+                    CategorySeed(id = 200, sourceId = 20, mediaType = MediaType.LIVE, name = "Live", sortOrder = 0),
+                ),
+            )
+        }
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun findByNumber_returnsAllMatchingChannels_acrossSources() = runBlocking {
+        seedCategory(
+            categoryId = 100, sourceId = 10,
+            channels = listOf(
+                ChannelSpec(id = 1L, name = "A-News",   number = 5, sortOrder = 0),
+                ChannelSpec(id = 2L, name = "A-Sports", number = 5, sortOrder = 1),  // duplicate number
+            ),
+        )
+        seedCategory(
+            categoryId = 200, sourceId = 20,
+            channels = listOf(
+                ChannelSpec(id = 3L, name = "B-News",   number = 5, sortOrder = 0),
+            ),
+        )
+
+        val results = dao.findByNumber(listOf(10L, 20L), 5)
+        assertEquals(3, results.size)
+        assertEquals(setOf(1L, 2L, 3L), results.map { it.id }.toSet())
+    }
+
+    @Test
+    fun findByNumber_returnsEmptyForUnknownNumber() = runBlocking {
+        seedCategory(
+            categoryId = 100, sourceId = 10,
+            channels = listOf(
+                ChannelSpec(id = 1L, name = "A-News",   number = 5, sortOrder = 0),
+            ),
+        )
+        assertEquals(emptyList<ChannelEntity>(), dao.findByNumber(listOf(10L), 99))
+    }
+
+    /**
+     * findByNumber must return duplicates in a stable, deterministic order so the resolver's
+     * single-match fast path is meaningful. The ORDER BY is (sourceId, sortOrder, name, id).
+     */
+    @Test
+    fun findByNumber_duplicateNumber_returnsInDeterministicOrder() = runBlocking {
+        seedCategory(
+            categoryId = 100, sourceId = 10,
+            channels = listOf(
+                ChannelSpec(id = 1L, name = "Bravo", number = 7, sortOrder = 0),
+                ChannelSpec(id = 2L, name = "Alpha", number = 7, sortOrder = 0),  // same sortOrder, name sorts first
+                ChannelSpec(id = 3L, name = "Alpha", number = 7, sortOrder = 0),  // same name + sortOrder → id tiebreaker
+                ChannelSpec(id = 4L, name = "Charlie", number = 7, sortOrder = 1),
+            ),
+        )
+
+        val results = dao.findByNumber(listOf(10L), 7)
+        assertEquals(listOf(2L, 3L, 1L, 4L), results.map { it.id })
+    }
+
+    /**
+     * Two sources with the same provider number → current-source wins. The resolver relies on
+     * findByNumber returning the current-source row first when both sources are queried.
+     */
+    @Test
+    fun findByNumber_crossSource_currentSourceWins() = runBlocking {
+        seedCategory(
+            categoryId = 100, sourceId = 10,
+            channels = listOf(
+                ChannelSpec(id = 1L, name = "SourceA-Ch42", number = 42, sortOrder = 0),
+            ),
+        )
+        seedCategory(
+            categoryId = 200, sourceId = 20,
+            channels = listOf(
+                ChannelSpec(id = 2L, name = "SourceB-Ch42", number = 42, sortOrder = 0),
+            ),
+        )
+
+        // Querying both together: source 10 (current) comes first.
+        val both = dao.findByNumber(listOf(10L, 20L), 42)
+        assertEquals(listOf(1L, 2L), both.map { it.id })
+    }
+
+    @Test
+    fun channelsAfterCategory_excludesTunedChannel_andStopsAtLimit() = runBlocking {
+        // 8 channels in category 100; tuned channel is id=5 (sortOrder=4). Half-window=3 means
+        // the next 3 strictly-after rows: id=6,7,8.
+        seedCategory(
+            categoryId = 100, sourceId = 10,
+            channels = (1L..8L).map { i ->
+                ChannelSpec(id = i, name = "Ch$i", number = i.toInt(), sortOrder = i.toInt() - 1)
+            },
+        )
+
+        val after = dao.channelsAfterCategory(
+            categoryId = 100, afterSortOrder = 4, afterId = 5L, limit = 3,
+        )
+        assertEquals(listOf(6L, 7L, 8L), after.map { it.id })
+    }
+
+    @Test
+    fun channelsBeforeCategory_returnsInReverse_andExcludesTunedChannel() = runBlocking {
+        // Tuned channel is id=5 (sortOrder=4). Half-window=3 means the 3 strictly-before rows
+        // (id=4,3,2) in DESC order.
+        seedCategory(
+            categoryId = 100, sourceId = 10,
+            channels = (1L..8L).map { i ->
+                ChannelSpec(id = i, name = "Ch$i", number = i.toInt(), sortOrder = i.toInt() - 1)
+            },
+        )
+
+        val before = dao.channelsBeforeCategory(
+            categoryId = 100, beforeSortOrder = 4, beforeId = 5L, limit = 3,
+        )
+        assertEquals(listOf(4L, 3L, 2L), before.map { it.id })
+    }
+
+    /**
+     * The exact regression: sortOrder ties. Three channels at sortOrder=5, ids 10/11/12; tuned
+     * channel is id=11. After-query must return id=12 (strictly greater), never id=10 or 11 —
+     * the old `(sortOrder > x)` predicate would have skipped id=12 entirely.
+     */
+    @Test
+    fun channelsAfterCategory_handlesSortOrderTie_viaIdTiebreaker() = runBlocking {
+        seedCategory(
+            categoryId = 100, sourceId = 10,
+            channels = listOf(
+                ChannelSpec(id = 10L, name = "Tied-A", number = 1, sortOrder = 5),
+                ChannelSpec(id = 11L, name = "Tuned",  number = 2, sortOrder = 5),  // tuned
+                ChannelSpec(id = 12L, name = "Tied-B", number = 3, sortOrder = 5),  // must appear in AFTER
+                ChannelSpec(id = 13L, name = "Tied-C", number = 4, sortOrder = 5),  // must appear in AFTER after id=12
+            ),
+        )
+
+        val after = dao.channelsAfterCategory(
+            categoryId = 100, afterSortOrder = 5, afterId = 11L, limit = 10,
+        )
+        assertEquals(listOf(12L, 13L), after.map { it.id })
+    }
+
+    @Test
+    fun channelsBeforeCategory_handlesSortOrderTie_viaIdTiebreaker() = runBlocking {
+        seedCategory(
+            categoryId = 100, sourceId = 10,
+            channels = listOf(
+                ChannelSpec(id = 10L, name = "Tied-A", number = 1, sortOrder = 5),  // must appear in BEFORE
+                ChannelSpec(id = 11L, name = "Tied-B", number = 2, sortOrder = 5),  // must appear in BEFORE
+                ChannelSpec(id = 12L, name = "Tuned",  number = 3, sortOrder = 5),  // tuned
+                ChannelSpec(id = 13L, name = "Tied-C", number = 4, sortOrder = 5),
+            ),
+        )
+
+        val before = dao.channelsBeforeCategory(
+            categoryId = 100, beforeSortOrder = 5, beforeId = 12L, limit = 10,
+        )
+        // DESC order: id=11 first, then id=10.
+        assertEquals(listOf(11L, 10L), before.map { it.id })
+    }
+
+    @Test
+    fun channelsAfterSource_spansAcrossCategories() = runBlocking {
+        // Source 10 has two categories. Tuned channel in cat 100; AFTER must include channels
+        // from cat 200 that have a higher sortOrder than the tuned channel.
+        seedCategory(
+            categoryId = 100, sourceId = 10,
+            channels = listOf(
+                ChannelSpec(id = 1L, name = "Cat100-A", number = 1, sortOrder = 0),
+                ChannelSpec(id = 2L, name = "Cat100-B", number = 2, sortOrder = 1),  // tuned
+            ),
+        )
+        seedCategory(
+            categoryId = 200, sourceId = 10,
+            channels = listOf(
+                ChannelSpec(id = 3L, name = "Cat200-A", number = 3, sortOrder = 2),
+                ChannelSpec(id = 4L, name = "Cat200-B", number = 4, sortOrder = 3),
+            ),
+        )
+
+        val after = dao.channelsAfterSource(
+            sourceId = 10, afterSortOrder = 1, afterId = 2L, limit = 10,
+        )
+        assertEquals(listOf(3L, 4L), after.map { it.id })
+    }
+
+    @Test
+    fun channelsAfterSource_isolatesBySource() = runBlocking {
+        // Two sources with channels at the same sortOrder. AFTER in source 10 must NOT include
+        // channels from source 20.
+        seedCategory(
+            categoryId = 100, sourceId = 10,
+            channels = listOf(
+                ChannelSpec(id = 1L, name = "A-1", number = 1, sortOrder = 0),
+                ChannelSpec(id = 2L, name = "A-2", number = 2, sortOrder = 1),  // tuned
+                ChannelSpec(id = 3L, name = "A-3", number = 3, sortOrder = 2),
+            ),
+        )
+        seedCategory(
+            categoryId = 200, sourceId = 20,
+            channels = listOf(
+                ChannelSpec(id = 4L, name = "B-1", number = 1, sortOrder = 0),
+                ChannelSpec(id = 5L, name = "B-2", number = 2, sortOrder = 1),
+                ChannelSpec(id = 6L, name = "B-3", number = 3, sortOrder = 2),
+            ),
+        )
+
+        val after = dao.channelsAfterSource(
+            sourceId = 10, afterSortOrder = 1, afterId = 2L, limit = 10,
+        )
+        assertEquals(listOf(3L), after.map { it.id })
+        // Sanity: the source-20 channels really do exist with the same sortOrders.
+        val after20 = dao.channelsAfterSource(
+            sourceId = 20, afterSortOrder = 1, afterId = 5L, limit = 10,
+        )
+        assertEquals(listOf(6L), after20.map { it.id })
+    }
+
+    @Test
+    fun channelsBeforeSource_handlesSortOrderTie() = runBlocking {
+        seedCategory(
+            categoryId = 100, sourceId = 10,
+            channels = listOf(
+                ChannelSpec(id = 10L, name = "Tied-A", number = 1, sortOrder = 5),
+                ChannelSpec(id = 11L, name = "Tied-B", number = 2, sortOrder = 5),
+                ChannelSpec(id = 12L, name = "Tuned",  number = 3, sortOrder = 5),
+                ChannelSpec(id = 13L, name = "Tied-C", number = 4, sortOrder = 5),
+            ),
+        )
+
+        val before = dao.channelsBeforeSource(
+            sourceId = 10, beforeSortOrder = 5, beforeId = 12L, limit = 10,
+        )
+        assertEquals(listOf(11L, 10L), before.map { it.id })
+    }
+
+    /**
+     * Integration check for the direct-tune resolver: findByNumber returns all candidates in
+     * a deterministic order, and resolveDirectTuneCandidate applies the zap-context tiebreaker
+     * exactly once per (source, number) group. Hidden channels are filtered before resolution
+     * (LiveViewModel does that), so we test with an unfiltered candidate set here.
+     */
+    @Test
+    fun resolveDirectTune_integration_withDaoCandidates() = runBlocking {
+        seedCategory(
+            categoryId = 100, sourceId = 10,
+            channels = listOf(
+                ChannelSpec(id = 1L, name = "News-A",   number = 42, sortOrder = 0),
+                ChannelSpec(id = 2L, name = "Sports-A", number = 42, sortOrder = 1),  // duplicate
+                ChannelSpec(id = 3L, name = "Movies-A", number = 42, sortOrder = 2),  // duplicate
+            ),
+        )
+
+        val candidates = dao.findByNumber(listOf(10L), 42)
+            .map { it.id }
+
+        // No zap context → ambiguous (3 candidates, none in zap).
+        assertNull(tv.own.owntv.player.resolveDirectTuneCandidate(candidates, emptySet()))
+
+        // Exactly one in zap context → that one wins.
+        assertEquals(2L, tv.own.owntv.player.resolveDirectTuneCandidate(candidates, setOf(2L)))
+
+        // Two in zap context → still ambiguous (multiple visible duplicates).
+        assertNull(tv.own.owntv.player.resolveDirectTuneCandidate(candidates, setOf(1L, 2L)))
+    }
+
+    /**
+     * Cross-source fallback integration: when the current source has no match, the other active
+     * sources are queried and the resolver applies the same uniqueness/zap-context policy.
+     */
+    @Test
+    fun resolveDirectTune_crossSource_fallbackPicksUniqueMatch() = runBlocking {
+        seedCategory(
+            categoryId = 100, sourceId = 10,
+            channels = listOf(
+                ChannelSpec(id = 1L, name = "SourceA-Other", number = 99, sortOrder = 0),
+            ),
+        )
+        seedCategory(
+            categoryId = 200, sourceId = 20,
+            channels = listOf(
+                ChannelSpec(id = 2L, name = "SourceB-Ch42", number = 42, sortOrder = 0),
+            ),
+        )
+
+        // Current source (10) has no match → fallback to source 20 → unique match.
+        val currentCandidates = dao.findByNumber(listOf(10L), 42)
+        val fallbackCandidates = dao.findByNumber(listOf(20L), 42)
+            .map { it.id }
+        assertEquals(emptyList<ChannelEntity>(), currentCandidates)
+        assertEquals(2L, tv.own.owntv.player.resolveDirectTuneCandidate(fallbackCandidates, emptySet()))
+    }
+
+    // --- helpers ---
+
+    private suspend fun seedCategory(
+        categoryId: Long,
+        sourceId: Long,
+        channels: List<ChannelSpec>,
+    ) {
+        dao.upsertAll(
+            channels.map { spec ->
+                ChannelEntity(
+                    id = spec.id,
+                    sourceId = sourceId,
+                    categoryId = categoryId,
+                    name = spec.name,
+                    streamUrl = "https://example.test/${spec.id}",
+                    number = spec.number,
+                    sortOrder = spec.sortOrder,
+                )
+            },
+        )
+    }
+
+    private data class ChannelSpec(val id: Long, val name: String, val number: Int, val sortOrder: Int)
+}
+
+// Tiny helpers so the test stays readable (avoid pulling in every DAO surface).
+private suspend fun tv.own.owntv.core.database.dao.SourceDao.seedSources(seed: List<SourceSeed>) {
+    for (s in seed) insert(s.toEntity())
+}
+
+private data class SourceSeed(val id: Long, val name: String) {
+    fun toEntity() = tv.own.owntv.core.database.entity.SourceEntity(
+        id = id, name = name, type = SourceType.XTREAM, url = "https://example.test/$id",
+    )
+}
+
+private suspend fun tv.own.owntv.core.database.dao.CategoryDao.seedCategories(seed: List<CategorySeed>) {
+    upsertAll(seed.map { it.toEntity() })
+}
+
+private data class CategorySeed(
+    val id: Long, val sourceId: Long, val mediaType: MediaType, val name: String, val sortOrder: Int,
+) {
+    fun toEntity() = tv.own.owntv.core.database.entity.CategoryEntity(
+        id = id, sourceId = sourceId, mediaType = mediaType, name = name, sortOrder = sortOrder,
+    )
+}

--- a/app/src/androidTest/java/tv/own/owntv/core/database/OwnTVDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/tv/own/owntv/core/database/OwnTVDatabaseMigrationTest.kt
@@ -110,6 +110,10 @@ class OwnTVDatabaseMigrationTest {
             assertColumnExists(sqlite, "metadata_cache", "logoPath")
             assertColumnExists(sqlite, "sources", "mac")
             assertIndexExists(sqlite, "index_movies_sourceId_rating_name")
+            // v20: direct-tune index on (sourceId, number).
+            assertIndexExists(sqlite, "index_channels_sourceId_number")
+            // Channel number column preserved through the full migration chain.
+            assertColumnValue(sqlite, "channels", "number", 30, 1L)
             // User data survives.
             assertCount(sqlite, "profiles", 1)
             assertCount(sqlite, "sources", 1)
@@ -311,6 +315,7 @@ class OwnTVDatabaseMigrationTest {
             OwnTVDatabase.MIGRATION_16_17,
             OwnTVDatabase.MIGRATION_17_18,
             OwnTVDatabase.MIGRATION_18_19,
+            OwnTVDatabase.MIGRATION_19_20,
         )
         .allowMainThreadQueries()
         .build()
@@ -451,6 +456,14 @@ class OwnTVDatabaseMigrationTest {
                 arrayOf<Any?>(column),
             ),
         )
+    }
+
+    private fun assertColumnValue(db: SupportSQLiteDatabase, table: String, column: String, rowId: Long, expected: Long?) {
+        db.query(SimpleSQLiteQuery("SELECT `$column` FROM `$table` WHERE id = ?", arrayOf(rowId))).use { cursor ->
+            if (!cursor.moveToFirst()) throw AssertionError("Row $rowId not found in $table")
+            val actual = if (cursor.isNull(0)) null else cursor.getLong(0)
+            assertEquals(expected, actual)
+        }
     }
 
     private fun assertCount(db: SupportSQLiteDatabase, table: String, expected: Long) {

--- a/app/src/main/java/tv/own/owntv/core/database/OwnTVDatabase.kt
+++ b/app/src/main/java/tv/own/owntv/core/database/OwnTVDatabase.kt
@@ -84,7 +84,7 @@ import tv.own.owntv.core.database.dao.SubtitleDao
         SeriesFtsEntity::class,
         EpisodeFtsEntity::class,
     ],
-    version = 19, // v7: content_order (Move). v8: contentHash + browse/unique indexes. v9: EPG contentHash + natural key. v10: TMDB metadata cache. v11: movies/series rating-sort indexes. v12: metadata_cache trailerKey. v13: metadata_cache logoPath. v14: sources.mac (Stalker portal). v15: external-subtitle cache/selection/timing tables. v16: subtitle_link (downloaded-sub ↔ content). v17: sources.syncLive/Movies/Series (skip-sync enabledScope). v18: series.episodesSyncedAt (episode-cache freshness, S8). v19: epg_channels.iconUrl (XMLTV channel logos)
+    version = 20, // v7: content_order (Move). v8: contentHash + browse/unique indexes. v9: EPG contentHash + natural key. v10: TMDB metadata cache. v11: movies/series rating-sort indexes. v12: metadata_cache trailerKey. v13: metadata_cache logoPath. v14: sources.mac (Stalker portal). v15: external-subtitle cache/selection/timing tables. v16: subtitle_link (downloaded-sub ↔ content). v17: sources.syncLive/Movies/Series (skip-sync enabledScope). v18: series.episodesSyncedAt (episode-cache freshness, S8). v19: epg_channels.iconUrl (XMLTV channel logos). v20: channels (sourceId, number) index for direct tune
 
     exportSchema = true,
 )
@@ -495,8 +495,6 @@ abstract class OwnTVDatabase : RoomDatabase() {
          * Existing rows default to 0 ("never"), so every already-cached show refreshes its episodes
          * once on next open, which is exactly what an upgrading user needs: the shows frozen by S8
          * pick up their missing episodes without deleting and re-adding the playlist.
-         *
-         * Last hop, so it carries [healSchema] (standing rule).
          */
         val MIGRATION_17_18 = object : androidx.room.migration.Migration(17, 18) {
             override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
@@ -513,6 +511,19 @@ abstract class OwnTVDatabase : RoomDatabase() {
                 if (!hasColumn(db, "epg_channels", "iconUrl")) {
                     db.execSQL("ALTER TABLE `epg_channels` ADD COLUMN `iconUrl` TEXT")
                 }
+                healSchema(db)
+            }
+        }
+
+        /**
+         * v19 → v20: non-unique `(sourceId, number)` index on `channels` for direct-tune channel-number
+         * lookup. Additive index-only migration; no data or column changes.
+         *
+         * Last hop, so it carries [healSchema] (standing rule).
+         */
+        val MIGRATION_19_20 = object : androidx.room.migration.Migration(19, 20) {
+            override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_channels_sourceId_number` ON `channels` (`sourceId`, `number`)")
                 healSchema(db)
             }
         }
@@ -535,6 +546,7 @@ abstract class OwnTVDatabase : RoomDatabase() {
                 "CREATE INDEX IF NOT EXISTS `index_channels_categoryId_name` ON `channels` (`categoryId`, `name`)",
                 "CREATE INDEX IF NOT EXISTS `index_channels_sourceId_sortOrder_name` ON `channels` (`sourceId`, `sortOrder`, `name`)",
                 "CREATE INDEX IF NOT EXISTS `index_channels_categoryId_sortOrder_name` ON `channels` (`categoryId`, `sortOrder`, `name`)",
+                "CREATE INDEX IF NOT EXISTS `index_channels_sourceId_number` ON `channels` (`sourceId`, `number`)",
             ),
             "movies" to listOf(
                 "CREATE INDEX IF NOT EXISTS `index_movies_sourceId` ON `movies` (`sourceId`)",

--- a/app/src/main/java/tv/own/owntv/core/database/dao/ChannelDao.kt
+++ b/app/src/main/java/tv/own/owntv/core/database/dao/ChannelDao.kt
@@ -136,6 +136,30 @@ interface ChannelDao {
     @Query("SELECT remoteId, id, contentHash, sortOrder FROM channels WHERE sourceId = :sourceId AND remoteId IS NOT NULL")
     suspend fun contentHashesForSource(sourceId: Long): List<ContentHashProjection>
 
+    // --- Direct tune (channel-number lookup) ---
+    /** All channels whose provider number matches [number] in the given sources. Non-unique because
+     *  provider data can contain duplicates; the caller applies visibility and zap-context policy. */
+    @Query("SELECT * FROM channels WHERE sourceId IN (:sourceIds) AND number = :number ORDER BY sourceId ASC, sortOrder ASC, name ASC, id ASC")
+    suspend fun findByNumber(sourceIds: List<Long>, number: Int): List<ChannelEntity>
+
+    /** Bounded window of channels in provider order AFTER [afterSortOrder]/[afterId] within a category.
+     *  Combined with [channelsBeforeCategory] to build a neighbourhood around a tuned channel.
+     *  Ordered by (sortOrder, id) to match the cursor predicate — avoids mismatch when sortOrder ties. */
+    @Query("SELECT * FROM channels WHERE categoryId = :categoryId AND (sortOrder > :afterSortOrder OR (sortOrder = :afterSortOrder AND id > :afterId)) ORDER BY sortOrder ASC, id ASC LIMIT :limit")
+    suspend fun channelsAfterCategory(categoryId: Long, afterSortOrder: Int, afterId: Long, limit: Int): List<ChannelEntity>
+
+    /** Bounded window of channels in provider order BEFORE [beforeSortOrder]/[beforeId] within a category. */
+    @Query("SELECT * FROM channels WHERE categoryId = :categoryId AND (sortOrder < :beforeSortOrder OR (sortOrder = :beforeSortOrder AND id < :beforeId)) ORDER BY sortOrder DESC, id DESC LIMIT :limit")
+    suspend fun channelsBeforeCategory(categoryId: Long, beforeSortOrder: Int, beforeId: Long, limit: Int): List<ChannelEntity>
+
+    /** Bounded window of channels in provider order AFTER [afterSortOrder]/[afterId] within a source. */
+    @Query("SELECT * FROM channels WHERE sourceId = :sourceId AND (sortOrder > :afterSortOrder OR (sortOrder = :afterSortOrder AND id > :afterId)) ORDER BY sortOrder ASC, id ASC LIMIT :limit")
+    suspend fun channelsAfterSource(sourceId: Long, afterSortOrder: Int, afterId: Long, limit: Int): List<ChannelEntity>
+
+    /** Bounded window of channels in provider order BEFORE [beforeSortOrder]/[beforeId] within a source. */
+    @Query("SELECT * FROM channels WHERE sourceId = :sourceId AND (sortOrder < :beforeSortOrder OR (sortOrder = :beforeSortOrder AND id < :beforeId)) ORDER BY sortOrder DESC, id DESC LIMIT :limit")
+    suspend fun channelsBeforeSource(sourceId: Long, beforeSortOrder: Int, beforeId: Long, limit: Int): List<ChannelEntity>
+
     @Query("DELETE FROM channels WHERE sourceId = :sourceId AND remoteId IN (:remoteIds)")
     suspend fun deleteByRemoteIds(sourceId: Long, remoteIds: List<String>)
 

--- a/app/src/main/java/tv/own/owntv/core/database/entity/ContentEntities.kt
+++ b/app/src/main/java/tv/own/owntv/core/database/entity/ContentEntities.kt
@@ -57,6 +57,7 @@ data class CategoryEntity(
         Index(value = ["categoryId", "name"]),
         Index(value = ["sourceId", "sortOrder", "name"]),
         Index(value = ["categoryId", "sortOrder", "name"]),
+        Index(value = ["sourceId", "number"]),
     ],
 )
 @Immutable

--- a/app/src/main/java/tv/own/owntv/di/DatabaseModule.kt
+++ b/app/src/main/java/tv/own/owntv/di/DatabaseModule.kt
@@ -37,6 +37,7 @@ val databaseModule = module {
                 OwnTVDatabase.MIGRATION_16_17,
                 OwnTVDatabase.MIGRATION_17_18,
                 OwnTVDatabase.MIGRATION_18_19,
+                OwnTVDatabase.MIGRATION_19_20,
             )
             .addCallback(object : RoomDatabase.Callback() {
                 // Self-heal index/FTS drift on every open (no-op when healthy): an interrupted bulk

--- a/app/src/main/java/tv/own/owntv/features/live/LiveViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/live/LiveViewModel.kt
@@ -295,10 +295,7 @@ class LiveViewModel(
                 val hiddenCats = cs.hiddenCats
                 if (cust.hiddenItems.isEmpty() && cust.itemNames.isEmpty() && hiddenCats.isEmpty()) paging
                 else paging
-                    .filter { ch ->
-                        CustomizeKeys.channel(ch) !in cust.hiddenItems &&
-                            (ch.categoryId == null || ch.categoryId !in hiddenCats)
-                    }
+                    .filter { ch -> isChannelVisible(ch, cust, hiddenCats) }
                     .map { ch -> cust.itemNames[CustomizeKeys.channel(ch)]?.let { ch.copy(name = it) } ?: ch }
             }
         }
@@ -483,7 +480,7 @@ class LiveViewModel(
         setStalkerReconnect(null) // non-Stalker: URLs are stable, replay on reconnect
         previewEngine.play(
             channel.streamUrl, muted = !livePreviewAudio.value,
-            meta = tv.own.owntv.player.MediaMeta(title = channel.name, logoUrl = channel.displayLogoUrl),
+            meta = tv.own.owntv.player.MediaMeta(title = channel.name, subtitle = channel.number?.let { "#$it" }, logoUrl = channel.displayLogoUrl),
             userAgent = sourceUaMap[channel.sourceId],
         )
     }
@@ -507,7 +504,7 @@ class LiveViewModel(
             setStalkerReconnect(channel.streamUrl) // C-3: re-resolve on reconnect if the URL expires
             previewEngine.play(
                 url, muted = !livePreviewAudio.value,
-                meta = tv.own.owntv.player.MediaMeta(title = channel.name, logoUrl = channel.displayLogoUrl),
+                meta = tv.own.owntv.player.MediaMeta(title = channel.name, subtitle = channel.number?.let { "#$it" }, logoUrl = channel.displayLogoUrl),
                 userAgent = source.userAgent,
             )
         }
@@ -571,6 +568,28 @@ class LiveViewModel(
             .filter { CustomizeKeys.channel(it) !in cust.hiddenItems && (it.categoryId == null || it.categoryId !in hiddenCats) }
             .map { ch -> cust.itemNames[CustomizeKeys.channel(ch)]?.let { ch.copy(name = it) } ?: ch }
     }
+
+    /** Bumped every time we start a new rebuild OR cancel one. The background rebuild coroutine
+     *  captures this at start; before publishing its result it verifies the captured generation
+     *  still equals [zapRebuildGeneration]. Older builds therefore cannot overwrite the live
+     *  fields after a newer navigation, a newer numeric tune, or a CH+/- fallback. */
+    private var zapRebuildGeneration: Long = 0L
+    private var zapRebuildJob: Job? = null
+
+    /** Fallback CH+/CH- anchor for the window during which the tuned channel is NOT yet in
+     *  [zapList]. Set right before [playChannel] for a numeric tune so the user can still navigate
+     *  via CH+/- while the bounded window rebuilds in the background. Cleared when:
+     *   - the rebuild publishes successfully (the new list contains the tuned channel),
+     *   - normal navigation replaces the playing channel (via [cancelPendingZapRebuild]),
+     *   - CH+/- resolves through the saved anchor (fallback consumption).
+     *  The list reference + index pair is stored together so a concurrent `zapList` replacement
+     *  can't silently redirect CH+/- to an unrelated channel. */
+    private data class PendingDirectTuneZapContext(
+        val targetChannelId: Long,
+        val previousList: List<ChannelEntity>,
+        val previousIndex: Int,
+    )
+    private var pendingDirectTuneZapContext: PendingDirectTuneZapContext? = null
 
     /** True when full-screen is running on the **ExoPlayer** engine (a promoted preview) rather than mpv.
      *  The shell renders the ExoPlayer surface instead of mpv's when this is set. */
@@ -643,30 +662,276 @@ class LiveViewModel(
         recordLiveHistory(channel, immediate = true)
     }
 
-    /** Zap to the neighbouring channel ([delta] = +1 down / -1 up) within the opened list, wrapping
-     *  around at the ends so you never dead-end (last → first, first → last). */
+    /** Zap to the neighbouring channel ([delta] = +1 down / -1 up). Two-axis resolution:
+     *
+     *  1. If the currently playing channel is in the live [zapList], apply the existing wrapped
+     *     delta on that list (normal navigation). [ensurePlaying] cancels any pending rebuild.
+     *  2. Otherwise (the common case right after an out-of-window numeric tune, before its
+     *     bounded zap list has finished rebuilding), fall back to [pendingDirectTuneZapContext]'s
+     *     saved list + index so CH+/- is responsive while the rebuild is still running. The saved
+     *     list is paired with its index so a concurrent `zapList` replacement can't redirect the
+     *     delta to an unrelated channel. [ensurePlaying] handles cancellation of the rebuild.
+     */
     fun zap(delta: Int) {
         val list = zapList
-        if (list.size < 2) return
-        val i = list.indexOfFirst { it.id == _previewChannel.value?.id }
-        if (i < 0) return
-        val next = ((i + delta) % list.size + list.size) % list.size // modulo wrap (handles negatives)
-        if (next == i) return
-        ensurePlaying(list[next])
+        val currentId = _previewChannel.value?.id
+        val i = if (currentId != null) list.indexOfFirst { it.id == currentId } else -1
+        if (i >= 0) {
+            // Path 1: normal navigation on the live list.
+            val nextIdx = tv.own.owntv.player.wrappedZapIndex(i, delta, list.size) ?: return
+            ensurePlaying(list[nextIdx])
+            return
+        }
+        // Path 2: fallback via the saved pending context. The context's targetChannelId is the
+        // channel we tuned to; if that no longer matches the playing channel (e.g. a newer numeric
+        // tune or CH+/- already moved us), the anchor is stale — drop it and no-op.
+        val ctx = pendingDirectTuneZapContext ?: return
+        if (ctx.targetChannelId != currentId) {
+            pendingDirectTuneZapContext = null
+            return
+        }
+        val prev = ctx.previousList
+        val nextIdx = tv.own.owntv.player.wrappedZapIndex(ctx.previousIndex, delta, prev.size) ?: run {
+            pendingDirectTuneZapContext = null
+            return
+        }
+        val next = prev[nextIdx]
+        ensurePlaying(next)
     }
 
-    /** Go full-screen on [channel]. ExoPlayer is the **primary** live engine (instant for HLS, and it plays
-     *  the channels mpv struggles to open): promote the running preview if it's already this channel, else
-     *  (re)start ExoPlayer on it. We fall back to the full **mpv** player ONLY if ExoPlayer **errors** (a
-     *  stream it can't open) — never just because it's still loading (clicking OK before the preview is ready
-     *  used to drop to mpv and stick on a black screen for HLS). */
+    /**
+     * Direct-tune: resolve a provider channel number to a channel and tune it.
+     *
+     * Two-stage lookup: the playing channel's source first, then other active Live sources only when
+     * the current source has zero visible matches. Duplicate numbers are resolved via zap-context
+     * tiebreaker. Hidden channels/categories are excluded.
+     *
+     * After resolution, playback starts IMMEDIATELY (no awaiting the bounded zap-list rebuild).
+     * The rebuild runs in [viewModelScope] on [Dispatchers.IO]; publication is guarded by both
+     * the captured generation and the currently playing channel, so a stale or cancelled rebuild
+     * can never overwrite [zapList], [_zapChannels], or [_canZap]. Until the rebuild publishes,
+     * CH+/- falls back to the saved previous-list index recorded at tune time.
+     */
+    suspend fun tuneByNumber(number: Int): tv.own.owntv.player.DirectTuneResult {
+        try {
+            val currentChannel = _previewChannel.value ?: return tv.own.owntv.player.DirectTuneResult.NotFound(number)
+            val snapshotSourceIds = ctx.value.sourceIds
+            // Snapshot the zap list at lookup START so the resolver's zap-context tiebreaker is
+            // stable for the duration of the IO query. After the lookup completes and context
+            // validity is verified we re-read zapList: a previous background rebuild may have
+            // published during the IO window, and the new tune must use the freshest view of the
+            // list for anchor selection and the "already present, skip rebuild" check. Using the
+            // stale snapshot there would lose the fallback anchor or incorrectly skip rebuilding.
+            val snapshotZapList = zapList
+
+            // DB queries on IO; playback on Main (ExoPlayer/mpv require main thread).
+            val resolved = withContext(Dispatchers.IO) {
+                // Resolve hidden categories for sources not in the active set (source may have been removed).
+                val activeHiddenCats = hiddenCategoryIds.value.toMutableSet()
+                if (currentChannel.sourceId !in snapshotSourceIds) {
+                    val cats = categoryDao.observe(listOf(currentChannel.sourceId), MediaType.LIVE).first()
+                    val cust = custom.value
+                    if (cust.hiddenCategories.isNotEmpty()) {
+                        cats.filter { CustomizeKeys.category(it) in cust.hiddenCategories }.forEach { activeHiddenCats += it.id }
+                    }
+                }
+                val currentCustom = custom.value
+
+                // Stage 1: query the currently playing source.
+                val currentSourceCandidates = channelDao.findByNumber(
+                    listOf(currentChannel.sourceId), number,
+                ).filter { isChannelVisible(it, currentCustom, activeHiddenCats) }
+
+                if (currentSourceCandidates.isNotEmpty()) {
+                    val resolvedId = tv.own.owntv.player.resolveDirectTuneCandidate(
+                        currentSourceCandidates.map { it.id },
+                        snapshotZapList.map { it.id }.toSet(),
+                    )
+                    val r = resolvedId?.let { id -> currentSourceCandidates.first { it.id == id } }
+                        ?: return@withContext ChannelNumberLookupResult.Ambiguous(currentSourceCandidates.size)
+                    val customName = currentCustom.itemNames[CustomizeKeys.channel(r)]
+                    return@withContext ChannelNumberLookupResult.Found(customName?.let { r.copy(name = it) } ?: r)
+                }
+
+                // Stage 2: fallback to other active Live sources.
+                val fallbackSourceIds = snapshotSourceIds.filter { it != currentChannel.sourceId }
+                if (fallbackSourceIds.isEmpty()) return@withContext ChannelNumberLookupResult.NotFound
+
+                val fallbackCandidates = channelDao.findByNumber(fallbackSourceIds, number)
+                    .filter { isChannelVisible(it, currentCustom, activeHiddenCats) }
+                if (fallbackCandidates.isEmpty()) return@withContext ChannelNumberLookupResult.NotFound
+
+                val r = tv.own.owntv.player.resolveDirectTuneCandidate(
+                    fallbackCandidates.map { it.id },
+                    snapshotZapList.map { it.id }.toSet(),
+                )?.let { id -> fallbackCandidates.first { it.id == id } }
+                    ?: return@withContext ChannelNumberLookupResult.Ambiguous(fallbackCandidates.size)
+                val customName = currentCustom.itemNames[CustomizeKeys.channel(r)]
+                ChannelNumberLookupResult.Found(customName?.let { r.copy(name = it) } ?: r)
+            }
+
+            // Dispatch the lookup outcome.
+            val tuned = when (val lookup = resolved) {
+                is ChannelNumberLookupResult.Found -> lookup.channel
+                is ChannelNumberLookupResult.Ambiguous ->
+                    return tv.own.owntv.player.DirectTuneResult.Ambiguous(number, lookup.matchCount)
+                ChannelNumberLookupResult.NotFound ->
+                    return tv.own.owntv.player.DirectTuneResult.NotFound(number)
+            }
+
+            // Verify context hasn't changed during lookup. If the playing channel or active source
+            // set moved, the resolved channel is stale — return Cancelled and do nothing.
+            if (_previewChannel.value?.id != currentChannel.id ||
+                ctx.value.sourceIds != snapshotSourceIds
+            ) return tv.own.owntv.player.DirectTuneResult.Cancelled
+
+            // If the tuned channel is already playing, skip playback + rebuild to avoid a stream
+            // restart. Still return Found so the HUD shows normal success feedback.
+            if (tuned.id == currentChannel.id) {
+                return tv.own.owntv.player.DirectTuneResult.Found(
+                    tv.own.owntv.player.DirectTuneChannelInfo(tuned.number, tuned.name),
+                )
+            }
+
+            // Re-read zapList NOW: a previous background rebuild may have published during the IO
+            // window above. Compute anchor data before any state mutation.
+            val currentZapList = zapList
+
+            val alreadyInLiveList = currentZapList.any { it.id == tuned.id }
+
+            val inherited = pendingDirectTuneZapContext
+                ?.takeIf { it.targetChannelId == currentChannel.id }
+
+            val anchorList = inherited?.previousList ?: currentZapList
+            val anchorIndex = inherited?.previousIndex
+                ?: currentZapList.indexOfFirst { it.id == currentChannel.id }
+
+            val hasValidAnchor =
+                anchorList.size >= 2 &&
+                    anchorIndex in anchorList.indices
+
+            if (alreadyInLiveList) {
+                zapRebuildJob?.cancel()
+                zapRebuildJob = null
+                zapRebuildGeneration++
+                pendingDirectTuneZapContext = null
+            }
+
+            // Playback starts IMMEDIATELY — do not await the rebuild.
+            playChannel(tuned)
+
+            // Launch the background rebuild only when the target is outside the current list.
+            if (!alreadyInLiveList) {
+                zapRebuildJob?.cancel()
+                zapRebuildGeneration++
+                val myGeneration = zapRebuildGeneration
+
+                if (hasValidAnchor) {
+                    pendingDirectTuneZapContext = PendingDirectTuneZapContext(
+                        targetChannelId = tuned.id,
+                        previousList = anchorList,
+                        previousIndex = anchorIndex,
+                    )
+                } else {
+                    pendingDirectTuneZapContext = null
+                }
+
+                zapRebuildJob = viewModelScope.launch {
+                    try {
+                        val rebuilt = try {
+                            buildZapList(tuned)
+                        } catch (e: kotlinx.coroutines.CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            Log.w(TAG, "tuneByNumber: zap rebuild failed", e)
+                            return@launch
+                        }
+                        if (myGeneration != zapRebuildGeneration) return@launch
+                        if (_previewChannel.value?.id != tuned.id) return@launch
+                        replaceZapList(rebuilt)
+                        pendingDirectTuneZapContext = null
+                    } finally {
+                        if (myGeneration == zapRebuildGeneration) {
+                            zapRebuildJob = null
+                        }
+                    }
+                }
+            }
+
+            return tv.own.owntv.player.DirectTuneResult.Found(
+                tv.own.owntv.player.DirectTuneChannelInfo(tuned.number, tuned.name),
+            )
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.w(TAG, "tuneByNumber($number) failed", e)
+            return tv.own.owntv.player.DirectTuneResult.Failed(number)
+        }
+    }
+
+    /** Leaf outcome of the IO database lookup inside [tuneByNumber]. */
+    private sealed interface ChannelNumberLookupResult {
+        data class Found(val channel: ChannelEntity) : ChannelNumberLookupResult
+        data class Ambiguous(val matchCount: Int) : ChannelNumberLookupResult
+        data object NotFound : ChannelNumberLookupResult
+    }
+
+    private fun isChannelVisible(ch: ChannelEntity, cust: SectionCustomizations, hiddenCats: Set<Long>): Boolean =
+        CustomizeKeys.channel(ch) !in cust.hiddenItems &&
+            (ch.categoryId == null || ch.categoryId !in hiddenCats)
+
+    /** Rebuild the zap list so CH+/- and the channel-list overlay work after jumping outside the
+     *  original list window. Loads a bounded provider-order window centred on the tuned channel
+     *  (half before, half after), applying hidden-channel/category filtering and custom names.
+     *  Pure builder: returns the local list without mutating any shared state, so the caller can
+     *  guard publication by generation/target and discard stale or cancelled results. */
+    private suspend fun buildZapList(channel: ChannelEntity): List<ChannelEntity> = withContext(Dispatchers.IO) {
+        val cust = custom.value
+        val hiddenCats = hiddenCategoryIds.value
+        val half = ZAP_WINDOW_HALF
+        val afterRaw: List<ChannelEntity>
+        val beforeRaw: List<ChannelEntity>
+        if (channel.categoryId != null) {
+            afterRaw = channelDao.channelsAfterCategory(channel.categoryId, channel.sortOrder, channel.id, half)
+            beforeRaw = channelDao.channelsBeforeCategory(channel.categoryId, channel.sortOrder, channel.id, half)
+        } else {
+            afterRaw = channelDao.channelsAfterSource(channel.sourceId, channel.sortOrder, channel.id, half)
+            beforeRaw = channelDao.channelsBeforeSource(channel.sourceId, channel.sortOrder, channel.id, half)
+        }
+        // beforeRaw is in reverse order; combine: before(reversed) + tuned + after
+        val raw = beforeRaw.asReversed() + channel + afterRaw
+        raw
+            .filter { isChannelVisible(it, cust, hiddenCats) }
+            .map { ch -> cust.itemNames[CustomizeKeys.channel(ch)]?.let { ch.copy(name = it) } ?: ch }
+    }
+
+    /** Single main-thread publication point for the three shared zap-list fields. Caller must have
+     *  already verified generation + target before calling. */
+    private fun replaceZapList(list: List<ChannelEntity>) {
+        zapList = list
+        _zapChannels.value = list
+        _canZap.value = list.size > 1
+    }
+
+    /** Cancel any in-flight background zap-list rebuild and discard its pending fallback. Normal
+     *  navigation (CH+/-, channel-list, Guide, ensurePlayingById) calls this before playing the
+     *  new channel so an obsolete rebuild never publishes after the user has moved elsewhere.
+     *  Direct-tune deliberately skips this — it manages the rebuild itself so playback is
+     *  immediate and the new list still finishes in the background. */
+    private fun cancelPendingZapRebuild() {
+        zapRebuildJob?.cancel()
+        zapRebuildJob = null
+        zapRebuildGeneration++
+        pendingDirectTuneZapContext = null
+    }
+
     /** "External player" is on for Live TV — the screen must NOT open the fullscreen in-app player
      *  (mounting it spins up an engine even though the channel went to the external app). */
     val externalPlayerOn: StateFlow<Boolean> = settings.externalPlayerLive
         .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     /** Hand [channel] to an external app (VLC, MX Player). Used by the Live TV long-press menu, and by
-     *  [ensurePlaying] when Live TV's external-player default is on. Stalker channels store a portal
+     *  [playChannel] when Live TV's external-player default is on. Stalker channels store a portal
      *  cmd rather than a URL, so it's resolved first — an external app can't mint one. */
     fun playExternal(channel: ChannelEntity) {
         viewModelScope.launch {
@@ -685,7 +950,22 @@ class LiveViewModel(
         }
     }
 
+    /** Go full-screen on [channel]. Cancels any pending direct-tune zap rebuild first, so normal
+     *  navigation always wins over an in-flight rebuild. ExoPlayer is the **primary** live engine
+     *  (instant for HLS, and it plays the channels mpv struggles to open): promote the running
+     *  preview if it's already this channel, else (re)start ExoPlayer on it. We fall back to the
+     *  full **mpv** player ONLY if ExoPlayer **errors** (a stream it can't open) — never just
+     *  because it's still loading (clicking OK before the preview is ready used to drop to mpv and
+     *  stick on a black screen for HLS). */
     fun ensurePlaying(channel: ChannelEntity) {
+        cancelPendingZapRebuild()
+        playChannel(channel)
+    }
+
+    /** Internal playback: the canonical ExoPlayer / mpv / Stalker / history side-effects for a
+     *  channel. Direct-tune's background rebuild path calls this without [cancelPendingZapRebuild]
+     *  so the in-flight rebuild it owns isn't killed by its own play. */
+    private fun playChannel(channel: ChannelEntity) {
         // Live TV set to play externally: hand the channel over instead of tuning an in-app engine.
         // History is still recorded, so the channel shows up in History/Recently watched either way.
         if (externalPlayerOn.value) { playExternal(channel); return }
@@ -735,7 +1015,7 @@ class LiveViewModel(
             setStalkerReconnect(null) // non-Stalker: URLs are stable, replay on reconnect
             previewEngine.play(
                 channel.streamUrl, muted = false,
-                meta = tv.own.owntv.player.MediaMeta(title = channel.name, logoUrl = channel.displayLogoUrl),
+                meta = tv.own.owntv.player.MediaMeta(title = channel.name, subtitle = channel.number?.let { "#$it" }, logoUrl = channel.displayLogoUrl),
                 userAgent = sourceUaMap[channel.sourceId],
             )
         }
@@ -762,7 +1042,7 @@ class LiveViewModel(
             setStalkerReconnect(channel.streamUrl) // C-3: re-resolve on reconnect if the URL expires
             previewEngine.play(
                 url, muted = false,
-                meta = tv.own.owntv.player.MediaMeta(title = channel.name, logoUrl = channel.displayLogoUrl),
+                meta = tv.own.owntv.player.MediaMeta(title = channel.name, subtitle = channel.number?.let { "#$it" }, logoUrl = channel.displayLogoUrl),
                 userAgent = source.userAgent,
             )
             watchExoOutcome(channel)
@@ -880,7 +1160,7 @@ class LiveViewModel(
             if (_previewChannel.value?.streamUrl != channel.streamUrl) return // zapped away while resolving
             // C-3: mpv is now the active engine — install/clear the reconnect provider to match.
             setStalkerReconnect(if (isStalker) channel.streamUrl else null)
-            player.play(url, title = channel.name, logoUrl = channel.displayLogoUrl, isLive = true, muted = false, userAgent = source?.userAgent)
+            player.play(url, title = channel.name, subtitle = channel.number?.let { "#$it" }, logoUrl = channel.displayLogoUrl, isLive = true, muted = false, userAgent = source?.userAgent)
         }
     }
 
@@ -1308,5 +1588,6 @@ class LiveViewModel(
             LiveRailItem(LiveKey.All, "All Channels"),
         )
         const val CATCHUP_LOOKBACK_CAP_MS = 48L * 60 * 60 * 1000 // bounded by the EPG we retain (~2 days)
+        const val ZAP_WINDOW_HALF = 50 // channels loaded on each side of the tuned channel for CH+/-
     }
 }

--- a/app/src/main/java/tv/own/owntv/features/live/LiveViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/live/LiveViewModel.kt
@@ -789,7 +789,9 @@ class LiveViewModel(
             // restart. Still return Found so the HUD shows normal success feedback.
             if (tuned.id == currentChannel.id) {
                 return tv.own.owntv.player.DirectTuneResult.Found(
-                    tv.own.owntv.player.DirectTuneChannelInfo(tuned.number, tuned.name),
+                    tv.own.owntv.player.DirectTuneChannelInfo(
+                        tuned.number, tuned.name, tuned.logoUrl, restarted = false,
+                    ),
                 )
             }
 
@@ -859,7 +861,9 @@ class LiveViewModel(
             }
 
             return tv.own.owntv.player.DirectTuneResult.Found(
-                tv.own.owntv.player.DirectTuneChannelInfo(tuned.number, tuned.name),
+                tv.own.owntv.player.DirectTuneChannelInfo(
+                    tuned.number, tuned.name, tuned.logoUrl, restarted = true,
+                ),
             )
         } catch (e: kotlinx.coroutines.CancellationException) {
             throw e

--- a/app/src/main/java/tv/own/owntv/features/shell/OwnTVShell.kt
+++ b/app/src/main/java/tv/own/owntv/features/shell/OwnTVShell.kt
@@ -695,6 +695,8 @@ fun OwnTVShell(
                     onGoToLive = if (isTunedLive) liveVm::goToLive else null,
                     onScrubLive = if (isTunedLive && canRewindLive) liveVm::scrubLive else null,
                     timeshiftOffsetSec = if (isTunedLive) timeshiftOffset else null,
+                    onTuneToNumber = if (isTunedLive && isLiveStream && timeshiftOffset == null && previewChannel != null) liveVm::tuneByNumber else null,
+                    directTuneContextKey = previewChannel?.id ?: 0L,
                     // Show the ACTUAL running engine (mpv when pinned OR auto-fallen-back), not just the pin —
                     // otherwise an auto-fallback to mpv still read "EXO". true = on mpv (pill shows MPV, teal).
                     compatMode = if (isTunedLive) !liveOnExo else null,

--- a/app/src/main/java/tv/own/owntv/features/shell/components/ChannelListOverlay.kt
+++ b/app/src/main/java/tv/own/owntv/features/shell/components/ChannelListOverlay.kt
@@ -143,7 +143,7 @@ private fun ChannelRow(
             // Name + (optional) current programme subtitle, shown only when guide data exists.
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    channel.name,
+                    channel.number?.let { "$it  ${channel.name}" } ?: channel.name,
                     style = MaterialTheme.typography.bodyMedium,
                     color = when {
                         isCurrent -> colors.primary

--- a/app/src/main/java/tv/own/owntv/player/DirectTune.kt
+++ b/app/src/main/java/tv/own/owntv/player/DirectTune.kt
@@ -1,0 +1,68 @@
+package tv.own.owntv.player
+import androidx.compose.ui.input.key.Key
+/** Outcome of a direct-tune channel-number lookup, communicated from [tv.own.owntv.features.live.LiveViewModel]
+ *  back to [PlayerHud] without requiring the HUD to query the database or infer success from player state. */
+sealed interface DirectTuneResult {
+    /** Exactly one candidate resolved; the channel is now playing. */
+    data class Found(val channel: DirectTuneChannelInfo) : DirectTuneResult
+    /** No visible channel carries this provider number in the searched sources. */
+    data class NotFound(val number: Int) : DirectTuneResult
+    /** Multiple visible candidates and no zap-context tiebreaker resolved a single one. */
+    data class Ambiguous(val number: Int, val matchCount: Int) : DirectTuneResult
+    /** An unexpected error during lookup (logged, playback unchanged). */
+    data class Failed(val number: Int) : DirectTuneResult
+    /** The playing channel or source set changed during lookup; stale result discarded. */
+    data object Cancelled : DirectTuneResult
+}
+
+/** Minimal presentation data for a successfully tuned channel, so the HUD can render feedback
+ *  immediately without reading the player metadata (which may still describe the previous channel). */
+data class DirectTuneChannelInfo(
+    val number: Int?,
+    val name: String,
+)
+
+/** Resolve a list of candidate channel IDs (same provider number, same source) to a single one.
+ *  If exactly one candidate exists, return it. If multiple exist, return the one in [zapContext]
+ *  (if exactly one duplicate is there). Returns null when resolution is ambiguous. */
+internal fun resolveDirectTuneCandidate(
+    candidateIds: List<Long>,
+    zapContextIds: Set<Long>,
+): Long? {
+    if (candidateIds.size == 1) return candidateIds[0]
+    val inZap = candidateIds.filter { it in zapContextIds }
+    return if (inZap.size == 1) inZap[0] else null
+}
+
+/** Maps standard and numpad digit keys to '0'..'9', or null for non-digit keys.
+ *  Internal for testing. */
+internal fun keyToDigit(key: Key): Char? = when (key) {
+    Key.Zero, Key.NumPad0 -> '0'
+    Key.One, Key.NumPad1 -> '1'
+    Key.Two, Key.NumPad2 -> '2'
+    Key.Three, Key.NumPad3 -> '3'
+    Key.Four, Key.NumPad4 -> '4'
+    Key.Five, Key.NumPad5 -> '5'
+    Key.Six, Key.NumPad6 -> '6'
+    Key.Seven, Key.NumPad7 -> '7'
+    Key.Eight, Key.NumPad8 -> '8'
+    Key.Nine, Key.NumPad9 -> '9'
+    else -> null
+}
+
+/** Compute the next index for a CH+/- delta within a bounded zap list. Handles negative deltas
+ *  (CH+ = -1, CH- = +1 in the OwnTV convention) and wraps around both ends so the user never
+ *  dead-ends (last → first, first → last).
+ *
+ *  Returns null when there is no valid navigation target:
+ *    - [listSize] < 2: a single-element list has no neighbour.
+ *    - [currentIndex] out of range: caller passed an inconsistent snapshot.
+ *    - The wrapped index lands on [currentIndex] itself (can only happen with a single-element list,
+ *      already guarded by the first rule, but kept defensively).
+ */
+internal fun wrappedZapIndex(currentIndex: Int, delta: Int, listSize: Int): Int? {
+    if (listSize < 2) return null
+    if (currentIndex !in 0 until listSize) return null
+    val raw = ((currentIndex + delta) % listSize + listSize) % listSize
+    return if (raw == currentIndex) null else raw
+}

--- a/app/src/main/java/tv/own/owntv/player/DirectTune.kt
+++ b/app/src/main/java/tv/own/owntv/player/DirectTune.kt
@@ -20,6 +20,10 @@ sealed interface DirectTuneResult {
 data class DirectTuneChannelInfo(
     val number: Int?,
     val name: String,
+    val logoUrl: String? = null,
+    /** False when the tuned channel was already playing and no stream was restarted — the HUD then has no
+     *  playback start to wait for before it retires the OSD. */
+    val restarted: Boolean = true,
 )
 
 /** Resolve a list of candidate channel IDs (same provider number, same source) to a single one.

--- a/app/src/main/java/tv/own/owntv/player/LivePreviewEngine.kt
+++ b/app/src/main/java/tv/own/owntv/player/LivePreviewEngine.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlin.math.abs
 import okhttp3.OkHttpClient
 import tv.own.owntv.core.network.HttpClient
 
@@ -238,7 +239,7 @@ class LivePreviewEngine(
         val chips = ArrayList<String>(5)
         p.videoFormat?.let { f ->
             if (f.width > 0 && f.height > 0) aspectLabel(f.width, f.height)?.let { chips += it }
-            qualityLabel(f.height)?.let { chips += it }
+            qualityLabel(f.width, f.height)?.let { chips += it }
             displayFps(f)?.let { chips += "${Math.round(it)} FPS" }
             f.bitrate.takeIf { it > 0 }?.let { chips += "%.1f Mbps".format(it / 1_000_000.0) }
         }
@@ -277,15 +278,25 @@ class LivePreviewEngine(
             else -> "%.2f:1".format(r)
         }
     }
-    private fun qualityLabel(h: Int): String? = when {
-        h <= 0 -> null
-        h >= 2160 -> "4K"
-        h >= 1440 -> "1440p"
-        h >= 1080 -> "1080p"
-        h >= 720 -> "720p"
-        h >= 480 -> "480p"
-        else -> "${h}p"
+    private fun qualityLabel(w: Int, h: Int): String? {
+        if (h <= 0) return null
+        if (h < 480) return "${h}p"
+        if (w <= 0) return null
+        val area = w.toLong() * h.toLong()
+        return standards.minByOrNull { (_, stdArea) ->
+            abs(area - stdArea).toDouble() / stdArea.toDouble()
+        }?.label
     }
+
+    private data class ResStd(val label: String, val pixelArea: Long)
+
+    private val standards = listOf(
+        ResStd("4K",     8_294_400),     // 3840×2160
+        ResStd("1440p",  3_686_400),     // 2560×1440
+        ResStd("1080p",  2_073_600),     // 1920×1080
+        ResStd("720p",   921_600),       // 1280×720
+        ResStd("480p",   409_920),       // 854×480
+    )
 
     private val _currentMeta = MutableStateFlow(MediaMeta())
     override val currentMeta: StateFlow<MediaMeta> = _currentMeta.asStateFlow()

--- a/app/src/main/java/tv/own/owntv/player/PlayerHud.kt
+++ b/app/src/main/java/tv/own/owntv/player/PlayerHud.kt
@@ -1,6 +1,13 @@
 package tv.own.owntv.player
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.focusGroup
@@ -34,9 +41,13 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Brush
@@ -51,11 +62,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
 import tv.own.owntv.ui.components.FocusableSurface
 import tv.own.owntv.ui.components.OwnTVButton
 import tv.own.owntv.ui.components.OwnTVIcon
@@ -70,9 +84,18 @@ private val TEAL = Color(0xFF52DBC8)
 
 private const val DIRECT_TUNE_TIMEOUT_MS = 2_000L
 private const val DIRECT_TUNE_FEEDBACK_MS = 1_500L
+private const val DIRECT_TUNE_PLAYBACK_WAIT_MS = 8_000L
 private const val MAX_DIRECT_TUNE_DIGITS = 5
 
 private enum class HudDialog { NONE, AUDIO, SUBS, SPEED, ZOOM, VOLUME, SUB_TIMING }
+
+/** What the top-left channel OSD shows for direct tune: the digits being typed, the channel a number
+ *  resolved to, or a failure message. All three render as the same card as the channel OSD. */
+private sealed interface TuneOsd {
+    data class Entry(val digits: String) : TuneOsd
+    data class Tuned(val info: DirectTuneChannelInfo) : TuneOsd
+    data class Message(val digits: String, val text: String) : TuneOsd
+}
 
 @Composable
 fun PlayerHud(
@@ -198,8 +221,7 @@ fun PlayerHud(
 
     var lookupInFlight by remember { mutableStateOf(false) }
 
-    var tuneOsdText by remember { mutableStateOf<String?>(null) }
-    var tuneOsdIsResult by remember { mutableStateOf(false) }
+    var tuneOsd by remember { mutableStateOf<TuneOsd?>(null) }
     var tuneOsdTick by remember { mutableIntStateOf(0) }
 
     val digitsActive = digitBuffer.isNotEmpty()
@@ -208,8 +230,7 @@ fun PlayerHud(
     val cancelDirectTune: () -> Unit = {
         digitBuffer = ""
         submissionRequest = null
-        tuneOsdText = null
-        tuneOsdIsResult = false
+        tuneOsd = null
         heldDigitKeys.clear()
         submissionTick++
         tuneOsdTick++
@@ -227,10 +248,10 @@ fun PlayerHud(
         val num = digitBuffer.toIntOrNull()
         digitBuffer = ""
         if (num != null) { submissionRequest = num; submissionTick++ }
-        else tuneOsdText = null
+        else tuneOsd = null
     }
     // Submission: keyed on the immutable tick so setting submissionRequest=null doesn't cancel us.
-    // lookupInFlight covers only the suspend callback, not the 1.5 s result-display period.
+    // lookupInFlight covers only the suspend callback, not the result-display period.
     LaunchedEffect(submissionTick) {
         val num = submissionRequest ?: return@LaunchedEffect
         submissionRequest = null
@@ -240,29 +261,35 @@ fun PlayerHud(
         } finally {
             lookupInFlight = false
         }
-        tuneOsdText = when (result) {
-            is DirectTuneResult.Found -> "#${result.channel.number ?: num} \u00b7 ${result.channel.name}"
-            is DirectTuneResult.NotFound -> "Channel $num not found"
-            is DirectTuneResult.Ambiguous -> "Multiple channels found"
-            is DirectTuneResult.Failed -> "Tune failed"
+        tuneOsd = when (result) {
+            is DirectTuneResult.Found -> TuneOsd.Tuned(result.channel)
+            is DirectTuneResult.NotFound -> TuneOsd.Message("$num", "Channel not found")
+            is DirectTuneResult.Ambiguous -> TuneOsd.Message("$num", "Multiple channels")
+            is DirectTuneResult.Failed -> TuneOsd.Message("$num", "Tune failed")
             is DirectTuneResult.Cancelled -> null
             null -> null
         }
-        if (tuneOsdText != null) {
-            tuneOsdIsResult = true
-            tuneOsdTick++
-        }
+        if (tuneOsd != null) tuneOsdTick++
     }
-    // Result-feedback expiry: clears the OSD after DIRECT_TUNE_FEEDBACK_MS if it hasn't been
-    // replaced by a new digit entry. Keyed on tuneOsdTick so a new entry invalidates the old timer.
+    // Result-feedback expiry, keyed on tuneOsdTick so a new entry invalidates the old timer. A tuned
+    // channel holds the OSD until the new stream is actually on screen (the lookup returns the moment
+    // playback is KICKED OFF, not when it starts) and then DIRECT_TUNE_FEEDBACK_MS longer.
     LaunchedEffect(tuneOsdTick) {
-        if (!tuneOsdIsResult || tuneOsdText == null) {
-            return@LaunchedEffect
-        }
-        delay(DIRECT_TUNE_FEEDBACK_MS)
-        if (tuneOsdIsResult) {
-            tuneOsdText = null
-            tuneOsdIsResult = false
+        when (val osd = tuneOsd) {
+            is TuneOsd.Tuned -> {
+                if (osd.info.restarted) {
+                    withTimeoutOrNull(DIRECT_TUNE_PLAYBACK_WAIT_MS) {
+                        // Two phases: the outgoing stream can still report playing for a beat (Stalker/mpv
+                        // resolve their URL asynchronously), so wait for the teardown before the start.
+                        snapshotFlow { isPlaying && !buffering && error == null }.first { !it }
+                        snapshotFlow { (isPlaying && !buffering) || error != null }.first { it }
+                    }
+                }
+                delay(DIRECT_TUNE_FEEDBACK_MS)
+                tuneOsd = null
+            }
+            is TuneOsd.Message -> { delay(DIRECT_TUNE_FEEDBACK_MS); tuneOsd = null }
+            is TuneOsd.Entry, null -> Unit
         }
     }
     // Cancellation triggers (CH+/-, D-pad, overlay open, HUD dialog open).
@@ -276,10 +303,12 @@ fun PlayerHud(
             submissionRequest = null
             heldDigitKeys.clear()
             submissionTick++
+            // Abandoned digits have no timer of their own — drop the card with the entry it belonged to.
+            if (tuneOsd is TuneOsd.Entry) tuneOsd = null
         }
     }
     // Back cancels digit entry before it hides/exits controls.
-    BackHandler(enabled = digitsActive) { digitBuffer = ""; tuneOsdText = null }
+    BackHandler(enabled = digitsActive) { digitBuffer = ""; tuneOsd = null }
 
     LaunchedEffect(forceShow) { if (forceShow) controlsVisible = true }
     LaunchedEffect(controlsVisible, player) { if (controlsVisible) player.refreshStreamChips() }
@@ -321,9 +350,8 @@ fun PlayerHud(
                             return@onPreviewKeyEvent true
                         }
                         val enteredDigits = digitBuffer + digit
-                        tuneOsdIsResult = false
+                        tuneOsd = TuneOsd.Entry(enteredDigits)
                         tuneOsdTick++
-                        tuneOsdText = enteredDigits
                         if (enteredDigits.length == MAX_DIRECT_TUNE_DIGITS) {
                             digitBuffer = ""
                             submissionRequest = enteredDigits.toIntOrNull()
@@ -377,19 +405,31 @@ fun PlayerHud(
             StreamInfoOverlay(player, modifier = Modifier.align(Alignment.TopEnd).padding(top = 112.dp, end = 20.dp))
         }
 
-        // Channel flash card (zapping with the HUD hidden) — shown independently of the full controls.
-        if (isLive && showFlash && !controlsVisible) {
-            ChannelCard(player, modifier = Modifier.align(Alignment.TopStart).padding(start = 28.dp, top = 28.dp))
-        }
-
-        // Direct-tune OSD: shows typed digits while entering, or brief feedback after a tune result.
-        // Rendered independently of controls visibility so digits are visible even when the HUD is hidden.
-        val activeTuneText = tuneOsdText
-        if (onTuneToNumber != null && activeTuneText != null) {
-            ChannelNumberEntryOverlay(
-                text = activeTuneText,
-                modifier = Modifier.align(Alignment.TopStart).padding(start = 28.dp, top = if (isLive && showFlash && !controlsVisible) 84.dp else 28.dp),
-            )
+        // Top-left OSD stack: the channel card (briefly on a zap, or the freshly tuned channel) plus the
+        // direct-tune card, which pushes down under it. Drawn outside the controls-visible block so both
+        // zapping and digit entry stay visible with the HUD hidden. With the controls up the unified top
+        // strip already names the channel, so only a direct tune — whose card names the channel the stream
+        // is still switching to — draws here.
+        val tuned = (tuneOsd as? TuneOsd.Tuned)?.info
+        Column(
+            modifier = Modifier.align(Alignment.TopStart)
+                .padding(start = 28.dp, top = if (controlsVisible) 92.dp else 28.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            if (isLive && (tuned != null || (showFlash && !controlsVisible))) {
+                // A fresh tune drives the card from the lookup result, not player metadata: the Stalker and
+                // mpv paths publish their metadata after an async resolve, which would show the old channel.
+                if (tuned != null) {
+                    ChannelOsdCard(title = tuned.name, subtitle = tuned.number?.let { "#$it" }, logoUrl = tuned.logoUrl)
+                } else {
+                    ChannelCard(player)
+                }
+            }
+            when (val osd = tuneOsd) {
+                is TuneOsd.Entry -> ChannelNumberCard(osd.digits)
+                is TuneOsd.Message -> ChannelNumberCard(osd.digits, error = osd.text)
+                is TuneOsd.Tuned, null -> Unit
+            }
         }
 
         if (controlsVisible) {
@@ -626,38 +666,89 @@ private fun LiveBadge() {
     }
 }
 
-/** Small OSD for direct-tune digit entry and feedback. Shown at the top-left of the player. */
+/** The player's channel OSD: channel logo beside its name and number. */
 @Composable
-private fun ChannelNumberEntryOverlay(text: String, modifier: Modifier = Modifier) {
-    Text(
-        text,
-        style = MaterialTheme.typography.headlineSmall,
-        color = Color.White,
-        fontWeight = FontWeight.Bold,
-        modifier = modifier
-            .clip(RoundedCornerShape(12.dp))
-            .background(Color.Black.copy(alpha = 0.7f))
-            .padding(horizontal = 16.dp, vertical = 10.dp),
-    )
+private fun ChannelOsdCard(
+    title: String?,
+    subtitle: String?,
+    logoUrl: String?,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.widthIn(max = 340.dp).clip(RoundedCornerShape(14.dp)).background(Color.Black.copy(alpha = 0.55f)).padding(14.dp),
+        verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Box(Modifier.size(44.dp).clip(RoundedCornerShape(10.dp)).background(Color(0xFF004F46)), contentAlignment = Alignment.Center) {
+            if (!logoUrl.isNullOrBlank()) AsyncImage(model = logoUrl, contentDescription = null, modifier = Modifier.fillMaxSize())
+            else Text((title ?: "?").take(3).uppercase(), style = MaterialTheme.typography.labelMedium, color = Color(0xFF6FF8E4), fontWeight = FontWeight.Bold)
+        }
+        Column {
+            Text(title ?: "", style = MaterialTheme.typography.titleSmall, color = Color.White, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            subtitle?.takeIf { it.isNotBlank() }?.let {
+                Text(it, style = MaterialTheme.typography.labelSmall, color = Color.White.copy(alpha = 0.5f), maxLines = 1, overflow = TextOverflow.Ellipsis)
+            }
+        }
+    }
 }
 
 @Composable
 private fun ChannelCard(player: PlaybackEngine, modifier: Modifier = Modifier) {
     // Collect the reactive meta so the card refreshes the instant a zap changes the channel.
     val meta by player.currentMeta.collectAsStateWithLifecycle()
-    Row(
-        modifier = modifier.widthIn(max = 340.dp).clip(RoundedCornerShape(14.dp)).background(Color.Black.copy(alpha = 0.55f)).padding(14.dp),
-        verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ChannelOsdCard(title = meta.title ?: "", subtitle = meta.subtitle, logoUrl = meta.logoUrl, modifier = modifier)
+}
+
+/** Direct-tune entry OSD: the number as it's typed, on the same surface (position, radius, scrim) the
+ *  channel card uses, so a resolved number simply becomes that card. A blinking caret says "still
+ *  accepting digits" and the bar along the bottom drains over the auto-submit window, so the wait is
+ *  visible instead of mysterious. [error] turns it into the failure readout for the same number. */
+@Composable
+private fun ChannelNumberCard(digits: String, error: String? = null, modifier: Modifier = Modifier) {
+    val caret = rememberInfiniteTransition(label = "tuneCaret")
+    val caretAlpha by caret.animateFloat(
+        initialValue = 1f, targetValue = 0f,
+        animationSpec = infiniteRepeatable(tween(600, easing = LinearEasing), RepeatMode.Reverse),
+        label = "tuneCaretAlpha",
+    )
+    val countdown = remember { Animatable(0f) }
+    LaunchedEffect(digits, error) {
+        if (error != null) { countdown.snapTo(0f); return@LaunchedEffect }
+        countdown.snapTo(1f)
+        countdown.animateTo(0f, tween(DIRECT_TUNE_TIMEOUT_MS.toInt(), easing = LinearEasing))
+    }
+    Column(
+        modifier.widthIn(min = 148.dp, max = 340.dp).clip(RoundedCornerShape(14.dp)).background(Color.Black.copy(alpha = 0.55f))
+            // Painted, not laid out: a real bar would fillMaxWidth and stretch the card to its max width.
+            .drawWithContent {
+                drawContent()
+                val barHeight = 3.dp.toPx()
+                val top = Offset(0f, size.height - barHeight)
+                drawRect(Color.White.copy(alpha = 0.08f), topLeft = top, size = Size(size.width, barHeight))
+                drawRect(TEAL, topLeft = top, size = Size(size.width * countdown.value, barHeight))
+            }
+            .padding(bottom = 3.dp),
     ) {
-        Box(Modifier.size(44.dp).clip(RoundedCornerShape(10.dp)).background(Color(0xFF004F46)), contentAlignment = Alignment.Center) {
-            val logo = meta.logoUrl
-            if (!logo.isNullOrBlank()) AsyncImage(model = logo, contentDescription = null, modifier = Modifier.fillMaxSize())
-            else Text((meta.title ?: "?").take(3).uppercase(), style = MaterialTheme.typography.labelMedium, color = Color(0xFF6FF8E4), fontWeight = FontWeight.Bold)
-        }
-        Column {
-            Text(meta.title ?: "", style = MaterialTheme.typography.titleSmall, color = Color.White, maxLines = 1, overflow = TextOverflow.Ellipsis)
-            meta.subtitle?.takeIf { it.isNotBlank() }?.let {
-                Text(it, style = MaterialTheme.typography.labelSmall, color = Color.White.copy(alpha = 0.5f), maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Column(Modifier.padding(start = 16.dp, end = 20.dp, top = 12.dp, bottom = 12.dp)) {
+            Text(
+                "CHANNEL",
+                style = MaterialTheme.typography.labelSmall, color = TEAL, fontWeight = FontWeight.Bold,
+                letterSpacing = 2.sp,
+            )
+            Row(verticalAlignment = Alignment.Bottom) {
+                Text(
+                    digits,
+                    style = MaterialTheme.typography.headlineSmall, color = Color.White, fontWeight = FontWeight.Bold,
+                    letterSpacing = 3.sp,
+                )
+                if (error == null) {
+                    Box(
+                        Modifier.padding(start = 4.dp, bottom = 4.dp).width(3.dp).height(22.dp)
+                            .clip(RoundedCornerShape(2.dp)).background(TEAL.copy(alpha = caretAlpha)),
+                    )
+                }
+            }
+            error?.let {
+                Text(it, style = MaterialTheme.typography.labelMedium, color = Color(0xFFFF8A80), maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
         }
     }

--- a/app/src/main/java/tv/own/owntv/player/PlayerHud.kt
+++ b/app/src/main/java/tv/own/owntv/player/PlayerHud.kt
@@ -68,6 +68,10 @@ import tv.own.owntv.ui.theme.OwnTVTheme
 private val SPEEDS = listOf(0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0)
 private val TEAL = Color(0xFF52DBC8)
 
+private const val DIRECT_TUNE_TIMEOUT_MS = 2_000L
+private const val DIRECT_TUNE_FEEDBACK_MS = 1_500L
+private const val MAX_DIRECT_TUNE_DIGITS = 5
+
 private enum class HudDialog { NONE, AUDIO, SUBS, SPEED, ZOOM, VOLUME, SUB_TIMING }
 
 @Composable
@@ -96,6 +100,10 @@ fun PlayerHud(
     onGoToLive: (() -> Unit)? = null,
     onScrubLive: ((Int) -> Unit)? = null, // timeline scrub: +sec = back, −sec = toward live
     timeshiftOffsetSec: Int? = null,
+    // Direct tune: enter a provider channel number to switch channels. Null = disabled (not live / no channel).
+    onTuneToNumber: (suspend (Int) -> DirectTuneResult)? = null,
+    // Channel identity key for direct tune: changing this cancels any in-flight submission.
+    directTuneContextKey: Long = 0L,
     // Live "compatibility mode": pin this channel to the mpv engine (fixes UHD artifacts / undecodable
     // streams ExoPlayer can't handle). null = not a live channel; true = currently pinned to mpv.
     compatMode: Boolean? = null,
@@ -169,7 +177,6 @@ fun PlayerHud(
     var channelFlash by remember { mutableIntStateOf(0) }
     var showFlash by remember { mutableStateOf(false) }
     LaunchedEffect(channelFlash) { if (channelFlash > 0) { showFlash = true; delay(3000); showFlash = false } }
-    val zap: (Int) -> Unit = { d -> (if (d < 0) onChannelUp else onChannelDown)?.invoke(); channelFlash++ }
 
     // Engine-switch confirmation toast: a brief "Switched to MPV/ExoPlayer" at the bottom-center when the
     // user flips the engine via the HUD toggle. Mirrors the channel-flash pattern above.
@@ -183,6 +190,96 @@ fun PlayerHud(
     val toggleVod: (() -> Unit)? = onToggleVodEngine?.let { cb -> {
         engineMsg = if (vodOnExo == true) "Switched to MPV" else "Switched to ExoPlayer"; engineFlash++; cb()
     } }
+
+    // ---- Direct tune (channel-number entry) ----
+    var digitBuffer by remember { mutableStateOf("") }
+    var submissionRequest by remember { mutableStateOf<Int?>(null) }
+    var submissionTick by remember { mutableIntStateOf(0) }
+
+    var lookupInFlight by remember { mutableStateOf(false) }
+
+    var tuneOsdText by remember { mutableStateOf<String?>(null) }
+    var tuneOsdIsResult by remember { mutableStateOf(false) }
+    var tuneOsdTick by remember { mutableIntStateOf(0) }
+
+    val digitsActive = digitBuffer.isNotEmpty()
+    val heldDigitKeys = remember { mutableSetOf<Key>() }
+
+    val cancelDirectTune: () -> Unit = {
+        digitBuffer = ""
+        submissionRequest = null
+        tuneOsdText = null
+        tuneOsdIsResult = false
+        heldDigitKeys.clear()
+        submissionTick++
+        tuneOsdTick++
+    }
+
+    val zap: (Int) -> Unit = { d ->
+        cancelDirectTune()
+        (if (d < 0) onChannelUp else onChannelDown)?.invoke(); channelFlash++
+    }
+
+    // Restartable timeout: each new digit restarts the ~2 s window. On expiry, submit.
+    LaunchedEffect(digitBuffer) {
+        if (digitBuffer.isEmpty()) return@LaunchedEffect
+        delay(DIRECT_TUNE_TIMEOUT_MS)
+        val num = digitBuffer.toIntOrNull()
+        digitBuffer = ""
+        if (num != null) { submissionRequest = num; submissionTick++ }
+        else tuneOsdText = null
+    }
+    // Submission: keyed on the immutable tick so setting submissionRequest=null doesn't cancel us.
+    // lookupInFlight covers only the suspend callback, not the 1.5 s result-display period.
+    LaunchedEffect(submissionTick) {
+        val num = submissionRequest ?: return@LaunchedEffect
+        submissionRequest = null
+        lookupInFlight = true
+        val result = try {
+            onTuneToNumber?.invoke(num)
+        } finally {
+            lookupInFlight = false
+        }
+        tuneOsdText = when (result) {
+            is DirectTuneResult.Found -> "#${result.channel.number ?: num} \u00b7 ${result.channel.name}"
+            is DirectTuneResult.NotFound -> "Channel $num not found"
+            is DirectTuneResult.Ambiguous -> "Multiple channels found"
+            is DirectTuneResult.Failed -> "Tune failed"
+            is DirectTuneResult.Cancelled -> null
+            null -> null
+        }
+        if (tuneOsdText != null) {
+            tuneOsdIsResult = true
+            tuneOsdTick++
+        }
+    }
+    // Result-feedback expiry: clears the OSD after DIRECT_TUNE_FEEDBACK_MS if it hasn't been
+    // replaced by a new digit entry. Keyed on tuneOsdTick so a new entry invalidates the old timer.
+    LaunchedEffect(tuneOsdTick) {
+        if (!tuneOsdIsResult || tuneOsdText == null) {
+            return@LaunchedEffect
+        }
+        delay(DIRECT_TUNE_FEEDBACK_MS)
+        if (tuneOsdIsResult) {
+            tuneOsdText = null
+            tuneOsdIsResult = false
+        }
+    }
+    // Cancellation triggers (CH+/-, D-pad, overlay open, HUD dialog open).
+    LaunchedEffect(inert) { if (inert) cancelDirectTune() }
+    LaunchedEffect(dialog) { if (dialog != HudDialog.NONE) cancelDirectTune() }
+    // Channel-key cleanup: narrow to pending entry state only. Do not clear timed result feedback
+    // from a successful tune that changed the playing channel.
+    LaunchedEffect(directTuneContextKey) {
+        if (digitBuffer.isNotEmpty() || submissionRequest != null) {
+            digitBuffer = ""
+            submissionRequest = null
+            heldDigitKeys.clear()
+            submissionTick++
+        }
+    }
+    // Back cancels digit entry before it hides/exits controls.
+    BackHandler(enabled = digitsActive) { digitBuffer = ""; tuneOsdText = null }
 
     LaunchedEffect(forceShow) { if (forceShow) controlsVisible = true }
     LaunchedEffect(controlsVisible, player) { if (controlsVisible) player.refreshStreamChips() }
@@ -211,6 +308,43 @@ fun PlayerHud(
     CompositionLocalProvider(LocalActionSurface provides null) {
     Box(
         modifier = modifier.fillMaxSize().onPreviewKeyEvent { e ->
+            // ---- Direct-tune digit capture (before the existing KeyDown guard) ----
+            if (onTuneToNumber != null && !inert && dialog == HudDialog.NONE) {
+                val digit = keyToDigit(e.key)
+                if (digit != null) {
+                    if (e.type == KeyEventType.KeyUp) {
+                        heldDigitKeys.remove(e.key)
+                        return@onPreviewKeyEvent true
+                    }
+                    if (e.type == KeyEventType.KeyDown) {
+                        if (lookupInFlight || !heldDigitKeys.add(e.key)) {
+                            return@onPreviewKeyEvent true
+                        }
+                        val enteredDigits = digitBuffer + digit
+                        tuneOsdIsResult = false
+                        tuneOsdTick++
+                        tuneOsdText = enteredDigits
+                        if (enteredDigits.length == MAX_DIRECT_TUNE_DIGITS) {
+                            digitBuffer = ""
+                            submissionRequest = enteredDigits.toIntOrNull()
+                            submissionTick++
+                        } else {
+                            digitBuffer = enteredDigits
+                        }
+                        return@onPreviewKeyEvent true
+                    }
+                }
+                // Enter/Center/NumpadEnter: submit immediately while digits are pending.
+                if (e.type == KeyEventType.KeyDown && !lookupInFlight && digitsActive &&
+                    (e.key == Key.DirectionCenter || e.key == Key.Enter || e.key == Key.NumPadEnter)
+                ) {
+                    val num = digitBuffer.toIntOrNull()
+                    digitBuffer = ""
+                    if (num != null) { submissionRequest = num; submissionTick++ }
+                    return@onPreviewKeyEvent true
+                }
+            }
+            // ---- Existing key handling (unchanged, but skip for digit KeyUp already consumed above) ----
             if (e.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
             when {
                 // Channel surfing: dedicated CH+/CH- and media prev/next keys always zap. D-pad Up/Down
@@ -246,6 +380,16 @@ fun PlayerHud(
         // Channel flash card (zapping with the HUD hidden) — shown independently of the full controls.
         if (isLive && showFlash && !controlsVisible) {
             ChannelCard(player, modifier = Modifier.align(Alignment.TopStart).padding(start = 28.dp, top = 28.dp))
+        }
+
+        // Direct-tune OSD: shows typed digits while entering, or brief feedback after a tune result.
+        // Rendered independently of controls visibility so digits are visible even when the HUD is hidden.
+        val activeTuneText = tuneOsdText
+        if (onTuneToNumber != null && activeTuneText != null) {
+            ChannelNumberEntryOverlay(
+                text = activeTuneText,
+                modifier = Modifier.align(Alignment.TopStart).padding(start = 28.dp, top = if (isLive && showFlash && !controlsVisible) 84.dp else 28.dp),
+            )
         }
 
         if (controlsVisible) {
@@ -480,6 +624,21 @@ private fun LiveBadge() {
         Box(Modifier.size(6.dp).clip(CircleShape).background(Color.White))
         Text("LIVE", style = MaterialTheme.typography.labelSmall, color = Color.White, fontWeight = FontWeight.Bold)
     }
+}
+
+/** Small OSD for direct-tune digit entry and feedback. Shown at the top-left of the player. */
+@Composable
+private fun ChannelNumberEntryOverlay(text: String, modifier: Modifier = Modifier) {
+    Text(
+        text,
+        style = MaterialTheme.typography.headlineSmall,
+        color = Color.White,
+        fontWeight = FontWeight.Bold,
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(Color.Black.copy(alpha = 0.7f))
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+    )
 }
 
 @Composable

--- a/app/src/test/java/tv/own/owntv/player/DirectTuneResolverTest.kt
+++ b/app/src/test/java/tv/own/owntv/player/DirectTuneResolverTest.kt
@@ -1,0 +1,167 @@
+package tv.own.owntv.player
+
+import androidx.compose.ui.input.key.Key
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class DirectTuneResolverTest {
+
+    // --- resolveDirectTuneCandidate ---
+
+    @Test
+    fun singleCandidate_returnsIt() {
+        assertEquals(10L, resolveDirectTuneCandidate(listOf(10L), emptySet()))
+    }
+
+    @Test
+    fun singleCandidate_evenIfNotInZap_returnsIt() {
+        assertEquals(10L, resolveDirectTuneCandidate(listOf(10L), setOf(99L)))
+    }
+
+    @Test
+    fun twoCandidates_oneInZap_returnsThat() {
+        assertEquals(20L, resolveDirectTuneCandidate(listOf(10L, 20L), setOf(20L)))
+    }
+
+    @Test
+    fun twoCandidates_noneInZap_returnsNull() {
+        assertNull(resolveDirectTuneCandidate(listOf(10L, 20L), emptySet()))
+    }
+
+    @Test
+    fun twoCandidates_bothInZap_returnsNull() {
+        assertNull(resolveDirectTuneCandidate(listOf(10L, 20L), setOf(10L, 20L)))
+    }
+
+    @Test
+    fun threeCandidates_oneInZap_returnsThat() {
+        assertEquals(30L, resolveDirectTuneCandidate(listOf(10L, 20L, 30L), setOf(30L)))
+    }
+
+    @Test
+    fun threeCandidates_twoInZap_returnsNull() {
+        assertNull(resolveDirectTuneCandidate(listOf(10L, 20L, 30L), setOf(10L, 20L)))
+    }
+
+    @Test
+    fun emptyCandidates_returnsNull() {
+        assertNull(resolveDirectTuneCandidate(emptyList(), emptySet()))
+    }
+
+    @Test
+    fun zapContextWithNoOverlap_returnsNull() {
+        assertNull(resolveDirectTuneCandidate(listOf(10L, 20L), setOf(99L, 100L)))
+    }
+
+    // --- keyToDigit ---
+
+    @Test
+    fun standardDigits_0through9() {
+        assertEquals('0', keyToDigit(Key.Zero))
+        assertEquals('1', keyToDigit(Key.One))
+        assertEquals('2', keyToDigit(Key.Two))
+        assertEquals('3', keyToDigit(Key.Three))
+        assertEquals('4', keyToDigit(Key.Four))
+        assertEquals('5', keyToDigit(Key.Five))
+        assertEquals('6', keyToDigit(Key.Six))
+        assertEquals('7', keyToDigit(Key.Seven))
+        assertEquals('8', keyToDigit(Key.Eight))
+        assertEquals('9', keyToDigit(Key.Nine))
+    }
+
+    @Test
+    fun numpadDigits_0through9() {
+        assertEquals('0', keyToDigit(Key.NumPad0))
+        assertEquals('1', keyToDigit(Key.NumPad1))
+        assertEquals('2', keyToDigit(Key.NumPad2))
+        assertEquals('3', keyToDigit(Key.NumPad3))
+        assertEquals('4', keyToDigit(Key.NumPad4))
+        assertEquals('5', keyToDigit(Key.NumPad5))
+        assertEquals('6', keyToDigit(Key.NumPad6))
+        assertEquals('7', keyToDigit(Key.NumPad7))
+        assertEquals('8', keyToDigit(Key.NumPad8))
+        assertEquals('9', keyToDigit(Key.NumPad9))
+    }
+
+    @Test
+    fun nonDigitKeys_returnNull() {
+        assertNull(keyToDigit(Key.Enter))
+        assertNull(keyToDigit(Key.DirectionCenter))
+        assertNull(keyToDigit(Key.Back))
+        assertNull(keyToDigit(Key.DirectionUp))
+        assertNull(keyToDigit(Key.ChannelUp))
+        assertNull(keyToDigit(Key.A))
+    }
+
+    @Test
+    fun standardAndNumpadProduceSameDigit() {
+        // Each standard key and its numpad counterpart must produce the same char.
+        val pairs = listOf(
+            Key.Zero to Key.NumPad0, Key.One to Key.NumPad1, Key.Two to Key.NumPad2,
+            Key.Three to Key.NumPad3, Key.Four to Key.NumPad4, Key.Five to Key.NumPad5,
+            Key.Six to Key.NumPad6, Key.Seven to Key.NumPad7, Key.Eight to Key.NumPad8,
+            Key.Nine to Key.NumPad9,
+        )
+        for ((std, numpad) in pairs) {
+            assertEquals(keyToDigit(std), keyToDigit(numpad))
+        }
+    }
+
+    // --- wrappedZapIndex ---
+    // The wraparound behaviour that lets CH+/- never dead-end (last → first, first → last) and
+    // handles both the OwnTV convention (CH+ = -1, CH- = +1) and any other delta. Used by both
+    // the live-list path and the saved-anchor fallback path in LiveViewModel.zap().
+
+    @Test
+    fun wrappedZapIndex_chDown_fromMiddle() {
+        // delta=+1 (CH-), size=5, current=2 → index 3.
+        assertEquals(3, wrappedZapIndex(currentIndex = 2, delta = 1, listSize = 5))
+    }
+
+    @Test
+    fun wrappedZapIndex_chUp_fromMiddle() {
+        // delta=-1 (CH+), size=5, current=2 → index 1.
+        assertEquals(1, wrappedZapIndex(currentIndex = 2, delta = -1, listSize = 5))
+    }
+
+    @Test
+    fun wrappedZapIndex_chDown_atLast_wrapsToZero() {
+        assertEquals(0, wrappedZapIndex(currentIndex = 4, delta = 1, listSize = 5))
+    }
+
+    @Test
+    fun wrappedZapIndex_chUp_atZero_wrapsToLast() {
+        assertEquals(4, wrappedZapIndex(currentIndex = 0, delta = -1, listSize = 5))
+    }
+
+    @Test
+    fun wrappedZapIndex_handlesLargeNegativeDelta() {
+        // Effectively a CH- by 2 from the second-to-last position.
+        assertEquals(0, wrappedZapIndex(currentIndex = 3, delta = -3, listSize = 5))
+    }
+
+    @Test
+    fun wrappedZapIndex_handlesLargePositiveDelta() {
+        assertEquals(2, wrappedZapIndex(currentIndex = 3, delta = 4, listSize = 5))
+    }
+
+    @Test
+    fun wrappedZapIndex_singleElement_returnsNull() {
+        // No neighbour possible.
+        assertEquals(null, wrappedZapIndex(currentIndex = 0, delta = 1, listSize = 1))
+        assertEquals(null, wrappedZapIndex(currentIndex = 0, delta = -1, listSize = 1))
+    }
+
+    @Test
+    fun wrappedZapIndex_emptyList_returnsNull() {
+        assertEquals(null, wrappedZapIndex(currentIndex = 0, delta = 1, listSize = 0))
+    }
+
+    @Test
+    fun wrappedZapIndex_outOfRangeCurrentIndex_returnsNull() {
+        // Defensive: caller passed a stale snapshot. Don't pretend we have a neighbour.
+        assertEquals(null, wrappedZapIndex(currentIndex = 10, delta = 1, listSize = 5))
+        assertEquals(null, wrappedZapIndex(currentIndex = -1, delta = 1, listSize = 5))
+    }
+}

--- a/extras/USER_GUIDE.md
+++ b/extras/USER_GUIDE.md
@@ -202,6 +202,20 @@ or **narrow the whole app to just one**.
 - ⓘ **Stream info** is the right‑most button on the control bar; **Back** exits full screen (there's no
   separate exit button).
 - **CH+ / CH−** (or Up/Down on the channel‑list overlay) zap through the current category.
+- 🔢 **Type a channel number to tune**: in full screen, just **key in the number** (number row or numpad)
+  and OwnTV switches to that channel. The digits show top‑left with a **bar that drains over two seconds**
+  before it submits — press **OK** to go immediately, **Back** to cancel, or keep typing (five digits submit
+  on their own). When it resolves, the same card turns into the **channel card** (logo · name · number) and
+  holds until the channel is on screen; if nothing matches you get **"Channel not found"**.
+  - The number is your **provider's channel number**, looked up in the **playlist you're watching**. Only
+    if that playlist has no such channel are your other active Live playlists searched.
+  - **Hidden channels and categories are skipped** and renamed channels show your name. If a playlist uses
+    one number for several visible channels you'll see **"Multiple channels"** instead of a guess.
+  - **CH+ / CH−** keeps working straight after a numeric jump, even when the channel is far outside the
+    list you opened. Channel numbers are also listed in the **channel‑list overlay** and under the name on
+    the player's channel card, so you can learn the ones you use.
+  - Number keys are only captured on a **live channel in full screen** — during **catch‑up or timeshift**
+    they're left alone.
 - 🔧 **Compatibility mode (two playback engines)**: live channels play on the fast **ExoPlayer** engine by
   default. If a channel shows **UHD artifacts**, won't open, or stutters, bring up the controls and press the
   **engine toggle (the ⇄ MPV/EXO pill)** — this **pins that channel to the mpv engine**. The pill always shows


### PR DESCRIPTION
<!-- Thanks for contributing to OwnTV! Please fill this in so it's easy to review. -->

## Before you open this PR (required)
<!-- These are mandatory — PRs that duplicate an existing in-app feature are closed. -->
- [x] I read the **[User Guide](https://github.com/ahXN00/OwnTV/blob/main/extras/USER_GUIDE.md)** and checked the app's **Settings** and existing **functions** - this change isn't already possible in the app.
- [x] I searched existing issues/PRs and this isn't a duplicate.

## What does this PR do?

Two things: **direct channel-number tuning** for Live TV (the bulk of it), and a **resolution-badge accuracy fix**. 3 commits, 14 files, +3845/-57 (2573 of those lines are the exported Room schema JSON).

### 📺 Direct channel-number tuning

Type a provider channel number on the remote during full-screen live playback and the app tunes straight to it, the way a set-top box does. No list, no guide, no D-pad walking.

**How it behaves**

- Works with the **number row and the numpad**. The digits you typed are shown exactly, leading zeros included.
- Submits **2 s after the last digit**, or immediately on **OK** / at **5 digits**.
- Held-key auto-repeat is filtered, so leaning on a key does not enter `55555`.
- **CH+/-, D-pad, an overlay, or a HUD dialog cancels** a pending entry. **Back** cancels digit entry before it hides the controls.
- Only available on a live stream that is not timeshifted (catch-up and timeshift keep the number keys free).

**Which channel a number resolves to**

- The **currently playing source is searched first**. Other active Live sources are searched only when the current source has no visible match, so a number that exists in your current playlist is never hijacked by another playlist.
- Hidden channels and hidden categories are excluded; custom channel names are applied to the result.
- Provider data does contain duplicate numbers. When several visible channels share one, the one already in your open zap list wins; if that still does not single one out, the OSD says **"Multiple channels"** rather than guessing.
- Tuning to the channel that is already playing does **not** restart the stream, but still shows normal success feedback.

**The OSD**

Direct tune reuses the player's own channel card instead of a throwaway text pill:

- While typing: the same surface as the channel card, with a **blinking caret** and a **bar that drains over the 2 s auto-submit window**, so the wait is visible rather than mysterious.
- On resolve: that surface becomes the **channel OSD** (logo, name, number), fed from the lookup result rather than player metadata, so the Stalker and mpv paths no longer flash the *previous* channel while they resolve their URL asynchronously.
- The card is held until the new stream is **actually on screen** (not a fixed delay after the lookup returns), then 1.5 s longer.
- Failures reuse the same card with the number that was entered: "Channel not found" / "Multiple channels" / "Tune failed".
- The three previously independent top-left overlays are collapsed into **one stack**, so the cards push each other down instead of overlapping.

**Channel numbers are now visible elsewhere too**, so a user can learn the numbers to type: the channel-list overlay rows show `number  name`, and the player's channel card carries `#number` as its subtitle on every playback path (ExoPlayer preview, promoted preview, Stalker, mpv).

### 🏷️ Resolution badge accuracy

`LivePreviewEngine.qualityLabel` matched on **height alone**, so an anamorphic or letterboxed stream was labelled by its short edge: a 1920x800 broadcast read **"720p"** despite being a 1080p-class picture. It now matches on **pixel area** against the standard resolutions (4K / 1440p / 1080p / 720p / 480p), picking the smallest *relative* distance. Heights below 480 still fall through to the literal `${h}p`.

## Which issue / improvement does it address?

- **Direct channel-number tuning** is an upgrade, not a bug report: every set-top box and most competing players let you type a channel number, and OwnTV's own playlists already carry provider numbers (they are shown in search results and the EPG) but there was no way to use one. The nearest existing feature is CH+/- zapping and the channel-list overlay, both of which are sequential.
- **Resolution badge** is a plain correctness fix: a 1080p stream should not report 720p in the stream-info overlay.

## How was it tested?
<!-- IMPORTANT: OwnTV is a TV app — please test on a REAL Android TV / Fire TV device, not the emulator
     only. The emulator misses a lot: HDR, hardware decoding, surround/passthrough, and real remote
     (D-pad) behaviour. -->
- **Device(s) tested on:** TCL C6K (Google TV)
- **What you exercised:**
  - Digit entry on the **number row and the numpad**; leading zeros; auto-submit vs **OK**; the 5-digit cap; held-key auto-repeat.
  - Cancellation via **CH+/-**, D-pad, opening the channel-list overlay, opening a HUD dialog, and **Back**.
  - **Not found**, **multiple channels** (duplicate provider numbers), and re-tuning the channel that is already playing (no stream restart).
  - Tuning to a channel **outside the open zap list**, then using **CH+/-** immediately, while the bounded window is still rebuilding in the background.
  - Cross-source fallback: a number absent from the current playlist but present in another active Live source.
  - Hidden channels / hidden categories excluded from resolution; custom-renamed channels showing their custom name in the OSD.
  - The resolved card **held through buffering** on both the **ExoPlayer** and the **Stalker/mpv** paths, and the existing channel card unchanged when zapping normally.
  - Resolution badge against a non-16:9 stream (previously mislabelled) and against ordinary 720p/1080p/4K channels.
- **Automated:** `compileStandardDebugKotlin`, `testStandardDebugUnitTest`, `compileStandardDebugAndroidTestKotlin`, `connectedStandardDebugAndroidTest`, `git diff --check`.

## Checklist
- [x] Builds locally (`./gradlew assembleDebug`) and CI is green
- [x] **Tested on a real Android TV / Fire TV device** (not emulator only) - D-pad/remote navigation works
- [x] No user data is wiped (Room migrations stay additive)
- [x] Keeps OwnTV player-only (no bundled channels/content)
- [x] Commit messages are clear (they become the release notes)

---

## Technical notes

### Database: Room v17 → v18 (additive, index only)

`MIGRATION_17_18` creates one non-unique index and nothing else:

```sql
CREATE INDEX IF NOT EXISTS `index_channels_sourceId_number` ON `channels` (`sourceId`, `number`)
```

- No column or data changes, so no user data is touched. `healSchema(db)` runs as in the other migrations, and the index was added to the canonical non-unique-index list so a healed schema still matches what Room expects.
- Schema JSON exported (`18.json`), registered in `DatabaseModule`, and `OwnTVDatabaseMigrationTest` extended: it asserts the new index exists **and** that `channels.number` survives the full v7→v18 chain with its value intact (new `assertColumnValue` helper).
- The index is what makes `findByNumber` cheap on a ~50k-channel playlist instead of a full table scan on every keypress.

### Direct-tune concurrency model

The hard requirement is that **playback starts the moment a number resolves**, before the CH+/- window is known. `LiveViewModel` therefore carries two guards:

- **`zapRebuildGeneration`** is bumped on every rebuild start *and* every cancel. The background coroutine captures it and, before publishing, re-checks both the generation and `_previewChannel.value?.id`. A stale or superseded rebuild can never overwrite `zapList` / `_zapChannels` / `_canZap`.
- **`pendingDirectTuneZapContext`** holds the pre-tune list *reference paired with the index*, not just the index, so a concurrent `zapList` replacement cannot silently redirect CH+/- to an unrelated channel. It is cleared when the rebuild publishes, when normal navigation replaces the playing channel, or when the anchor proves stale (its `targetChannelId` no longer matches what is playing).
- `ensurePlaying()` now calls `cancelPendingZapRebuild()` and delegates to a new private **`playChannel()`**. Direct tune calls `playChannel()` directly so it does not kill the rebuild it owns. Net effect: **normal navigation always wins over an in-flight rebuild**, and direct tune never cancels itself.
- `zap(delta)` gained a second path: if the playing channel is in the live list, apply the wrapped delta as before; otherwise fall back to the saved anchor. `wrappedZapIndex()` was extracted so the wraparound rules (and the degenerate single-element / out-of-range cases) are unit-testable.
- `replaceZapList()` is now the single main-thread publication point for the three shared zap fields, and `buildZapList()` is a pure builder that returns a local list without touching shared state, so the caller owns the publish decision.
- The lookup snapshots `zapList` at **start** for the duplicate tiebreaker (stable across the IO query), then **re-reads it after** the query for anchor selection and the "already in the list, skip the rebuild" check. Using the stale snapshot there would either lose the fallback anchor or wrongly skip a needed rebuild.
- `isChannelVisible()` was extracted so the paging filter and both lookup stages apply exactly the same hidden-channel / hidden-category rule.

### Bounded zap window

`ZAP_WINDOW_HALF = 50` channels each side of the tuned channel, in provider order:

- Four new DAO queries: `channelsBefore/AfterCategory` and `channelsBefore/AfterSource` (a channel with no category falls back to source scope).
- Each uses a `(sortOrder, id)` **cursor predicate that matches its own `ORDER BY`**, so ties in `sortOrder` cannot skip or duplicate a row. `beforeRaw` comes back descending and is reversed before being concatenated as `before + tuned + after`.
- Bounded by design: the point is that jumping to channel 900 in a 50k-channel playlist must not load 50k rows to make CH+/- work.

### Input handling

- Digit capture happens in `onPreviewKeyEvent` **before** the existing `KeyDown` guard, and consumes both `KeyDown` and `KeyUp` for digit keys. `heldDigitKeys` is what filters auto-repeat: a key must go up before it counts again.
- The submit effect is keyed on an immutable **`submissionTick`**, not on `submissionRequest`, so clearing the request to null does not cancel the in-flight submission.
- `lookupInFlight` covers only the suspend callback, not the result-display window, so feedback is never swallowed by a new keypress mid-display.
- The result-expiry effect waits in **two phases** before starting its 1.5 s hold: first for the outgoing stream to stop reporting `playing` (Stalker/mpv resolve their URL asynchronously and can report playing for a beat after the switch), then for the new one to start or error, capped at 8 s.
- The channel-key effect (`directTuneContextKey`) retires an **abandoned digit entry** when the channel changes from elsewhere. Previously that left an OSD on screen with no timer to clear it. It deliberately does *not* clear timed result feedback from a successful tune, since that tune is what changed the channel.
- `DirectTuneResult` is a sealed interface (`Found` / `NotFound` / `Ambiguous` / `Failed` / `Cancelled`) so the HUD never has to query the database or infer success from player state, and `DirectTuneChannelInfo.restarted` tells it whether there is a playback start to wait for at all.

### Gating

`onTuneToNumber` is wired in `OwnTVShell` as:

```kotlin
if (isLiveChannel && isLiveStream && timeshiftOffset == null && previewChannel != null) liveVm::tuneByNumber else null
```

Null disables digit capture entirely, so VOD, catch-up and timeshift keep the number keys free for their own handling.

### Tests added

- **`DirectTuneResolverTest`** (unit, 22 tests) - candidate resolution including the duplicate/zap-context tiebreaker, `keyToDigit` across both key sets, and `wrappedZapIndex` wraparound plus degenerate cases.
- **`ChannelDaoBoundedWindowTest`** (instrumented, 13 tests) - the four bounded-window queries, cursor behaviour on `sortOrder` ties, and window bounds.
- **`OwnTVDatabaseMigrationTest`** - v17 → v18 added to the chain, index asserted, `channels.number` value asserted to survive.

Behavioural coroutine/Compose tests for the rebuild race are deliberately deferred; the race is instead constrained by the generation + current-target guard and covered by the resolver unit tests.

### Risk and rollback

| Area | Risk | Mitigation |
| --- | --- | --- |
| Zap rebuild | a stale rebuild publishes the wrong list | generation **and** current-target guard before publish; worst case CH+/- no-ops until the next navigation |
| CH+/- during rebuild | anchor points into a replaced list | list reference stored with the index; mismatched anchor is dropped, not followed |
| Room v18 | none expected | additive, `IF NOT EXISTS`, `healSchema`, migration test |
| Key capture | digits stolen from another consumer | capture gated to full-screen live, non-timeshift, no HUD dialog; null callback disables it outright |
| Resolution badge | a stream mislabelled the other way | relative-area distance, so only genuinely ambiguous pictures shift; sub-480 unchanged |

### Files worth reviewing first

- `features/live/LiveViewModel.kt` - lookup, the zap-rebuild concurrency, `playChannel()` split (largest behavioural change)
- `player/PlayerHud.kt` - digit capture, the OSD stack, cancellation triggers, the two-phase playback wait
- `player/DirectTune.kt` - new: result types plus the three pure helpers the unit tests target
- `core/database/dao/ChannelDao.kt` and `core/database/OwnTVDatabase.kt` - bounded queries and the migration
- `features/shell/OwnTVShell.kt` - the gating expression

### Docs

- `CHANGELOG.md` - new **📺 Channel numbers** section under `v4.1.5`, plus a `### 🐛 Fixes` entry for the resolution badge.
- `CHANGELOG_APP.md` - the matching one-line feature and fix titles (bullet-only house style, no descriptions).
- `extras/USER_GUIDE.md` - a **🔢 Type a channel number to tune** entry in the Live TV full-screen controls list, covering the entry window, OK/Back, the current-playlist-first lookup, hidden/duplicate handling, CH+/- after a jump, and the catch-up/timeshift exclusion.
