### PR TITLE
Add per-source "Prefer HLS for Live TV" option and format auto-detection

### DIFF
--- a/app/schemas/tv.own.owntv.core.database.OwnTVDatabase/23.json
+++ b/app/schemas/tv.own.owntv.core.database.OwnTVDatabase/23.json
@@ -1,0 +1,2722 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 23,
+    "identityHash": "8ef00a759e3a1ce200a76f95f081a08b",
+    "entities": [
+      {
+        "tableName": "profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `avatarColor` INTEGER NOT NULL, `avatarId` INTEGER NOT NULL, `isKids` INTEGER NOT NULL, `pinHash` TEXT, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarColor",
+            "columnName": "avatarColor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarId",
+            "columnName": "avatarId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isKids",
+            "columnName": "isKids",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinHash",
+            "columnName": "pinHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `url` TEXT NOT NULL, `username` TEXT, `password` TEXT, `mac` TEXT, `userAgent` TEXT, `epgUrl` TEXT, `syncLive` INTEGER NOT NULL, `syncMovies` INTEGER NOT NULL, `syncSeries` INTEGER NOT NULL, `hlsSupported` INTEGER NOT NULL, `preferHls` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `lastSyncAt` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mac",
+            "columnName": "mac",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userAgent",
+            "columnName": "userAgent",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "epgUrl",
+            "columnName": "epgUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncLive",
+            "columnName": "syncLive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncMovies",
+            "columnName": "syncMovies",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncSeries",
+            "columnName": "syncSeries",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hlsSupported",
+            "columnName": "hlsSupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "preferHls",
+            "columnName": "preferHls",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncAt",
+            "columnName": "lastSyncAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sources_type",
+            "unique": false,
+            "columnNames": [
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sources_type` ON `${TABLE_NAME}` (`type`)"
+          }
+        ]
+      },
+      {
+        "tableName": "profile_source",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`profileId` INTEGER NOT NULL, `sourceId` INTEGER NOT NULL, PRIMARY KEY(`profileId`, `sourceId`), FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "profileId",
+            "sourceId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_profile_source_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_profile_source_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `name` TEXT NOT NULL, `remoteId` TEXT, `sortOrder` INTEGER NOT NULL, FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_categories_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_categories_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_categories_sourceId_mediaType",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "mediaType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_categories_sourceId_mediaType` ON `${TABLE_NAME}` (`sourceId`, `mediaType`)"
+          },
+          {
+            "name": "index_categories_sourceId_mediaType_remoteId",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "mediaType",
+              "remoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_categories_sourceId_mediaType_remoteId` ON `${TABLE_NAME}` (`sourceId`, `mediaType`, `remoteId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "channels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `categoryId` INTEGER, `name` TEXT NOT NULL, `logoUrl` TEXT, `streamUrl` TEXT NOT NULL, `epgChannelId` TEXT, `number` INTEGER, `remoteId` TEXT, `sortOrder` INTEGER NOT NULL, `catchup` INTEGER NOT NULL, `catchupDays` INTEGER NOT NULL, `catchupSource` TEXT, `contentHash` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`categoryId`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoUrl",
+            "columnName": "logoUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epgChannelId",
+            "columnName": "epgChannelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catchup",
+            "columnName": "catchup",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catchupDays",
+            "columnName": "catchupDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catchupSource",
+            "columnName": "catchupSource",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_channels_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_channels_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          },
+          {
+            "name": "index_channels_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_channels_epgChannelId",
+            "unique": false,
+            "columnNames": [
+              "epgChannelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_epgChannelId` ON `${TABLE_NAME}` (`epgChannelId`)"
+          },
+          {
+            "name": "index_channels_sourceId_remoteId",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "remoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_channels_sourceId_remoteId` ON `${TABLE_NAME}` (`sourceId`, `remoteId`)"
+          },
+          {
+            "name": "index_channels_sourceId_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_sourceId_name` ON `${TABLE_NAME}` (`sourceId`, `name`)"
+          },
+          {
+            "name": "index_channels_categoryId_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_categoryId_name` ON `${TABLE_NAME}` (`categoryId`, `name`)"
+          },
+          {
+            "name": "index_channels_sourceId_sortOrder_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "sortOrder",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_sourceId_sortOrder_name` ON `${TABLE_NAME}` (`sourceId`, `sortOrder`, `name`)"
+          },
+          {
+            "name": "index_channels_categoryId_sortOrder_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "sortOrder",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_categoryId_sortOrder_name` ON `${TABLE_NAME}` (`categoryId`, `sortOrder`, `name`)"
+          },
+          {
+            "name": "index_channels_sourceId_number",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "number"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_channels_sourceId_number` ON `${TABLE_NAME}` (`sourceId`, `number`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "categories",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "categoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "movies",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `categoryId` INTEGER, `name` TEXT NOT NULL, `posterUrl` TEXT, `backdropUrl` TEXT, `year` INTEGER, `rating` REAL, `durationSecs` INTEGER, `plot` TEXT, `streamUrl` TEXT NOT NULL, `containerExt` TEXT, `remoteId` TEXT, `addedAt` INTEGER, `sortOrder` INTEGER NOT NULL, `contentHash` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`categoryId`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "posterUrl",
+            "columnName": "posterUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "backdropUrl",
+            "columnName": "backdropUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "durationSecs",
+            "columnName": "durationSecs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "plot",
+            "columnName": "plot",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "containerExt",
+            "columnName": "containerExt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_movies_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_movies_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          },
+          {
+            "name": "index_movies_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_movies_sourceId_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_sourceId_name` ON `${TABLE_NAME}` (`sourceId`, `name`)"
+          },
+          {
+            "name": "index_movies_categoryId_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_categoryId_name` ON `${TABLE_NAME}` (`categoryId`, `name`)"
+          },
+          {
+            "name": "index_movies_sourceId_sortOrder_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "sortOrder",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_sourceId_sortOrder_name` ON `${TABLE_NAME}` (`sourceId`, `sortOrder`, `name`)"
+          },
+          {
+            "name": "index_movies_categoryId_sortOrder_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "sortOrder",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_categoryId_sortOrder_name` ON `${TABLE_NAME}` (`categoryId`, `sortOrder`, `name`)"
+          },
+          {
+            "name": "index_movies_sourceId_remoteId",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "remoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_movies_sourceId_remoteId` ON `${TABLE_NAME}` (`sourceId`, `remoteId`)"
+          },
+          {
+            "name": "index_movies_sourceId_rating_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "rating",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_sourceId_rating_name` ON `${TABLE_NAME}` (`sourceId`, `rating`, `name`)"
+          },
+          {
+            "name": "index_movies_categoryId_rating_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "rating",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_categoryId_rating_name` ON `${TABLE_NAME}` (`categoryId`, `rating`, `name`)"
+          },
+          {
+            "name": "index_movies_sourceId_addedAt_sortOrder",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "addedAt",
+              "sortOrder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_sourceId_addedAt_sortOrder` ON `${TABLE_NAME}` (`sourceId`, `addedAt`, `sortOrder`)"
+          },
+          {
+            "name": "index_movies_categoryId_addedAt_sortOrder",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "addedAt",
+              "sortOrder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_movies_categoryId_addedAt_sortOrder` ON `${TABLE_NAME}` (`categoryId`, `addedAt`, `sortOrder`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "categories",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "categoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `categoryId` INTEGER, `name` TEXT NOT NULL, `posterUrl` TEXT, `backdropUrl` TEXT, `year` INTEGER, `rating` REAL, `plot` TEXT, `remoteId` TEXT, `sortOrder` INTEGER NOT NULL, `contentHash` INTEGER NOT NULL DEFAULT 0, `addedAt` INTEGER, `episodesSyncedAt` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`categoryId`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "posterUrl",
+            "columnName": "posterUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "backdropUrl",
+            "columnName": "backdropUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "plot",
+            "columnName": "plot",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "episodesSyncedAt",
+            "columnName": "episodesSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_series_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_series_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          },
+          {
+            "name": "index_series_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_series_sourceId_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_sourceId_name` ON `${TABLE_NAME}` (`sourceId`, `name`)"
+          },
+          {
+            "name": "index_series_categoryId_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_categoryId_name` ON `${TABLE_NAME}` (`categoryId`, `name`)"
+          },
+          {
+            "name": "index_series_sourceId_sortOrder_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "sortOrder",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_sourceId_sortOrder_name` ON `${TABLE_NAME}` (`sourceId`, `sortOrder`, `name`)"
+          },
+          {
+            "name": "index_series_categoryId_sortOrder_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "sortOrder",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_categoryId_sortOrder_name` ON `${TABLE_NAME}` (`categoryId`, `sortOrder`, `name`)"
+          },
+          {
+            "name": "index_series_sourceId_remoteId",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "remoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_series_sourceId_remoteId` ON `${TABLE_NAME}` (`sourceId`, `remoteId`)"
+          },
+          {
+            "name": "index_series_sourceId_rating_name",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "rating",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_sourceId_rating_name` ON `${TABLE_NAME}` (`sourceId`, `rating`, `name`)"
+          },
+          {
+            "name": "index_series_categoryId_rating_name",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "rating",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_categoryId_rating_name` ON `${TABLE_NAME}` (`categoryId`, `rating`, `name`)"
+          },
+          {
+            "name": "index_series_sourceId_addedAt_sortOrder",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "addedAt",
+              "sortOrder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_sourceId_addedAt_sortOrder` ON `${TABLE_NAME}` (`sourceId`, `addedAt`, `sortOrder`)"
+          },
+          {
+            "name": "index_series_categoryId_addedAt_sortOrder",
+            "unique": false,
+            "columnNames": [
+              "categoryId",
+              "addedAt",
+              "sortOrder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_categoryId_addedAt_sortOrder` ON `${TABLE_NAME}` (`categoryId`, `addedAt`, `sortOrder`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "categories",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "categoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "seasons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `seriesId` INTEGER NOT NULL, `seasonNumber` INTEGER NOT NULL, `name` TEXT, `remoteId` TEXT, FOREIGN KEY(`seriesId`) REFERENCES `series`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seasonNumber",
+            "columnName": "seasonNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_seasons_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_seasons_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "series",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "seriesId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `seriesId` INTEGER NOT NULL, `seasonId` INTEGER, `seasonNumber` INTEGER NOT NULL, `episodeNumber` INTEGER NOT NULL, `name` TEXT NOT NULL, `plot` TEXT, `streamUrl` TEXT NOT NULL, `durationSecs` INTEGER, `containerExt` TEXT, `remoteId` TEXT, FOREIGN KEY(`seriesId`) REFERENCES `series`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`seasonId`) REFERENCES `seasons`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seasonId",
+            "columnName": "seasonId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seasonNumber",
+            "columnName": "seasonNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeNumber",
+            "columnName": "episodeNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "plot",
+            "columnName": "plot",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationSecs",
+            "columnName": "durationSecs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "containerExt",
+            "columnName": "containerExt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_episodes_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_episodes_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          },
+          {
+            "name": "index_episodes_seasonId",
+            "unique": false,
+            "columnNames": [
+              "seasonId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_episodes_seasonId` ON `${TABLE_NAME}` (`seasonId`)"
+          },
+          {
+            "name": "index_episodes_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_episodes_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_episodes_seriesId_remoteId",
+            "unique": true,
+            "columnNames": [
+              "seriesId",
+              "remoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_episodes_seriesId_remoteId` ON `${TABLE_NAME}` (`seriesId`, `remoteId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "series",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "seriesId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "seasons",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "seasonId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "favorites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileId` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `itemId` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorites_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorites_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_favorites_profileId_mediaType_itemId",
+            "unique": true,
+            "columnNames": [
+              "profileId",
+              "mediaType",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_favorites_profileId_mediaType_itemId` ON `${TABLE_NAME}` (`profileId`, `mediaType`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "watch_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileId` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `itemId` INTEGER NOT NULL, `watchedAt` INTEGER NOT NULL, FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watchedAt",
+            "columnName": "watchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_watch_history_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_watch_history_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_watch_history_profileId_watchedAt",
+            "unique": false,
+            "columnNames": [
+              "profileId",
+              "watchedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_watch_history_profileId_watchedAt` ON `${TABLE_NAME}` (`profileId`, `watchedAt`)"
+          },
+          {
+            "name": "index_watch_history_profileId_mediaType_itemId",
+            "unique": true,
+            "columnNames": [
+              "profileId",
+              "mediaType",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_watch_history_profileId_mediaType_itemId` ON `${TABLE_NAME}` (`profileId`, `mediaType`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileId` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `itemId` INTEGER NOT NULL, `positionMs` INTEGER NOT NULL, `durationMs` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "positionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_progress_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_progress_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_playback_progress_profileId_mediaType_itemId",
+            "unique": true,
+            "columnNames": [
+              "profileId",
+              "mediaType",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_playback_progress_profileId_mediaType_itemId` ON `${TABLE_NAME}` (`profileId`, `mediaType`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "content_order",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileId` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `contextKey` TEXT NOT NULL, `itemId` INTEGER NOT NULL, `position` INTEGER NOT NULL, FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextKey",
+            "columnName": "contextKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_content_order_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_content_order_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_content_order_profileId_mediaType_contextKey",
+            "unique": false,
+            "columnNames": [
+              "profileId",
+              "mediaType",
+              "contextKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_content_order_profileId_mediaType_contextKey` ON `${TABLE_NAME}` (`profileId`, `mediaType`, `contextKey`)"
+          },
+          {
+            "name": "index_content_order_profileId_mediaType_contextKey_itemId",
+            "unique": true,
+            "columnNames": [
+              "profileId",
+              "mediaType",
+              "contextKey",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_content_order_profileId_mediaType_contextKey_itemId` ON `${TABLE_NAME}` (`profileId`, `mediaType`, `contextKey`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series_sort_order",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileId` INTEGER NOT NULL, `seriesId` INTEGER NOT NULL, `seasonsDescending` INTEGER NOT NULL, `episodesDescending` INTEGER NOT NULL, FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seasonsDescending",
+            "columnName": "seasonsDescending",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodesDescending",
+            "columnName": "episodesDescending",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_series_sort_order_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_series_sort_order_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_series_sort_order_profileId_seriesId",
+            "unique": true,
+            "columnNames": [
+              "profileId",
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_series_sort_order_profileId_seriesId` ON `${TABLE_NAME}` (`profileId`, `seriesId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileId` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `itemId` INTEGER NOT NULL, `title` TEXT NOT NULL, `posterUrl` TEXT, `streamUrl` TEXT NOT NULL, `filePath` TEXT, `status` TEXT NOT NULL, `downloadedBytes` INTEGER NOT NULL, `totalBytes` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "posterUrl",
+            "columnName": "posterUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedBytes",
+            "columnName": "downloadedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalBytes",
+            "columnName": "totalBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_downloads_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_downloads_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_downloads_profileId_mediaType_itemId",
+            "unique": true,
+            "columnNames": [
+              "profileId",
+              "mediaType",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_downloads_profileId_mediaType_itemId` ON `${TABLE_NAME}` (`profileId`, `mediaType`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "tv_provider_programs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `profileId` INTEGER NOT NULL, `surface` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `groupId` INTEGER NOT NULL, `targetItemId` INTEGER NOT NULL, `providerProgramId` INTEGER, `lastPositionMs` INTEGER NOT NULL, `durationMs` INTEGER NOT NULL, `lastEngagementAt` INTEGER NOT NULL, `lastPublishedAt` INTEGER NOT NULL, FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surface",
+            "columnName": "surface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetItemId",
+            "columnName": "targetItemId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerProgramId",
+            "columnName": "providerProgramId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastPositionMs",
+            "columnName": "lastPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastEngagementAt",
+            "columnName": "lastEngagementAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPublishedAt",
+            "columnName": "lastPublishedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tv_provider_programs_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tv_provider_programs_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_tv_provider_programs_profileId_surface_mediaType_groupId",
+            "unique": true,
+            "columnNames": [
+              "profileId",
+              "surface",
+              "mediaType",
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tv_provider_programs_profileId_surface_mediaType_groupId` ON `${TABLE_NAME}` (`profileId`, `surface`, `mediaType`, `groupId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "epg_channels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `epgChannelId` TEXT NOT NULL, `displayName` TEXT, `iconUrl` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epgChannelId",
+            "columnName": "epgChannelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "iconUrl",
+            "columnName": "iconUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_epg_channels_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_epg_channels_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_epg_channels_sourceId_epgChannelId",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "epgChannelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_epg_channels_sourceId_epgChannelId` ON `${TABLE_NAME}` (`sourceId`, `epgChannelId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "epg_programmes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sourceId` INTEGER NOT NULL, `epgChannelId` TEXT NOT NULL, `startMs` INTEGER NOT NULL, `stopMs` INTEGER NOT NULL, `title` TEXT NOT NULL, `description` TEXT, `contentHash` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epgChannelId",
+            "columnName": "epgChannelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startMs",
+            "columnName": "startMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopMs",
+            "columnName": "stopMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "contentHash",
+            "columnName": "contentHash",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_epg_programmes_epgChannelId_startMs",
+            "unique": false,
+            "columnNames": [
+              "epgChannelId",
+              "startMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_epg_programmes_epgChannelId_startMs` ON `${TABLE_NAME}` (`epgChannelId`, `startMs`)"
+          },
+          {
+            "name": "index_epg_programmes_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_epg_programmes_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_epg_programmes_stopMs",
+            "unique": false,
+            "columnNames": [
+              "stopMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_epg_programmes_stopMs` ON `${TABLE_NAME}` (`stopMs`)"
+          },
+          {
+            "name": "index_epg_programmes_sourceId_epgChannelId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "epgChannelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_epg_programmes_sourceId_epgChannelId` ON `${TABLE_NAME}` (`sourceId`, `epgChannelId`)"
+          },
+          {
+            "name": "index_epg_programmes_natural_key",
+            "unique": true,
+            "columnNames": [
+              "sourceId",
+              "epgChannelId",
+              "startMs"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_epg_programmes_natural_key` ON `${TABLE_NAME}` (`sourceId`, `epgChannelId`, `startMs`)"
+          }
+        ]
+      },
+      {
+        "tableName": "metadata_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `tmdbId` INTEGER NOT NULL, `imdbId` TEXT, `type` TEXT NOT NULL, `title` TEXT NOT NULL, `year` INTEGER, `overview` TEXT, `posterPath` TEXT, `backdropPath` TEXT, `rating` REAL, `genresJson` TEXT, `castJson` TEXT, `trailerKey` TEXT, `logoPath` TEXT, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tmdbId",
+            "columnName": "tmdbId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imdbId",
+            "columnName": "imdbId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "overview",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "posterPath",
+            "columnName": "posterPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "backdropPath",
+            "columnName": "backdropPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "genresJson",
+            "columnName": "genresJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "castJson",
+            "columnName": "castJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trailerKey",
+            "columnName": "trailerKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "logoPath",
+            "columnName": "logoPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_metadata_cache_tmdbId",
+            "unique": false,
+            "columnNames": [
+              "tmdbId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_metadata_cache_tmdbId` ON `${TABLE_NAME}` (`tmdbId`)"
+          },
+          {
+            "name": "index_metadata_cache_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_metadata_cache_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "metadata_match",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localKey` TEXT NOT NULL, `type` TEXT NOT NULL, `tmdbId` INTEGER, `confidence` REAL NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`localKey`))",
+        "fields": [
+          {
+            "fieldPath": "localKey",
+            "columnName": "localKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tmdbId",
+            "columnName": "tmdbId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "localKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_metadata_match_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_metadata_match_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subtitle_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `source` TEXT NOT NULL, `openSubFileId` INTEGER, `language` TEXT, `languageName` TEXT, `releaseName` TEXT, `format` TEXT, `hearingImpaired` INTEGER NOT NULL, `fileName` TEXT NOT NULL, `cachedPath` TEXT NOT NULL, `lastUsedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openSubFileId",
+            "columnName": "openSubFileId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "languageName",
+            "columnName": "languageName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "releaseName",
+            "columnName": "releaseName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "hearingImpaired",
+            "columnName": "hearingImpaired",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedPath",
+            "columnName": "cachedPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsedAt",
+            "columnName": "lastUsedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subtitle_cache_openSubFileId",
+            "unique": true,
+            "columnNames": [
+              "openSubFileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_subtitle_cache_openSubFileId` ON `${TABLE_NAME}` (`openSubFileId`)"
+          },
+          {
+            "name": "index_subtitle_cache_lastUsedAt",
+            "unique": false,
+            "columnNames": [
+              "lastUsedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subtitle_cache_lastUsedAt` ON `${TABLE_NAME}` (`lastUsedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subtitle_selection",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`profileId` INTEGER NOT NULL, `contentKey` TEXT NOT NULL, `cacheId` INTEGER, `off` INTEGER NOT NULL DEFAULT 0, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`profileId`, `contentKey`), FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`cacheId`) REFERENCES `subtitle_cache`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentKey",
+            "columnName": "contentKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheId",
+            "columnName": "cacheId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "off",
+            "columnName": "off",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "profileId",
+            "contentKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subtitle_selection_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subtitle_selection_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_subtitle_selection_cacheId",
+            "unique": false,
+            "columnNames": [
+              "cacheId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subtitle_selection_cacheId` ON `${TABLE_NAME}` (`cacheId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "subtitle_cache",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "cacheId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "subtitle_timing",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`profileId` INTEGER NOT NULL, `contentKey` TEXT NOT NULL, `subtitleKey` TEXT NOT NULL, `offsetMs` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`profileId`, `contentKey`, `subtitleKey`), FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentKey",
+            "columnName": "contentKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitleKey",
+            "columnName": "subtitleKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "offsetMs",
+            "columnName": "offsetMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "profileId",
+            "contentKey",
+            "subtitleKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subtitle_timing_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subtitle_timing_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "subtitle_link",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`profileId` INTEGER NOT NULL, `contentKey` TEXT NOT NULL, `cacheId` INTEGER NOT NULL, `mediaType` TEXT NOT NULL, `contentTitle` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`profileId`, `contentKey`, `cacheId`), FOREIGN KEY(`profileId`) REFERENCES `profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`cacheId`) REFERENCES `subtitle_cache`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentKey",
+            "columnName": "contentKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheId",
+            "columnName": "cacheId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentTitle",
+            "columnName": "contentTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "profileId",
+            "contentKey",
+            "cacheId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subtitle_link_profileId",
+            "unique": false,
+            "columnNames": [
+              "profileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subtitle_link_profileId` ON `${TABLE_NAME}` (`profileId`)"
+          },
+          {
+            "name": "index_subtitle_link_cacheId",
+            "unique": false,
+            "columnNames": [
+              "cacheId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subtitle_link_cacheId` ON `${TABLE_NAME}` (`cacheId`)"
+          },
+          {
+            "name": "index_subtitle_link_profileId_mediaType",
+            "unique": false,
+            "columnNames": [
+              "profileId",
+              "mediaType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subtitle_link_profileId_mediaType` ON `${TABLE_NAME}` (`profileId`, `mediaType`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "subtitle_cache",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "cacheId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "channels_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`name` TEXT NOT NULL, content=`channels`)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "channels",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_channels_fts_BEFORE_UPDATE BEFORE UPDATE ON `channels` BEGIN DELETE FROM `channels_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_channels_fts_BEFORE_DELETE BEFORE DELETE ON `channels` BEGIN DELETE FROM `channels_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_channels_fts_AFTER_UPDATE AFTER UPDATE ON `channels` BEGIN INSERT INTO `channels_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_channels_fts_AFTER_INSERT AFTER INSERT ON `channels` BEGIN INSERT INTO `channels_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END"
+        ]
+      },
+      {
+        "tableName": "movies_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`name` TEXT NOT NULL, content=`movies`)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "movies",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_movies_fts_BEFORE_UPDATE BEFORE UPDATE ON `movies` BEGIN DELETE FROM `movies_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_movies_fts_BEFORE_DELETE BEFORE DELETE ON `movies` BEGIN DELETE FROM `movies_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_movies_fts_AFTER_UPDATE AFTER UPDATE ON `movies` BEGIN INSERT INTO `movies_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_movies_fts_AFTER_INSERT AFTER INSERT ON `movies` BEGIN INSERT INTO `movies_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END"
+        ]
+      },
+      {
+        "tableName": "series_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`name` TEXT NOT NULL, content=`series`)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "series",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_series_fts_BEFORE_UPDATE BEFORE UPDATE ON `series` BEGIN DELETE FROM `series_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_series_fts_BEFORE_DELETE BEFORE DELETE ON `series` BEGIN DELETE FROM `series_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_series_fts_AFTER_UPDATE AFTER UPDATE ON `series` BEGIN INSERT INTO `series_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_series_fts_AFTER_INSERT AFTER INSERT ON `series` BEGIN INSERT INTO `series_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END"
+        ]
+      },
+      {
+        "tableName": "episodes_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`name` TEXT NOT NULL, content=`episodes`)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "episodes",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_episodes_fts_BEFORE_UPDATE BEFORE UPDATE ON `episodes` BEGIN DELETE FROM `episodes_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_episodes_fts_BEFORE_DELETE BEFORE DELETE ON `episodes` BEGIN DELETE FROM `episodes_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_episodes_fts_AFTER_UPDATE AFTER UPDATE ON `episodes` BEGIN INSERT INTO `episodes_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_episodes_fts_AFTER_INSERT AFTER INSERT ON `episodes` BEGIN INSERT INTO `episodes_fts`(`docid`, `name`) VALUES (NEW.`rowid`, NEW.`name`); END"
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8ef00a759e3a1ce200a76f95f081a08b')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/tv/own/owntv/core/database/OwnTVDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/tv/own/owntv/core/database/OwnTVDatabaseMigrationTest.kt
@@ -317,7 +317,10 @@ class OwnTVDatabaseMigrationTest {
             OwnTVDatabase.MIGRATION_18_19,
             OwnTVDatabase.MIGRATION_19_20,
             OwnTVDatabase.MIGRATION_20_21,
+<<<<<<< HEAD
             OwnTVDatabase.MIGRATION_21_22,
+=======
+>>>>>>> 4e48ce2 (Add per-source "Prefer HLS for Live TV" option and format auto-detection)
         )
         .allowMainThreadQueries()
         .build()
@@ -483,7 +486,7 @@ class OwnTVDatabaseMigrationTest {
         private const val DB_NAME = "owntv-migration-test.db"
 
         /** Must match `@Database(version = …)` on [OwnTVDatabase]. */
-        private const val CURRENT_VERSION = 22
+        private const val CURRENT_VERSION = 23
 
         /**
          * Every version with an exported schema that a real database can be sitting at.

--- a/app/src/androidTest/java/tv/own/owntv/core/parser/XtreamClientTest.kt
+++ b/app/src/androidTest/java/tv/own/owntv/core/parser/XtreamClientTest.kt
@@ -1,0 +1,99 @@
+package tv.own.owntv.core.parser
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import tv.own.owntv.core.database.entity.SourceEntity
+import tv.own.owntv.core.model.SourceType
+import tv.own.owntv.core.network.HttpClient
+
+@RunWith(AndroidJUnit4::class)
+class XtreamClientTest {
+
+    private fun createClient(jsonResponse: String): XtreamClient {
+        val okHttpClient = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                Response.Builder()
+                    .request(chain.request())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .body(jsonResponse.toByteArray(Charsets.UTF_8).toResponseBody("application/json".toMediaType()))
+                    .build()
+            }
+            .build()
+        return XtreamClient(HttpClient(okHttpClient))
+    }
+
+    private val testSource = SourceEntity(
+        id = 1,
+        name = "Test Source",
+        type = SourceType.XTREAM,
+        url = "http://example.com",
+        username = "user",
+        password = "pass",
+    )
+
+    @Test
+    fun fetchAccountDetails_detectsHlsSupport() = runBlocking {
+        val json = """
+            {
+              "user_info": {
+                "username": "testuser",
+                "status": "Active",
+                "exp_date": "1796598000",
+                "allowed_output_formats": ["m3u8", "ts", "rtmp"]
+              }
+            }
+        """.trimIndent()
+
+        val client = createClient(json)
+        val details = client.fetchAccountDetails(testSource)
+        assertTrue(details.hlsSupported)
+        assertEquals(1796598000000L, details.expiryMs)
+    }
+
+    @Test
+    fun fetchAccountDetails_hlsNotSupportedWhenOmitted() = runBlocking {
+        val json = """
+            {
+              "user_info": {
+                "username": "testuser",
+                "status": "Active",
+                "exp_date": "1796598000"
+              }
+            }
+        """.trimIndent()
+
+        val client = createClient(json)
+        val details = client.fetchAccountDetails(testSource)
+        assertFalse(details.hlsSupported)
+        assertEquals(1796598000000L, details.expiryMs)
+    }
+
+    @Test
+    fun fetchAccountDetails_hlsNotSupportedWhenTsOnly() = runBlocking {
+        val json = """
+            {
+              "user_info": {
+                "username": "testuser",
+                "status": "Active",
+                "allowed_output_formats": ["ts"]
+              }
+            }
+        """.trimIndent()
+
+        val client = createClient(json)
+        val details = client.fetchAccountDetails(testSource)
+        assertFalse(details.hlsSupported)
+    }
+}

--- a/app/src/main/java/tv/own/owntv/core/database/OwnTVDatabase.kt
+++ b/app/src/main/java/tv/own/owntv/core/database/OwnTVDatabase.kt
@@ -87,7 +87,7 @@ import tv.own.owntv.core.database.dao.SubtitleDao
         SeriesFtsEntity::class,
         EpisodeFtsEntity::class,
     ],
-    version = 22, // v7: content_order (Move). v8: contentHash + browse/unique indexes. v9: EPG contentHash + natural key. v10: TMDB metadata cache. v11: movies/series rating-sort indexes. v12: metadata_cache trailerKey. v13: metadata_cache logoPath. v14: sources.mac (Stalker portal). v15: external-subtitle cache/selection/timing tables. v16: subtitle_link (downloaded-sub ↔ content). v17: sources.syncLive/Movies/Series (skip-sync enabledScope). v18: series.episodesSyncedAt (episode-cache freshness, S8). v19: epg_channels.iconUrl (XMLTV channel logos). v20: channels (sourceId, number) index for direct tune. v21: series.addedAt + date-added sort indexes. v22: series_sort_order (per-series season/episode order)
+    version = 23, // v7: content_order (Move). v8: contentHash + browse/unique indexes. v9: EPG contentHash + natural key. v10: TMDB metadata cache. v11: movies/series rating-sort indexes. v12: metadata_cache trailerKey. v13: metadata_cache logoPath. v14: sources.mac (Stalker portal). v15: external-subtitle cache/selection/timing tables. v16: subtitle_link (downloaded-sub ↔ content). v17: sources.syncLive/Movies/Series (skip-sync enabledScope). v18: series.episodesSyncedAt (episode-cache freshness, S8). v19: epg_channels.iconUrl (XMLTV channel logos). v20: channels (sourceId, number) index for direct tune. v21: series.addedAt + date-added sort indexes. v22: series_sort_order (per-series season/episode order). v23: sources.hlsSupported and sources.preferHls
 
     exportSchema = true,
 )
@@ -598,6 +598,25 @@ abstract class OwnTVDatabase : RoomDatabase() {
                 db.execSQL("CREATE INDEX IF NOT EXISTS `index_series_sort_order_profileId` ON `series_sort_order` (`profileId`)")
                 db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_series_sort_order_profileId_seriesId` ON `series_sort_order` (`profileId`, `seriesId`)")
 
+                healSchema(db)
+            }
+        }
+
+        /**
+         * v22 → v23: `sources.hlsSupported` & `sources.preferHls` — per-source HLS support flag
+         * (detected from user_info.allowed_output_formats) and user preference for prioritizing
+         * .m3u8 live streams over .ts. Additive.
+         *
+         * Last hop, so it carries [healSchema] (standing rule).
+         */
+        val MIGRATION_22_23 = object : androidx.room.migration.Migration(22, 23) {
+            override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
+                if (!hasColumn(db, "sources", "hlsSupported")) {
+                    db.execSQL("ALTER TABLE `sources` ADD COLUMN `hlsSupported` INTEGER NOT NULL DEFAULT 0")
+                }
+                if (!hasColumn(db, "sources", "preferHls")) {
+                    db.execSQL("ALTER TABLE `sources` ADD COLUMN `preferHls` INTEGER NOT NULL DEFAULT 0")
+                }
                 healSchema(db)
             }
         }

--- a/app/src/main/java/tv/own/owntv/core/database/dao/SourceDao.kt
+++ b/app/src/main/java/tv/own/owntv/core/database/dao/SourceDao.kt
@@ -30,6 +30,12 @@ interface SourceDao {
     @Query("UPDATE sources SET lastSyncAt = :timestamp WHERE id = :id")
     suspend fun markSynced(id: Long, timestamp: Long)
 
+    @Query("UPDATE sources SET hlsSupported = :hlsSupported WHERE id = :id")
+    suspend fun updateHlsSupport(id: Long, hlsSupported: Boolean)
+
+    @Query("UPDATE sources SET preferHls = :preferHls WHERE id = :id")
+    suspend fun updatePreferHls(id: Long, preferHls: Boolean)
+
     // --- profile <-> source links (hybrid model) ---
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)

--- a/app/src/main/java/tv/own/owntv/core/database/entity/ContentEntities.kt
+++ b/app/src/main/java/tv/own/owntv/core/database/entity/ContentEntities.kt
@@ -83,6 +83,20 @@ data class ChannelEntity(
     @ColumnInfo(defaultValue = "0") val contentHash: Int = 0,
 )
 
+/** Returns the stream URL to tune, swapping .ts to .m3u8 if preferHls & hlsSupported are active for Xtream. */
+fun ChannelEntity.playStreamUrl(source: SourceEntity?): String =
+    resolveStreamUrl(streamUrl, source)
+
+/** Swaps .ts to .m3u8 if preferHls is active for an Xtream source. */
+fun resolveStreamUrl(url: String, source: SourceEntity?): String {
+    if (source != null && source.type == tv.own.owntv.core.model.SourceType.XTREAM && source.preferHls) {
+        if (url.endsWith(".ts", ignoreCase = true)) {
+            return url.dropLast(3) + ".m3u8"
+        }
+    }
+    return url
+}
+
 @Entity(
     tableName = "movies",
     foreignKeys = [

--- a/app/src/main/java/tv/own/owntv/core/database/entity/ProfileEntities.kt
+++ b/app/src/main/java/tv/own/owntv/core/database/entity/ProfileEntities.kt
@@ -47,6 +47,10 @@ data class SourceEntity(
     val syncLive: Boolean = true,
     val syncMovies: Boolean = true,
     val syncSeries: Boolean = true,
+    /** Whether the provider explicitly lists m3u8 in user_info.allowed_output_formats (v21). */
+    val hlsSupported: Boolean = false,
+    /** User preference (v21): prioritize .m3u8 streams over .ts for Live TV when hlsSupported is true. */
+    val preferHls: Boolean = false,
     val createdAt: Long = System.currentTimeMillis(),
     val lastSyncAt: Long? = null,
 )

--- a/app/src/main/java/tv/own/owntv/core/parser/XtreamClient.kt
+++ b/app/src/main/java/tv/own/owntv/core/parser/XtreamClient.kt
@@ -341,9 +341,9 @@ class XtreamClient(private val http: HttpClient) {
      * `…/timeshift/user/pass/{durationMinutes}/{yyyy-MM-dd:HH-mm}/{streamId}.ts`. The start is formatted
      * in [tz] (UTC by default — EPG timestamps are UTC; some panels expect server-local, hence the knob).
      */
-    fun timeshiftUrl(s: SourceEntity, streamId: String, startMs: Long, durationMinutes: Int, tz: java.util.TimeZone = java.util.TimeZone.getTimeZone("UTC")): String {
+    fun timeshiftUrl(s: SourceEntity, streamId: String, startMs: Long, durationMinutes: Int, tz: java.util.TimeZone = java.util.TimeZone.getTimeZone("UTC"), ext: String = "ts"): String {
         val fmt = java.text.SimpleDateFormat("yyyy-MM-dd:HH-mm", java.util.Locale.US).apply { timeZone = tz }
-        return "${base(s)}/timeshift/${s.username}/${s.password}/$durationMinutes/${fmt.format(java.util.Date(startMs))}/$streamId.ts"
+        return "${base(s)}/timeshift/${s.username}/${s.password}/$durationMinutes/${fmt.format(java.util.Date(startMs))}/$streamId.$ext"
     }
     fun movieUrl(s: SourceEntity, streamId: String, ext: String?) =
         "${base(s)}/movie/${s.username}/${s.password}/$streamId.${ext ?: "mp4"}"
@@ -351,43 +351,86 @@ class XtreamClient(private val http: HttpClient) {
         "${base(s)}/series/${s.username}/${s.password}/$episodeId.${ext ?: "mp4"}"
 
     /** Full XMLTV guide for the whole account (all channels) — the bulk EPG used by the guide grid. */
+    data class XtAccountDetails(
+        val expiryMs: Long? = null,
+        val hlsSupported: Boolean = false,
+    )
+
     /**
-     * Account expiry from the bare `player_api.php` call (`user_info.exp_date`, epoch seconds) —
-     * null when the panel reports none/unlimited or the payload is malformed. Small response; used
-     * for the Manage-sources "Expires …" line, never during sync.
+     * Account details (expiry + HLS support) from the bare `player_api.php` call
+     * (`user_info.exp_date` and `user_info.allowed_output_formats`).
+     *
+     * - [XtAccountDetails.expiryMs]: null when the panel reports none/unlimited or payload is malformed.
+     * - [XtAccountDetails.hlsSupported]: true only if `"m3u8"` is present in `allowed_output_formats`;
+     *   defaults to false when omitted, unlisted, or on network/parse failure.
      */
-    suspend fun accountExpiryMs(s: SourceEntity): Long? {
+    suspend fun fetchAccountDetails(s: SourceEntity): XtAccountDetails? {
         val u = URLEncoder.encode(s.username.orEmpty(), "UTF-8")
         val p = URLEncoder.encode(s.password.orEmpty(), "UTF-8")
-        return http.get("${base(s)}/player_api.php?username=$u&password=$p", s.userAgent) { input ->
-            var expSec: Long? = null
-            JsonReader(java.io.InputStreamReader(input, Charsets.UTF_8)).use { r ->
-                if (r.peek() != JsonToken.BEGIN_OBJECT) return@use
-                r.beginObject()
-                while (r.hasNext()) {
-                    if (r.nextName() == "user_info" && r.peek() == JsonToken.BEGIN_OBJECT) {
-                        r.beginObject()
-                        while (r.hasNext()) {
-                            if (r.nextName() == "exp_date") {
-                                expSec = when (r.peek()) {
-                                    JsonToken.STRING -> r.nextString().toLongOrNull()
-                                    JsonToken.NUMBER -> r.nextLong()
-                                    else -> { r.skipValue(); null }
+        return try {
+            http.get("${base(s)}/player_api.php?username=$u&password=$p", s.userAgent) { input ->
+                var expSec: Long? = null
+                var hlsSupported = false
+                JsonReader(java.io.InputStreamReader(input, Charsets.UTF_8)).use { r ->
+                    r.isLenient = true
+                    if (r.peek() != JsonToken.BEGIN_OBJECT) return@use
+                    r.beginObject()
+                    while (r.hasNext()) {
+                        if (r.nextName() == "user_info" && r.peek() == JsonToken.BEGIN_OBJECT) {
+                            r.beginObject()
+                            while (r.hasNext()) {
+                                when (r.nextName()) {
+                                    "exp_date" -> {
+                                        expSec = when (r.peek()) {
+                                            JsonToken.STRING -> r.nextString().toLongOrNull()
+                                            JsonToken.NUMBER -> r.nextLong()
+                                            else -> { r.skipValue(); null }
+                                        }
+                                    }
+                                    "allowed_output_formats", "user_output_formats" -> {
+                                        when (r.peek()) {
+                                            JsonToken.BEGIN_ARRAY -> {
+                                                r.beginArray()
+                                                while (r.hasNext()) {
+                                                    val fmt = r.nextStringOrNull()
+                                                    if (fmt?.equals("m3u8", ignoreCase = true) == true) {
+                                                        hlsSupported = true
+                                                    }
+                                                }
+                                                r.endArray()
+                                            }
+                                            JsonToken.STRING -> {
+                                                val str = r.nextString()
+                                                if (str.contains("m3u8", ignoreCase = true)) {
+                                                    hlsSupported = true
+                                                }
+                                            }
+                                            else -> r.skipValue()
+                                        }
+                                    }
+                                    else -> r.skipValue()
                                 }
-                            } else {
-                                r.skipValue()
                             }
+                            r.endObject()
+                        } else {
+                            r.skipValue()
                         }
-                        r.endObject()
-                    } else {
-                        r.skipValue()
                     }
+                    r.endObject()
                 }
-                r.endObject()
+                XtAccountDetails(
+                    expiryMs = expSec?.takeIf { it > 0 }?.times(1000),
+                    hlsSupported = hlsSupported,
+                )
             }
-            expSec?.takeIf { it > 0 }?.times(1000)
+        } catch (e: Exception) {
+            Log.w(TAG, "fetchAccountDetails failed for source ${s.id}", e)
+            null
         }
     }
+
+    /** Convenience delegate returning only [XtAccountDetails.expiryMs]. */
+    suspend fun accountExpiryMs(s: SourceEntity): Long? = fetchAccountDetails(s)?.expiryMs
 
     fun xmltvUrl(s: SourceEntity): String {
         val u = URLEncoder.encode(s.username.orEmpty(), "UTF-8")

--- a/app/src/main/java/tv/own/owntv/core/sync/SyncSupport.kt
+++ b/app/src/main/java/tv/own/owntv/core/sync/SyncSupport.kt
@@ -38,7 +38,7 @@ internal class SyncSupport(
     channelDao: ChannelDao,
     movieDao: MovieDao,
     seriesDao: SeriesDao,
-    private val sourceDao: SourceDao,
+    val sourceDao: SourceDao,
     private val customize: CustomizationStore,
     private val settings: SettingsRepository,
 ) {

--- a/app/src/main/java/tv/own/owntv/core/sync/XtreamSyncer.kt
+++ b/app/src/main/java/tv/own/owntv/core/sync/XtreamSyncer.kt
@@ -32,8 +32,12 @@ internal class XtreamSyncer(
     private val support: SyncSupport,
 ) {
     suspend fun sync(s: SourceEntity, progress: SyncCounters, stats: SyncStatsCollector, contentTypes: SyncContentTypes) {
+        val details = runCatching { xtream.fetchAccountDetails(s) }.getOrNull()
+        if (details != null) {
+            support.sourceDao.updateHlsSupport(s.id, details.hlsSupported)
+        }
         val semaphore = Semaphore(2)
-        Log.i(TAG, "Xtream sync scheduling sourceId=${s.id} contentTypes=$contentTypes concurrency=2")
+        Log.i(TAG, "Xtream sync scheduling sourceId=${s.id} contentTypes=$contentTypes concurrency=2 hlsSupported=${details?.hlsSupported}")
         coroutineScope {
             if (contentTypes.live) async { semaphore.withPermit { syncLive(s, progress, stats) } }
             if (contentTypes.movies) async { semaphore.withPermit { syncMovies(s, progress, stats) } }

--- a/app/src/main/java/tv/own/owntv/di/DatabaseModule.kt
+++ b/app/src/main/java/tv/own/owntv/di/DatabaseModule.kt
@@ -40,6 +40,9 @@ val databaseModule = module {
                 OwnTVDatabase.MIGRATION_17_18,
                 OwnTVDatabase.MIGRATION_18_19,
                 OwnTVDatabase.MIGRATION_19_20,
+                OwnTVDatabase.MIGRATION_20_21,
+                OwnTVDatabase.MIGRATION_21_22,
+                OwnTVDatabase.MIGRATION_22_23,
             )
             .addCallback(object : RoomDatabase.Callback() {
                 // Self-heal index/FTS drift on every open (no-op when healthy): an interrupted bulk

--- a/app/src/main/java/tv/own/owntv/features/live/LiveViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/live/LiveViewModel.kt
@@ -55,7 +55,10 @@ import tv.own.owntv.core.database.entity.ChannelEntity
 import tv.own.owntv.core.database.entity.CategoryEntity
 import tv.own.owntv.core.database.entity.ContentOrderEntity
 import tv.own.owntv.core.database.entity.FavoriteEntity
+import tv.own.owntv.core.database.entity.SourceEntity
 import tv.own.owntv.core.database.entity.WatchHistoryEntity
+import tv.own.owntv.core.database.entity.playStreamUrl
+import tv.own.owntv.core.database.entity.resolveStreamUrl
 import tv.own.owntv.core.launcher.LauncherIntegrationRepository
 import tv.own.owntv.core.model.MediaType
 import tv.own.owntv.core.util.throttleLatest
@@ -481,8 +484,9 @@ class LiveViewModel(
         if (_liveOnExo.value) return
         val source = sourceById[channel.sourceId]
         if (streamUrlResolver.needsResolve(source)) { playPreviewStalker(channel, source!!); return }
+        val targetUrl = channel.playStreamUrl(source)
         // Already previewing this channel (e.g. re-focus)? Just re-apply the preview mute, no reload.
-        if (previewEngine.currentUrl == channel.streamUrl &&
+        if (previewEngine.currentUrl == targetUrl &&
             previewEngine.state.value != tv.own.owntv.player.LivePreviewEngine.State.ERROR
         ) {
             previewEngine.setMuted(!livePreviewAudio.value)
@@ -491,7 +495,7 @@ class LiveViewModel(
         stalkerPreviewCmd = null
         setStalkerReconnect(null) // non-Stalker: URLs are stable, replay on reconnect
         previewEngine.play(
-            channel.streamUrl, muted = !livePreviewAudio.value,
+            targetUrl, muted = !livePreviewAudio.value,
             meta = tv.own.owntv.player.MediaMeta(title = channel.name, subtitle = channelNumberLabel(channel), logoUrl = channel.displayLogoUrl),
             userAgent = sourceUaMap[channel.sourceId],
         )
@@ -1013,13 +1017,16 @@ class LiveViewModel(
      *  stick on a black screen for HLS). */
     fun ensurePlaying(channel: ChannelEntity) {
         cancelPendingZapRebuild()
-        playChannel(channel)
+        viewModelScope.launch { playChannel(channel) }
     }
+
+    private suspend fun getSource(sourceId: Long): tv.own.owntv.core.database.entity.SourceEntity? =
+        sourceById[sourceId] ?: sourceDao.getById(sourceId)
 
     /** Internal playback: the canonical ExoPlayer / mpv / Stalker / history side-effects for a
      *  channel. Direct-tune's background rebuild path calls this without [cancelPendingZapRebuild]
      *  so the in-flight rebuild it owns isn't killed by its own play. */
-    private fun playChannel(channel: ChannelEntity) {
+    private suspend fun playChannel(channel: ChannelEntity) {
         // Live TV set to play externally: hand the channel over instead of tuning an in-app engine.
         // History is still recorded, so the channel shows up in History/Recently watched either way.
         if (externalPlayerOn.value) { playExternal(channel); return }
@@ -1043,7 +1050,7 @@ class LiveViewModel(
         tv.own.owntv.core.player.enginePinKey(channel.sourceId, "LIVE", channel.remoteId)
 
     /** Whether [channel] is pinned to mpv, honouring pins written by older builds under the stream
-     *  URL. A legacy hit is rewritten under the stable key so it survives the next Stalker resolve. */
+     *  URL. A legacy hit is rewritten under the stable key so it survives the next re-sync/Stalker resolve. */
     private fun isPinnedToMpv(channel: ChannelEntity): Boolean {
         val pins = forceMpvUrls.value
         val key = mpvPinKey(channel)
@@ -1053,12 +1060,13 @@ class LiveViewModel(
         return true
     }
 
-    private fun startOnExo(channel: ChannelEntity) {
+    private suspend fun startOnExo(channel: ChannelEntity) {
         _liveOnExo.value = true
         player.stop() // free mpv (decoder/connection) if a previous full-screen used it
-        val source = sourceById[channel.sourceId]
+        val source = getSource(channel.sourceId)
         if (streamUrlResolver.needsResolve(source)) { startOnExoStalker(channel, source!!); return }
-        if (previewEngine.currentUrl == channel.streamUrl) {
+        val targetUrl = channel.playStreamUrl(source)
+        if (previewEngine.currentUrl == targetUrl) {
             previewEngine.setMuted(false) // promote — instant if already PLAYING, otherwise keeps loading
         } else {
             // In-player zap to a DIFFERENT channel (CH+/-, D-pad, channel-list overlay): if we're leaving a
@@ -1068,9 +1076,9 @@ class LiveViewModel(
             stalkerPreviewCmd = null
             setStalkerReconnect(null) // non-Stalker: URLs are stable, replay on reconnect
             previewEngine.play(
-                channel.streamUrl, muted = false,
+                targetUrl, muted = false,
                 meta = tv.own.owntv.player.MediaMeta(title = channel.name, subtitle = channelNumberLabel(channel), logoUrl = channel.displayLogoUrl),
-                userAgent = sourceUaMap[channel.sourceId],
+                userAgent = sourceUaMap[channel.sourceId] ?: source?.userAgent,
             )
         }
         watchExoOutcome(channel)
@@ -1204,13 +1212,14 @@ class LiveViewModel(
             val source = sourceById[channel.sourceId] ?: sourceDao.getById(channel.sourceId)
             // Stalker stores the portal cmd — resolve it to a real URL (create_link) before mpv plays.
             val isStalker = streamUrlResolver.needsResolve(source)
-            val url = if (isStalker) {
+            val rawUrl = if (isStalker) {
                 runCatching { streamUrlResolver.resolve(source!!, channel.streamUrl) }
                     .onFailure { Log.w(ENGINE_TAG, "stalker mpv resolve failed '${channel.name}'", it) }
                     .getOrNull() ?: return
             } else {
                 channel.streamUrl
             }
+            val url = resolveStreamUrl(rawUrl, source)
             if (_previewChannel.value?.streamUrl != channel.streamUrl) return // zapped away while resolving
             // C-3: mpv is now the active engine — install/clear the reconnect provider to match.
             setStalkerReconnect(if (isStalker) channel.streamUrl else null)
@@ -1405,8 +1414,14 @@ class LiveViewModel(
     private suspend fun buildLiveTimeshiftUrl(ch: ChannelEntity, source: tv.own.owntv.core.database.entity.SourceEntity, startMs: Long, offsetSec: Int, tz: java.util.TimeZone): String? {
         val durationMin = (offsetSec / 60 + 5).coerceAtLeast(1) // rewound window + buffer to play up to live
         return when (source.type) {
-            SourceType.XTREAM -> ch.remoteId?.let { xtreamClient.timeshiftUrl(source, it, startMs, durationMin, tz) }
-            SourceType.M3U -> CatchupUrl.forM3u(ch.streamUrl, null, ch.catchupSource, startMs, startMs + durationMin * 60_000L)
+            SourceType.XTREAM -> ch.remoteId?.let {
+                val ext = if (source.hlsSupported && source.preferHls) "m3u8" else "ts"
+                xtreamClient.timeshiftUrl(source, it, startMs, durationMin, tz, ext)
+            }
+            SourceType.M3U -> {
+                val rawUrl = CatchupUrl.forM3u(ch.streamUrl, null, ch.catchupSource, startMs, startMs + durationMin * 60_000L)
+                rawUrl?.let { resolveStreamUrl(it, source) }
+            }
             // Stalker rewind = the same per-play archive create_link as catch-up (Phase E §5.6).
             SourceType.STALKER -> ch.remoteId?.let { rid ->
                 runCatching { streamUrlResolver.resolveCatchup(source, rid, startMs, startMs + durationMin * 60_000L) }

--- a/app/src/main/java/tv/own/owntv/features/settings/ManageSourcesScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/settings/ManageSourcesScreen.kt
@@ -154,12 +154,13 @@ fun ManageSourcesScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
                 initial = src,
                 initialAutoRefresh = playlistAutoRefresh[src.id] ?: PlaylistAutoRefresh.OFF,
                 initialIsDefault = src.id == defaultId,
-                onStartXtream = { n, server, u, p, ua, epg, autoRefresh, live, movies, series, isDefault ->
+                onStartXtream = { n, server, u, p, ua, epg, autoRefresh, live, movies, series, isDefault, preferHls ->
                     vm.updateSource(
                         src.id, n, server, u, p, ua, epg, autoRefresh, isDefault,
                         syncLive = live != tv.own.owntv.core.sync.SyncScopeChoice.Off,
                         syncMovies = movies != tv.own.owntv.core.sync.SyncScopeChoice.Off,
                         syncSeries = series != tv.own.owntv.core.sync.SyncScopeChoice.Off,
+                        preferHls = preferHls,
                     )
                     editingSource = null
                 },
@@ -199,7 +200,7 @@ fun ManageSourcesScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
                         modifier = Modifier,
                     )
                     AddMode.MANUAL -> AddSourceScreen(
-                        onStartXtream = { n, server, u, p, ua, epg, autoRefresh, live, movies, series, isDefault ->
+                        onStartXtream = { n, server, u, p, ua, epg, autoRefresh, live, movies, series, isDefault, _ ->
                             vm.addXtream(n, server, u, p, ua, epg, autoRefresh, live, movies, series, isDefault)
                         },
                         onStartM3u = { n, url, ua, epg, autoRefresh, isDefault -> vm.addM3u(n, url, ua, epg, autoRefresh, isDefault) },

--- a/app/src/main/java/tv/own/owntv/features/settings/SettingsViewModel.kt
+++ b/app/src/main/java/tv/own/owntv/features/settings/SettingsViewModel.kt
@@ -594,6 +594,7 @@ class SettingsViewModel(
         syncLive: Boolean = true,
         syncMovies: Boolean = true,
         syncSeries: Boolean = true,
+        preferHls: Boolean = false,
     ) {
         viewModelScope.launch {
             val existing = sourceDao.getById(id) ?: return@launch
@@ -616,6 +617,7 @@ class SettingsViewModel(
                 syncLive = syncLive,
                 syncMovies = syncMovies,
                 syncSeries = syncSeries,
+                preferHls = preferHls,
             )
             sourceRepository.updateSource(updated)
             settings.setPlaylistAutoRefresh(id, autoRefresh)
@@ -639,6 +641,12 @@ class SettingsViewModel(
             }
             // Hidden sections must drop from the Android TV launcher immediately.
             runCatching { refreshActiveTvHome(allowBrowsableRequest = true) }
+        }
+    }
+
+    fun togglePreferHls(sourceId: Long, preferHls: Boolean) {
+        viewModelScope.launch {
+            sourceDao.updatePreferHls(sourceId, preferHls)
         }
     }
 

--- a/app/src/main/java/tv/own/owntv/features/setup/AddSourceScreen.kt
+++ b/app/src/main/java/tv/own/owntv/features/setup/AddSourceScreen.kt
@@ -86,6 +86,7 @@ fun AddSourceScreen(
         movies: SyncScopeChoice,
         series: SyncScopeChoice,
         isDefault: Boolean,
+        preferHls: Boolean,
     ) -> Unit,
     onStartM3u: (name: String, url: String, userAgent: String, epgUrl: String, autoRefresh: PlaylistAutoRefresh, isDefault: Boolean) -> Unit,
     // The last submission from the Remote companion screen, retained as a StateFlow so it survives the
@@ -138,6 +139,7 @@ fun AddSourceScreen(
     var userAgent by remember(initial) { mutableStateOf(initial?.userAgent ?: "") }
     var autoRefresh by remember(initialAutoRefresh) { mutableStateOf(initialAutoRefresh) }
     var isDefault by remember(initialIsDefault) { mutableStateOf(initialIsDefault) }
+    var preferHls by remember(initial) { mutableStateOf(initial?.preferHls == true) }
     // Edit: On(=Now)/Off from persisted flags. Add: default all Now for Xtream; Stalker defaults
     // Live Now + Movies/Series Later when the kind switches (see LaunchedEffect below).
     var syncLive by remember(initial) {
@@ -332,6 +334,15 @@ fun AddSourceScreen(
                 ) { isDefault = it }
             }
 
+            if (kind == SourceKind.XTREAM && (initial?.hlsSupported == true)) {
+                Spacer(Modifier.height(16.dp))
+                ToggleRow(
+                    label = "Prefer HLS for Live TV",
+                    desc = "Prioritize HLS streams over MPEG-TS for Live TV & Catch-up. Automatically falls back to MPEG-TS if HLS fails.",
+                    checked = preferHls,
+                ) { preferHls = it }
+            }
+
             if (showContentToggles) {
                 Spacer(Modifier.height(20.dp))
                 Text("What to sync", style = MaterialTheme.typography.titleMedium, color = colors.onSurface)
@@ -361,7 +372,7 @@ fun AddSourceScreen(
                     label = if (editing) "Save" else "Start Import",
                     onClick = {
                         when (kind) {
-                            SourceKind.XTREAM -> onStartXtream(name, server, username, password, userAgent, epgUrl, autoRefresh, syncLive, syncMovies, syncSeries, isDefault)
+                            SourceKind.XTREAM -> onStartXtream(name, server, username, password, userAgent, epgUrl, autoRefresh, syncLive, syncMovies, syncSeries, isDefault, preferHls)
                             SourceKind.M3U -> onStartM3u(name, m3uUrl, userAgent, epgUrl, autoRefresh, isDefault)
                             SourceKind.STALKER -> onStartStalker?.invoke(
                                 name, portalUrl, mac, userAgent, autoRefresh, isDefault, syncLive, syncMovies, syncSeries,

--- a/app/src/main/java/tv/own/owntv/features/setup/SetupWizard.kt
+++ b/app/src/main/java/tv/own/owntv/features/setup/SetupWizard.kt
@@ -114,7 +114,7 @@ fun Onboarding(firstRun: Boolean, onDone: () -> Unit, onCancel: () -> Unit, modi
                 onBack = { vm.stopRemoteListener(); step = Step.ADD_SOURCE_CHOOSER },
             )
             Step.ADD_SOURCE -> AddSourceScreen(
-                onStartXtream = { name, server, user, pass, ua, epg, refresh, live, movies, series, _ ->
+                onStartXtream = { name, server, user, pass, ua, epg, refresh, live, movies, series, _, _ ->
                     vm.startXtream(name, server, user, pass, ua, epg, refresh, live, movies, series)
                     importOrigin = Step.ADD_SOURCE
                     step = Step.IMPORTING

--- a/app/src/main/java/tv/own/owntv/player/LivePreviewEngine.kt
+++ b/app/src/main/java/tv/own/owntv/player/LivePreviewEngine.kt
@@ -199,11 +199,14 @@ class LivePreviewEngine(
         return "$kind codec: ${e.message ?: e.javaClass.simpleName}"
     }
 
+    private var activeIsHls = false
+
     /** Technical readout for the stream-info overlay, from the active ExoPlayer formats. */
     override fun streamInfo(): List<Pair<String, String>> {
         val p = player ?: return emptyList()
         val out = ArrayList<Pair<String, String>>()
         out += "Engine" to "ExoPlayer"
+        out += "Format" to if (activeIsHls) "HLS" else "MPEG-TS"
         p.videoFormat?.let { f ->
             val line = listOfNotNull(
                 f.sampleMimeType?.substringAfterLast('/')?.let { mimeName(it) },
@@ -946,8 +949,13 @@ class LivePreviewEngine(
                 setLiveConfiguration(MediaItem.LiveConfiguration.Builder().setTargetOffsetMs(it * 1000L).build())
             }
         }.build()
-        val uri = item.localConfiguration?.uri ?: return cachedDefaultFactory!!.createMediaSource(item)
-        return if (Util.inferContentType(uri) == C.CONTENT_TYPE_HLS) cachedHlsCcFactory!!.createMediaSource(item)
+        val uri = item.localConfiguration?.uri ?: run {
+            activeIsHls = false
+            return cachedDefaultFactory!!.createMediaSource(item)
+        }
+        val isHls = Util.inferContentType(uri) == C.CONTENT_TYPE_HLS
+        activeIsHls = isHls
+        return if (isHls) cachedHlsCcFactory!!.createMediaSource(item)
         else cachedDefaultFactory!!.createMediaSource(item)
     }
 

--- a/app/src/main/java/tv/own/owntv/player/OwnTVPlayer.kt
+++ b/app/src/main/java/tv/own/owntv/player/OwnTVPlayer.kt
@@ -2323,6 +2323,14 @@ class OwnTVPlayer(
         fun str(p: String) = m.getPropertyString(p)?.takeIf { it.isNotBlank() }
         val out = ArrayList<Pair<String, String>>()
         out += "Engine" to "mpv"
+        (str("file-format") ?: str("demuxer"))?.lowercase()?.let { d ->
+            val fmt = when {
+                d.contains("hls") -> "HLS"
+                d.contains("mpegts") -> "MPEG-TS"
+                else -> d.uppercase()
+            }
+            out += "Format" to fmt
+        }
         // Video
         val vw = m.getPropertyInt("video-params/w") ?: m.getPropertyInt("width")
         val vh = m.getPropertyInt("video-params/h") ?: m.getPropertyInt("height")
@@ -2903,11 +2911,13 @@ class OwnTVPlayer(
                             if (gen == loadGeneration) {
                                 loadUrl(catchupAlt, currentMetaSnapshot(), isLiveContent, 0L, resetRetries = false)
                             }
-                        } else if (isLiveContent && !triedAltFormat && autoRetries >= 1 && tsUrl != null && tsUrl.endsWith(".ts", ignoreCase = true)) {
+                        } else if (isLiveContent && !triedAltFormat && autoRetries >= 1 && tsUrl != null && (tsUrl.endsWith(".ts", ignoreCase = true) || tsUrl.endsWith(".m3u8", ignoreCase = true))) {
                             triedAltFormat = true
                             autoRetries = 0
-                            val alt = tsUrl.dropLast(3) + ".m3u8"
-                            android.util.Log.w(TAG, "live .ts didn't start — trying .m3u8 fallback")
+                            val isHls = tsUrl.endsWith(".m3u8", ignoreCase = true)
+                            val (from, to) = if (isHls) ".m3u8" to ".ts" else ".ts" to ".m3u8"
+                            val alt = tsUrl.dropLast(from.length) + to
+                            android.util.Log.w(TAG, "live stream didn't start ($from) — trying format fallback ($from -> $to)")
                             _buffering.value = true
                             delay(FALLBACK_RETRY_DELAY_MS)
                             if (gen == loadGeneration) {


### PR DESCRIPTION
<!-- Thanks for contributing to OwnTV! Please fill this in so it's easy to review. -->

## Before you open this PR (required)
<!-- These are mandatory — PRs that duplicate an existing in-app feature are closed. -->
- [x] I read the **[User Guide](https://github.com/ahXN00/OwnTV/blob/main/extras/USER_GUIDE.md)** and checked the app's **Settings** and existing **functions** — this change isn't already possible in the app.
- [x] I searched existing issues/PRs and this isn't a duplicate.

## What does this PR do?
- **HLS Auto-detection:** Auto-detect HLS support from `user_info.allowed_output_formats` in Xtream `player_api.php` during sync (handles both JSON Arrays and Strings).
- **Database Migration:** Add `hlsSupported` and `preferHls` columns to sources table (Database v23 migration).
- **Settings Toggle:** Add "Prefer HLS for Live TV" settings toggle for Xtream sources supporting `.m3u8`.
- **Stream URL & Handoff Resolution:** Resolve live stream and timeshift URLs to `.m3u8` on initial tune when `preferHls` is active.
- **Format Fallback & Readout:** Support format fallback on stream error (`.m3u8` <-> `.ts`) and report native demuxer format (`HLS` vs `MPEG-TS`) in Stream Info Overlay.
- **Unit Tests:** Added unit tests for format auto-detection parsing and DB v22 -> v23 migration hop.

## Which issue / improvement does it address?
Some users prefer to use HLS by default for some Xtream Codes sources, due to reliability or other reasons. Previously this was not possible except in edge case where an MPEG-TS stream failed to play and, as part of fallback, was also switched to HLS. There was also an HLS-only latency setting feature introduced recently, which with this change would now be usable by Xtream Codes playlists.

## How was it tested?
- **Device(s) tested on:** Hisense Android 12 TV
- **What you exercised:** Stream tuning, player engine toggling (Exo <-> MPV), stream info overlay readout, settings toggle, catalog sync.

## Checklist
- [x] Builds locally (`./gradlew assembleDebug`) and CI is green
- [x] **Tested on a real Android TV / Fire TV device** (not emulator only) — D-pad/remote navigation works
- [x] No user data is wiped (Room migrations stay additive)
- [x] Keeps OwnTV player-only (no bundled channels/content)
- [x] Commit messages are clear (they become the release notes)
