### PR TITLE
Add in-player category browser for Live TV

### DIFF
--- a/app/src/main/java/tv/own/owntv/features/live/LiveViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/live/LiveViewModel.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
@@ -53,6 +52,7 @@ import tv.own.owntv.core.database.dao.ProfileDao
 import tv.own.owntv.core.database.dao.SourceDao
 import tv.own.owntv.core.database.dao.resolveExistingProfileId
 import tv.own.owntv.core.database.entity.ChannelEntity
+import tv.own.owntv.core.database.entity.CategoryEntity
 import tv.own.owntv.core.database.entity.ContentOrderEntity
 import tv.own.owntv.core.database.entity.FavoriteEntity
 import tv.own.owntv.core.database.entity.WatchHistoryEntity
@@ -67,6 +67,9 @@ import tv.own.owntv.features.settings.data.SettingsRepository
 import tv.own.owntv.player.OwnTVPlayer
 import tv.own.owntv.ui.components.OwnTVIcon
 import tv.own.owntv.ui.format.formatSystemTime
+
+/** Nivel del overlay de canales en el player: lista de canales o lista de categorías. */
+enum class ChannelOverlayLevel { CHANNELS, CATEGORIES }
 
 /** Layer-2 rail selection for Live TV. */
 sealed interface LiveKey {
@@ -538,6 +541,38 @@ class LiveViewModel(
     /** The category [zapList] was built from; null means the uncategorized → All fallback. */
     private var zapCategoryId: Long? = null
     private var zapArmed = false
+
+    // --- Category browser (second Left press shows all categories) ---
+    private val _showCategoryBrowser = MutableStateFlow(false)
+    val showCategoryBrowser: StateFlow<Boolean> = _showCategoryBrowser.asStateFlow()
+
+    /** Categories for the category browser (with customizations applied). */
+    val browserCategories: StateFlow<List<Pair<CategoryEntity, String>>> = ctx
+        .flatMapLatest { c ->
+            if (c.profileId < 0) flowOf(emptyList())
+            else combine(categoryDao.observe(c.sourceIds, MediaType.LIVE), custom) { cats, cust ->
+                cats.applyCustomizations(cust)
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    fun showCategories() { _showCategoryBrowser.value = true }
+    fun hideCategoryBrowser() { _showCategoryBrowser.value = false }
+
+    /** Load channels for an arbitrary category into the zap list. */
+    fun loadChannelsForCategory(categoryId: Long) {
+        zapListJob?.cancel()
+        zapListJob = viewModelScope.launch {
+            val pid = currentProfileId() ?: return@launch
+            val ctxKey = folderContextKeys.value[categoryId] ?: ""
+            val list = channelDao.snapshotByCategoryManual(categoryId, pid, ctxKey, ZAP_LIST_LIMIT)
+            zapCategoryId = categoryId
+            zapArmed = true
+            _zapChannels.value = list
+            _zapListTitle.value = categoryDao.getById(categoryId)?.name ?: "Channels"
+            _showCategoryBrowser.value = false
+        }
+    }
     private var zapListJob: Job? = null
 
     /** Rebuild [zapList] from [channel]'s own provider category. No-op while zapping inside the same

--- a/app/src/main/java/tv/own/owntv/features/shell/OwnTVShell.kt
+++ b/app/src/main/java/tv/own/owntv/features/shell/OwnTVShell.kt
@@ -179,6 +179,8 @@ fun OwnTVShell(
     var showHistoryList by remember { mutableStateOf(false) }
     val zapChannels by liveVm.zapChannels.collectAsStateWithLifecycle()
     val zapListTitle by liveVm.zapListTitle.collectAsStateWithLifecycle()
+    val showCategoryBrowser by liveVm.showCategoryBrowser.collectAsStateWithLifecycle()
+    val browserCategories by liveVm.browserCategories.collectAsStateWithLifecycle()
     val previewChannel by liveVm.previewChannel.collectAsStateWithLifecycle()
     // Favorite state for the player HUD's in-stream favorite toggle (live channel / movie / series).
     val liveFavoriteIds by liveVm.favoriteIds.collectAsStateWithLifecycle()
@@ -276,6 +278,7 @@ fun OwnTVShell(
         playerMode = PlayerMode.NONE
         showChannelList = false
         showHistoryList = false
+        liveVm.hideCategoryBrowser()
         liveVm.onFullscreenExited() // no longer full-screen on ExoPlayer → let the preview re-take the engine
         player.stop()
         subtitleController.clear() // leaving the player drops the OpenSubtitles item context
@@ -687,7 +690,7 @@ fun OwnTVShell(
                     onAudioMode = toAudioMode,
                     // The channel-list overlay draws ABOVE the HUD; while it's open the HUD goes inert so
                     // its hide/error focus grabs can't yank D-pad focus off the overlay.
-                    inert = showChannelList || showHistoryList || showSubtitleSearch || showLocalSubPicker,
+                    inert = showChannelList || showHistoryList || showCategoryBrowser || showSubtitleSearch || showLocalSubPicker,
                     onChannelUp = zap?.let { z -> { z(-1) } },
                     onChannelDown = zap?.let { z -> { z(1) } },
                     onOpenChannelList = if (isTunedLive && liveCanZap) { { showChannelList = true } } else null,
@@ -758,18 +761,31 @@ fun OwnTVShell(
                 }
                 tv.own.owntv.ui.components.InAppToast(localSubToast)
                 // Left — the playing channel's own provider category.
-                if (showChannelList && isLiveChannel && zapChannels.size > 1) {
-                    tv.own.owntv.features.shell.components.ChannelListOverlay(
-                        channels = zapChannels,
-                        currentId = previewChannel?.id,
-                        nowPlaying = overlayNowPlaying,
-                        title = zapListTitle,
-                        showNumbers = directTuneEnabled,
-                        onSelect = { liveVm.ensurePlaying(it); showChannelList = false },
-                        onDismiss = { showChannelList = false },
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                }
+                    if (showChannelList && isLiveChannel) {
+                        if (showCategoryBrowser) {
+                            // Segundo Left: navegador de categorías (todas las de Live TV).
+                            tv.own.owntv.features.shell.components.CategoryBrowserOverlay(
+                                categories = browserCategories,
+                                currentCategoryId = previewChannel?.categoryId,
+                                onSelect = { catId -> liveVm.loadChannelsForCategory(catId) },
+                                onDismiss = { liveVm.hideCategoryBrowser() },
+                                modifier = Modifier.fillMaxSize(),
+                            )
+                        } else if (zapChannels.size > 1) {
+                            // Primer Left: lista de canales de la categoría actual.
+                            tv.own.owntv.features.shell.components.ChannelListOverlay(
+                                channels = zapChannels,
+                                currentId = previewChannel?.id,
+                                nowPlaying = overlayNowPlaying,
+                                title = zapListTitle,
+                                showNumbers = directTuneEnabled,
+                                onSelect = { liveVm.ensurePlaying(it); showChannelList = false },
+                                onDismiss = { showChannelList = false },
+                                onOpenCategories = { liveVm.showCategories() },
+                                modifier = Modifier.fillMaxSize(),
+                            )
+                        }
+                    }
                 // Right — recently watched, to hop straight back to the previous channel.
                 if (showHistoryList && isLiveChannel && historyChannels.isNotEmpty()) {
                     tv.own.owntv.features.shell.components.ChannelListOverlay(

--- a/app/src/main/java/tv/own/owntv/features/shell/components/CategoryBrowserOverlay.kt
+++ b/app/src/main/java/tv/own/owntv/features/shell/components/CategoryBrowserOverlay.kt
@@ -1,0 +1,162 @@
+package tv.own.owntv.features.shell.components
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import tv.own.owntv.core.database.entity.CategoryEntity
+import tv.own.owntv.ui.components.FocusableSurface
+import tv.own.owntv.ui.components.OwnTVIcon
+import tv.own.owntv.ui.theme.OwnTVTheme
+
+/**
+ * Category browser that slides in over the playing video when the user presses Left a second time
+ * inside the in-player channel list. Shows every Live TV category/group (with customizations applied:
+ * hidden categories excluded, renames shown, manual order respected). OK loads that category's
+ * channels into the channel-list overlay; Back or Left returns to the channel list without changing
+ * anything. The playing channel's own category is highlighted and focused first.
+ */
+@Composable
+fun CategoryBrowserOverlay(
+    categories: List<Pair<CategoryEntity, String>>,
+    currentCategoryId: Long?,
+    onSelect: (categoryId: Long) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = OwnTVTheme.colors
+    val currentIndex = remember(categories, currentCategoryId) {
+        categories.indexOfFirst { it.first.id == currentCategoryId }.coerceAtLeast(0)
+    }
+    val listState = rememberLazyListState()
+    val focusCurrent = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        runCatching { listState.scrollToItem(currentIndex) }
+        runCatching { focusCurrent.requestFocus() }
+    }
+
+    BackHandler { onDismiss() }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .fillMaxHeight()
+                .width(380.dp)
+                .background(Color.Black.copy(alpha = 0.82f))
+                .onPreviewKeyEvent { e ->
+                    // Left goes back to the channel list (same direction the panel came from).
+                    if (e.type == KeyEventType.KeyDown && e.key == Key.DirectionLeft) {
+                        onDismiss(); true
+                    } else false
+                }
+                .padding(vertical = 18.dp),
+        ) {
+            Text(
+                "Categories",
+                style = MaterialTheme.typography.titleMedium,
+                color = colors.primary,
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 6.dp),
+            )
+            LazyColumn(
+                state = listState,
+                modifier = Modifier.fillMaxWidth(),
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                    horizontal = 12.dp, vertical = 6.dp,
+                ),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                items(categories, key = { it.first.id }) { (cat, displayName) ->
+                    val isCurrent = cat.id == currentCategoryId
+                    CategoryRow(
+                        name = displayName,
+                        isCurrent = isCurrent,
+                        onClick = { onSelect(cat.id) },
+                        modifier = if (cat.id == categories.getOrNull(currentIndex)?.first?.id) {
+                            Modifier.focusRequester(focusCurrent)
+                        } else {
+                            Modifier
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CategoryRow(
+    name: String,
+    isCurrent: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = OwnTVTheme.colors
+    FocusableSurface(
+        onClick = onClick,
+        selected = isCurrent,
+        modifier = modifier.fillMaxWidth(),
+    ) { focused ->
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(36.dp)
+                    .clip(androidx.compose.foundation.shape.RoundedCornerShape(8.dp))
+                    .background(colors.surfaceContainerLowest),
+                contentAlignment = Alignment.Center,
+            ) {
+                OwnTVIcon(
+                    OwnTVIcon.LIVE_TV,
+                    tint = if (isCurrent) colors.primary else colors.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+            Text(
+                name,
+                style = MaterialTheme.typography.bodyMedium,
+                color = when {
+                    isCurrent -> colors.primary
+                    focused -> colors.onSurface
+                    else -> colors.onSurfaceVariant
+                },
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}

--- a/app/src/main/java/tv/own/owntv/features/shell/components/ChannelListOverlay.kt
+++ b/app/src/main/java/tv/own/owntv/features/shell/components/ChannelListOverlay.kt
@@ -57,6 +57,7 @@ fun ChannelListOverlay(
     title: String = "Channels",
     alignEnd: Boolean = false,
     showNumbers: Boolean = true,
+    onOpenCategories: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val colors = OwnTVTheme.colors
@@ -81,7 +82,12 @@ fun ChannelListOverlay(
                 .width(380.dp)
                 .background(Color.Black.copy(alpha = 0.82f))
                 .onPreviewKeyEvent { e ->
-                    if (e.type == KeyEventType.KeyDown && e.key == dismissKey) { onDismiss(); true } else false
+                    if (e.type == KeyEventType.KeyDown && e.key == dismissKey) {
+                        // Left en el panel de canales: si hay navegador de categorías,
+                        // ábrelo en vez de cerrar. Back (BackHandler) siempre cierra.
+                        if (!alignEnd && onOpenCategories != null) onOpenCategories() else onDismiss()
+                        true
+                    } else false
                 }
                 .padding(vertical = 18.dp),
         ) {


### PR DESCRIPTION
## Before you open this PR (required)

- [x] I read the **[User Guide](https://github.com/ahXN00/OwnTV/blob/main/extras/USER_GUIDE.md)** and checked the app's **Settings** and existing **functions** — this change isn't already possible in the app.
- [x] I searched existing issues/PRs and this isn't a duplicate.

## What does this PR do?

Adds an in-player **category browser** for Live TV. While watching a channel fullscreen, pressing **Left** opens the channel-list overlay (existing). Pressing **Left again** now opens a **category browser** listing all Live TV categories/groups, so the user can browse and switch to channels from any group without leaving fullscreen playback.

### Changes:
- **LiveViewModel**: `showCategoryBrowser` state, `browserCategories` flow (with customizations applied), `showCategories()`/`hideCategoryBrowser()`, and `loadChannelsForCategory(categoryId)` to load an arbitrary category's channels into the zap list
- **ChannelListOverlay**: new `onOpenCategories` callback; Left opens the category browser instead of dismissing when the callback is provided
- **CategoryBrowserOverlay** (new): overlay listing all Live TV categories with customizations applied; OK loads the selected category's channels into the channel-list overlay
- **OwnTVShell**: wires the category browser overlay above the HUD, observes `showCategoryBrowser`/`browserCategories`, adds to the `inert` flag

## Which issue / improvement does it address?

Previously, the in-player channel-list overlay only showed channels from the playing channel's own category. There was no way to browse channels from other categories without leaving fullscreen. This PR adds a second-level category browser accessible with a second Left press.

## How was it tested?
- [x] Tested on a real Android TV device — D-pad/remote navigation works
- [x] First Left opens channel list (existing behavior unchanged)
- [x] Second Left opens category browser with all Live TV categories
- [x] Selecting a category loads its channels into the channel-list overlay
- [x] Back from category browser returns to channel list
- [x] Back from channel list closes the overlay
- [x] Hidden categories are excluded from the category browser
- [x] Category renames are reflected in the browser
- [x] Selecting a channel from another category tunes correctly
- [x] Builds locally (`./gradlew assembleDebug`) and CI is green
- [x] No user data is wiped
- [x] Keeps OwnTV player-only (no bundled channels/content)
- [x] Commit messages are clear