### PR TITLE
Pin core 1.0.19

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -80,7 +80,7 @@ espressoCore = "3.7.0"
 # Both artifacts always ship on the same version; never split them. Bumping this is how the TV app
 # takes a core change. For local work, owntv.corePath in ~/.gradle/gradle.properties substitutes
 # core's source for these artifacts, and this number is then ignored.
-owntvCore = "1.0.18"
+owntvCore = "1.0.19"
 
 [libraries]
 # The shared engine, from its own repository


### PR DESCRIPTION
Core `1.0.19` has been published to GitHub Packages.

- `owntvCore` moved to `1.0.19` in `gradle/libs.versions.toml`
- `tools/i18n/locales.json` refreshed from core

Local builds resolve core from source via `owntv.corePath` and ignore this pin, so this
pull request is what makes CI and the released APK agree with what has already been tested
locally.

Merge once the checks are green. See the core changelog for what `1.0.19` contains.
