### PR TITLE
chore: make .envrc platform-agnostic

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,10 +1,13 @@
-# .envrc
 case "$(uname -s)" in
   Darwin)
-    export JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home'
+    export JAVA_HOME="${JAVA_HOME:-$(/usr/libexec/java_home)}"
     ;;
   Linux)
-    export JAVA_HOME="${JAVA_HOME:-/usr/lib/jvm/java-17-openjdk-amd64}"
+    if [ -z "${JAVA_HOME:-}" ]; then
+      java_bin="$(command -v java)"
+      export JAVA_HOME="$(dirname "$(dirname "$(readlink -f "$java_bin")")")"
+      unset java_bin
+    fi
     ;;
 esac
 export GRADLE_USER_HOME="$PWD/.gradle-cache"

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,10 @@
+# .envrc
+case "$(uname -s)" in
+  Darwin)
+    export JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home'
+    ;;
+  Linux)
+    export JAVA_HOME="${JAVA_HOME:-/usr/lib/jvm/java-17-openjdk-amd64}"
+    ;;
+esac
+export GRADLE_USER_HOME="$PWD/.gradle-cache"


### PR DESCRIPTION
## Before you open this PR (required)

- [x] I read the **[User Guide](https://github.com/ahXN00/OwnTV/blob/main/extras/USER_GUIDE.md)** and checked the app's **Settings** and existing **functions** - this change isn't already possible in the app.
- [x] I searched existing issues/PRs and this isn't a duplicate.

## Intent

Make `.envrc` platform-agnostic by detecting the OS and setting `JAVA_HOME` appropriately for macOS and Linux, so the file can be committed to git and work across different developer machines.

## What Changed

- Added OS detection via `uname -s` in `.envrc`.
- Preserved an existing `JAVA_HOME` when developers configure one explicitly.
- Used `/usr/libexec/java_home` for native JDK discovery on macOS.
- Resolved the installed `java` executable on Linux without assuming an architecture-specific JDK path.
- Exported a local `GRADLE_USER_HOME` to keep Gradle caches scoped to the project.

## Risk Assessment

Low: The change only affects direnv users and preserves an explicitly configured `JAVA_HOME`.

## Testing

- Validated `.envrc` syntax with `bash -n .envrc`.
- Verified explicit `JAVA_HOME` values are preserved on macOS and Linux branches.
- Verified Linux JDK home resolution from the installed `java` executable.
- Verified `GRADLE_USER_HOME` resolves to the worktree-local `.gradle-cache` directory.
